### PR TITLE
fix(be): set fly.io memory to 512mb to prevent OOM

### DIFF
--- a/be/fly.toml
+++ b/be/fly.toml
@@ -23,6 +23,6 @@ primary_region = 'nrt'
     soft_limit = 20
 
 [[vm]]
-  memory = '256mb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1


### PR DESCRIPTION
256mb OOM 발생 확인. 512mb로 고정.