### PR TITLE
chore(be): reduce fly.io memory to 256mb for free tier

### DIFF
--- a/be/fly.toml
+++ b/be/fly.toml
@@ -23,6 +23,6 @@ primary_region = 'nrt'
     soft_limit = 20
 
 [[vm]]
-  memory = '512mb'
+  memory = '256mb'
   cpu_kind = 'shared'
   cpus = 1


### PR DESCRIPTION
Fly.io 무료 범위 내 운영을 위해 memory 512mb → 256mb 조정