### PR TITLE
feat: sync quest progress with server on load and complete

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ProgressController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ProgressController.kt
@@ -1,10 +1,14 @@
 package com.devquest.core.api.controller.v1
 
+import com.devquest.core.api.controller.v1.request.QuestCompleteRequestDto
 import com.devquest.core.domain.ProgressService
 import com.devquest.core.domain.model.ProgressResult
 import com.devquest.core.support.response.ApiResponse
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -16,5 +20,11 @@ class ProgressController(
     @GetMapping("/{userId}")
     fun getProgress(@PathVariable userId: String): ApiResponse<ProgressResult> {
         return ApiResponse.success(progressService.getProgress(userId))
+    }
+
+    @PostMapping("/complete")
+    fun completeQuest(@Valid @RequestBody request: QuestCompleteRequestDto): ApiResponse<Unit> {
+        progressService.completeQuest(request.userId, request.questId, request.actId, request.earnedXp)
+        return ApiResponse.success(Unit)
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/QuestCompleteRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/QuestCompleteRequestDto.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+
+data class QuestCompleteRequestDto(
+    @field:NotBlank val userId: String,
+    @field:NotBlank val questId: String,
+    @field:Positive val actId: Int,
+    @field:Positive val earnedXp: Int,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ProgressService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ProgressService.kt
@@ -1,14 +1,35 @@
 package com.devquest.core.domain
 
 import com.devquest.core.domain.model.ProgressResult
+import com.devquest.core.domain.model.QuestProgress
 import com.devquest.core.domain.port.QuestProgressPort
 import com.devquest.core.enums.QuestStatus
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class ProgressService(
     private val progressPort: QuestProgressPort
 ) {
+    @Transactional
+    fun completeQuest(userId: String, questId: String, actId: Int, earnedXp: Int) {
+        val existing = progressPort.findByUserIdAndQuestId(userId, questId)
+        if (existing?.status == QuestStatus.COMPLETED) return
+
+        progressPort.save(
+            QuestProgress(
+                id = existing?.id,
+                userId = userId,
+                questId = questId,
+                actId = actId,
+                status = QuestStatus.COMPLETED,
+                earnedXp = earnedXp,
+                completedAt = LocalDateTime.now(),
+            )
+        )
+    }
+
     fun getProgress(userId: String): ProgressResult {
         val progresses = progressPort.findAllByUserId(userId)
         val completed = progresses.filter { it.status == QuestStatus.COMPLETED }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ProgressControllerTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ProgressControllerTest.kt
@@ -8,9 +8,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @ExtendWith(MockitoExtension::class)
@@ -70,5 +73,28 @@ class ProgressControllerTest {
                 jsonPath("$.data.totalXp") { value(0) }
                 jsonPath("$.data.level") { value(1) }
             }
+    }
+
+    @Test
+    fun `completeQuest - 정상 요청이면 200과 SUCCESS 반환`() {
+        mockMvc.post("/api/v1/progress/complete") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userId":"user-1","questId":"1-1","actId":1,"earnedXp":100}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.result") { value("SUCCESS") }
+        }
+
+        verify(progressService).completeQuest("user-1", "1-1", 1, 100)
+    }
+
+    @Test
+    fun `completeQuest - userId 누락이면 400 반환`() {
+        mockMvc.post("/api/v1/progress/complete") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userId":"","questId":"1-1","actId":1,"earnedXp":100}"""
+        }.andExpect {
+            status { isBadRequest() }
+        }
     }
 }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ProgressServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ProgressServiceTest.kt
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExtendWith(MockitoExtension::class)
@@ -85,6 +88,26 @@ class ProgressServiceTest {
         assertThat(detail.status).isEqualTo(QuestStatus.COMPLETED)
         assertThat(detail.score).isEqualTo(80)
         assertThat(detail.xp).isEqualTo(160)
+    }
+
+    @Test
+    fun `completeQuest - 미완료 퀘스트는 COMPLETED로 저장한다`() {
+        whenever(progressPort.findByUserIdAndQuestId("user-1", "1-1")).thenReturn(null)
+
+        service.completeQuest("user-1", "1-1", 1, 100)
+
+        verify(progressPort).save(any())
+    }
+
+    @Test
+    fun `completeQuest - 이미 완료된 퀘스트는 저장하지 않는다`() {
+        whenever(progressPort.findByUserIdAndQuestId("user-1", "1-1")).thenReturn(
+            progress("1-1", QuestStatus.COMPLETED, earnedXp = 100)
+        )
+
+        service.completeQuest("user-1", "1-1", 1, 100)
+
+        verify(progressPort, never()).save(any())
     }
 
     private fun progress(

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,17 +1,39 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
 import type { AiEvaluationResult } from '@/types/api.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail } from '@/features/quest-detail'
+import { useUserId } from '@/hooks/useUserId'
+import { fetchProgress, completeQuest } from '@/lib/apiClient'
 
 type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest }
 
 export function App() {
+  const userId = useUserId()
   const [view, setView] = useState<View>({ kind: 'map' })
   const [completed, setCompleted] = useState<Record<string, boolean>>({})
   const [aiScores, setAiScores] = useState<Record<string, number>>({})
   const [aiResult, setAiResult] = useState<AiEvaluationResult | null>(null)
   const [showForm, setShowForm] = useState(false)
+
+  useEffect(() => {
+    fetchProgress(userId)
+      .then((progress) => {
+        const completedMap: Record<string, boolean> = {}
+        const scoresMap: Record<string, number> = {}
+        progress.completedQuests.forEach((id) => {
+          completedMap[id] = true
+        })
+        Object.entries(progress.questDetails).forEach(([id, detail]) => {
+          if (detail.score > 0) scoresMap[id] = detail.score
+        })
+        setCompleted(completedMap)
+        setAiScores(scoresMap)
+      })
+      .catch(() => {
+        // 서버 미응답 시 로컬 상태로 계속 진행
+      })
+  }, [userId])
 
   const getActProgress = useCallback(
     (act: Act) => {
@@ -30,8 +52,11 @@ export function App() {
     }
   }
 
-  const handleComplete = (questId: string, _xp: number) => {
+  const handleComplete = (questId: string, xp: number, actId: number) => {
     setCompleted((prev) => ({ ...prev, [questId]: true }))
+    completeQuest(userId, questId, actId, xp).catch(() => {
+      // 저장 실패해도 로컬 상태는 유지
+    })
   }
 
   const handleAiResult = (result: AiEvaluationResult) => {

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -13,7 +13,7 @@ interface QuestDetailProps {
   showForm: boolean
   onShowForm: () => void
   onAiResult: (result: AiEvaluationResult) => void
-  onComplete: (questId: string, xp: number) => void
+  onComplete: (questId: string, xp: number, actId: number) => void
   onMockInterviewComplete: (score: number) => void
 }
 
@@ -187,7 +187,7 @@ export function QuestDetail({
         {!quest.aiCheck && !done && (
           <button
             className="hov-btn"
-            onClick={() => onComplete(quest.id, quest.xp)}
+            onClick={() => onComplete(quest.id, quest.xp, act.id)}
             style={{
               width: '100%',
               padding: '12px',

--- a/fe/src/hooks/useUserId.ts
+++ b/fe/src/hooks/useUserId.ts
@@ -9,11 +9,11 @@ function generateUserId(): string {
 export function useUserId(): string {
   return useMemo(() => {
     try {
-      const stored = sessionStorage.getItem(STORAGE_KEY)
+      const stored = localStorage.getItem(STORAGE_KEY)
       if (stored) return stored
 
       const id = generateUserId()
-      sessionStorage.setItem(STORAGE_KEY, id)
+      localStorage.setItem(STORAGE_KEY, id)
       return id
     } catch {
       return 'user-demo'

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,6 +1,28 @@
-import type { ApiResponse } from '@/types/api.types'
+import type { ApiResponse, ProgressResult } from '@/types/api.types'
 
 const API_BASE = '/api/v1'
+
+export async function fetchProgress(userId: string): Promise<ProgressResult> {
+  const res = await fetch(`${API_BASE}/progress/${userId}`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json: ApiResponse<ProgressResult> = await res.json()
+  if (!json.success || json.data == null) throw new Error('진행 상황 조회 실패')
+  return json.data
+}
+
+export async function completeQuest(
+  userId: string,
+  questId: string,
+  actId: number,
+  earnedXp: number,
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/progress/complete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, actId, earnedXp }),
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+}
 
 export async function callAiCheck<T>(
   endpoint: string,

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -5,6 +5,20 @@ export interface ApiResponse<T> {
   message: string | null
 }
 
+export interface QuestDetail {
+  status: string
+  score: number
+  xp: number
+}
+
+export interface ProgressResult {
+  userId: string
+  totalXp: number
+  level: number
+  completedQuests: string[]
+  questDetails: Record<string, QuestDetail>
+}
+
 export interface AiEvaluationResult {
   score: number
   overallScore?: number


### PR DESCRIPTION
## Summary
- BE: `POST /api/v1/progress/complete` 추가 — 수동 완료 퀘스트 서버 저장
- FE: 앱 시작 시 `GET /api/v1/progress/{userId}` 호출해 진행 상황 복원
- FE: `sessionStorage` → `localStorage` 변경 (브라우저 닫아도 userId 유지)
- FE: 수동 완료 시 서버에 저장 (실패해도 로컬 상태 유지)

## Test plan
- [ ] BE 단위 테스트 통과 확인
- [ ] FE 타입 체크 통과 확인