### PR TITLE
test(be): add evaluator unit tests

### DIFF
--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluatorTest.kt
@@ -1,0 +1,58 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.CompanyFitResult
+import com.devquest.core.domain.port.CompanyInfo
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class CompanyFitEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = CompanyFitEvaluator(chatClient)
+
+    private val preferences = mapOf("문화" to "수평적", "기술스택" to "Kotlin")
+    private val companies = listOf(
+        CompanyInfo(name = "토스", culture = "수평적", techStack = listOf("Kotlin"), size = "중견", description = "핀테크")
+    )
+
+    @Test
+    fun `AI가 유효한 JSON을 반환하면 파싱된 결과 목록을 반환한다`() {
+        val json = """[{"companyName":"토스","fitScore":90,"fitGrade":"A","cultureFit":23,"techFit":24,"growthFit":22,"lifestyleFit":21,"pros":["수평적 문화"],"cons":[],"recommendation":"적극 추천"}]"""
+        whenever(chatClient.prompt().user(any<String>()).call().content()).thenReturn(json)
+
+        val result = evaluator.analyze(preferences, companies)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].companyName).isEqualTo("토스")
+        assertThat(result[0].fitScore).isEqualTo(90)
+        assertThat(result[0].fitGrade).isEqualTo("A")
+    }
+
+    @Test
+    fun `AI가 null을 반환하면 빈 배열로 처리된다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().content()).thenReturn(null)
+
+        val result = evaluator.analyze(preferences, companies)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `AI가 잘못된 JSON을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().content()).thenReturn("invalid json")
+
+        assertThatThrownBy { evaluator.analyze(preferences, companies) }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("파싱 실패")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
@@ -1,0 +1,59 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.JdAnalysisResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class JdAnalysisEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = JdAnalysisEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(JdAnalysisResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.analyze(
+                companyName = "토스",
+                jobDescription = "백엔드 개발자",
+                userSkills = listOf("Kotlin", "Spring"),
+                userExperiences = listOf("3년 경력")
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("JD 분석 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = JdAnalysisResult(
+            companyName = "토스",
+            overallMatchScore = 85,
+            applicationStrategy = "포트폴리오 강조"
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(JdAnalysisResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.analyze(
+            companyName = "토스",
+            jobDescription = "백엔드 개발자",
+            userSkills = listOf("Kotlin"),
+            userExperiences = listOf("3년 경력")
+        )
+
+        assertThat(result.companyName).isEqualTo("토스")
+        assertThat(result.overallMatchScore).isEqualTo(85)
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluatorTest.kt
@@ -1,0 +1,61 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.InterviewEvaluationResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class MockInterviewEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = MockInterviewEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(InterviewEvaluationResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                category = "기술",
+                question = "JVM이란?",
+                answer = "자바 가상 머신입니다",
+                questionId = "q-1"
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("면접 평가 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = InterviewEvaluationResult(
+            questionId = "q-1",
+            question = "JVM이란?",
+            score = 80,
+            passed = true
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(InterviewEvaluationResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            category = "기술",
+            question = "JVM이란?",
+            answer = "자바 가상 머신입니다",
+            questionId = "q-1"
+        )
+
+        assertThat(result.questionId).isEqualTo("q-1")
+        assertThat(result.score).isEqualTo(80)
+        assertThat(result.passed).isTrue()
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
@@ -1,0 +1,56 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.AiEvaluationResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class PersonalityInterviewEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = PersonalityInterviewEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                question = "갈등 상황을 어떻게 해결했나요?",
+                answer = "팀원과 대화로 해결했습니다"
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("인성 면접 평가 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = AiEvaluationResult(
+            score = 75,
+            passed = true,
+            grade = "B"
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            question = "갈등 상황을 어떻게 해결했나요?",
+            answer = "팀원과 대화로 해결했습니다"
+        )
+
+        assertThat(result.score).isEqualTo(75)
+        assertThat(result.passed).isTrue()
+        assertThat(result.grade).isEqualTo("B")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
@@ -1,0 +1,59 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.ResumeCheckResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class ResumeCheckEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = ResumeCheckEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(ResumeCheckResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                targetCompany = "토스",
+                targetJd = "백엔드 개발자 채용",
+                resumeContent = "3년 경력의 백엔드 개발자입니다"
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("이력서 평가 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = ResumeCheckResult(
+            overallScore = 72,
+            starMethodScore = 28,
+            quantificationScore = 22,
+            keywordMatchScore = 22
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(ResumeCheckResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            targetCompany = "토스",
+            targetJd = "백엔드 개발자 채용",
+            resumeContent = "3년 경력의 백엔드 개발자입니다"
+        )
+
+        assertThat(result.overallScore).isEqualTo(72)
+        assertThat(result.starMethodScore).isEqualTo(28)
+        assertThat(result.keywordMatchScore).isEqualTo(22)
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
@@ -1,0 +1,58 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.AiEvaluationResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class SystemDesignEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = SystemDesignEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                problemStatement = "URL 단축 서비스를 설계하세요",
+                architectureDescription = "Redis와 MySQL을 사용합니다",
+                considerations = listOf("확장성", "가용성")
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("시스템 설계 평가 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = AiEvaluationResult(
+            score = 80,
+            passed = true,
+            grade = "A"
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            problemStatement = "URL 단축 서비스를 설계하세요",
+            architectureDescription = "Redis와 MySQL을 사용합니다",
+            considerations = listOf("확장성", "가용성")
+        )
+
+        assertThat(result.score).isEqualTo(80)
+        assertThat(result.passed).isTrue()
+        assertThat(result.grade).isEqualTo("A")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
@@ -1,0 +1,58 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.AiEvaluationResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class TechBlogEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = TechBlogEvaluator(chatClient)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                techTopic = "JVM",
+                title = "JVM 메모리 구조 이해하기",
+                content = "JVM은 힙과 스택으로 구성됩니다"
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("AI 블로그 평가 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val expected = AiEvaluationResult(
+            score = 82,
+            passed = true,
+            grade = "A"
+        )
+        whenever(chatClient.prompt().user(any<String>()).call().entity(AiEvaluationResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            techTopic = "JVM",
+            title = "JVM 메모리 구조 이해하기",
+            content = "JVM은 힙과 스택으로 구성됩니다"
+        )
+
+        assertThat(result.score).isEqualTo(82)
+        assertThat(result.passed).isTrue()
+        assertThat(result.grade).isEqualTo("A")
+    }
+}


### PR DESCRIPTION
## Summary
- 7개 AI evaluator 전체에 대한 단위 테스트 추가
- `RETURNS_DEEP_STUBS`로 ChatClient fluent API 체인 모킹
- null 반환 시 AiEvaluationException 발생 / 정상 응답 시 결과 반환 검증
- 기존 MockInterviewEvaluatorTest, JdAnalysisEvaluatorTest의 잘못된 예외 메시지 assertion 수정

## Test plan
- [ ] BE CI 통과 확인
- [ ] 각 evaluator의 null → exception / 정상응답 → 반환 케이스 모두 포함