### PR TITLE
feat: add ACT clear report — AI generates summary when boss quest is completed

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
@@ -1,0 +1,53 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.ActClearReportResult
+import com.devquest.core.domain.port.ActClearReportPort
+import com.devquest.core.domain.support.AiEvaluationException
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+@Component
+class ActClearReportEvaluator(
+    private val chatClient: ChatClient
+) : ActClearReportPort {
+
+    override fun generate(actId: Int, actTitle: String, questScores: Map<String, Int>): ActClearReportResult {
+        val scoresText = questScores.entries.joinToString("\n") { (questId, score) ->
+            "- $questId: $score점"
+        }
+        val avgScore = if (questScores.isEmpty()) 0 else questScores.values.average().toInt()
+
+        val prompt = """
+            5년차 백엔드 개발자가 이직 준비 RPG의 ACT $actId "$actTitle" 를 클리어했습니다.
+            이 ACT에서의 퀘스트 점수를 바탕으로 종합 리포트를 작성해주세요.
+
+            ## 퀘스트 점수
+            $scoresText
+            (평균: ${avgScore}점)
+
+            ## 작성 지침
+            - developerClass: 이 개발자의 현재 클래스/직업군 (예: "시스템 아키텍트 지망생", "풀스택 전환형 백엔드", "기술 전문가형")
+            - achievements: 이번 ACT에서 보여준 강점 2~3가지 (구체적으로)
+            - nextActHint: 다음 ACT를 위한 핵심 조언 1문장
+            - encouragement: 이직 준비 중인 개발자에게 진심 어린 응원 메시지 1문장
+
+            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
+            {
+                "actId": $actId,
+                "actTitle": "$actTitle",
+                "overallScore": $avgScore,
+                "grade": "B",
+                "developerClass": "시스템 아키텍트 지망생",
+                "achievements": ["강점1", "강점2", "강점3"],
+                "nextActHint": "다음 단계 조언",
+                "encouragement": "응원 메시지"
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(ActClearReportResult::class.java)
+            ?: throw AiEvaluationException("ACT 클리어 리포트 생성 실패")
+    }
+}

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
@@ -13,7 +13,7 @@ class ActClearReportEvaluator(
 
     override fun generate(actId: Int, actTitle: String, questScores: Map<String, Int>): ActClearReportResult {
         val scoresText = questScores.entries.joinToString("\n") { (questId, score) ->
-            "- $questId: $score점"
+            "- $questId: ${score}점"
         }
         val avgScore = if (questScores.isEmpty()) 0 else questScores.values.average().toInt()
 

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
@@ -130,4 +130,15 @@ class AiCheckController(
             throw CoreException(ErrorType.AI_EVALUATION_FAILED)
         }
     }
+
+    @PostMapping("/act-clear-report")
+    fun generateActClearReport(@Valid @RequestBody request: ActClearReportRequestDto): ApiResponse<*> {
+        return try {
+            val result = aiCheckService.generateActClearReport(request.userId, request.actId, request.actTitle)
+            ApiResponse.success(result)
+        } catch (e: Exception) {
+            log.error("Act clear report generation failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ActClearReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ActClearReportRequestDto.kt
@@ -1,0 +1,10 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+
+data class ActClearReportRequestDto(
+    @field:NotBlank val userId: String,
+    @field:Positive val actId: Int,
+    @field:NotBlank val actTitle: String,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -1,8 +1,8 @@
 package com.devquest.core.domain
 
 import com.devquest.core.domain.model.QuestProgress
-import com.devquest.core.domain.port.*
 import com.devquest.core.domain.model.evaluation.*
+import com.devquest.core.domain.port.*
 import com.devquest.core.enums.QuestStatus
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
@@ -22,6 +22,7 @@ class AiCheckService(
     private val resumeEvaluator: ResumeEvaluatorPort,
     private val companyFitEvaluator: CompanyFitEvaluatorPort,
     private val personalityEvaluator: PersonalityEvaluatorPort,
+    private val actClearReportPort: ActClearReportPort,
     private val progressPort: QuestProgressPort
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -95,6 +96,13 @@ class AiCheckService(
         val result = personalityEvaluator.evaluate(question, answer)
         saveProgress(userId, "5-1", 5, result.score, result.passed, if (result.passed) (400 * result.xpMultiplier).toInt() else 0)
         return result
+    }
+
+    fun generateActClearReport(userId: String, actId: Int, actTitle: String): ActClearReportResult {
+        val questScores = progressPort.findAllByUserId(userId)
+            .filter { it.actId == actId && it.aiScore > 0 }
+            .associate { it.questId to it.aiScore }
+        return actClearReportPort.generate(actId, actTitle, questScores)
     }
 
     private fun saveProgress(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -25,6 +25,7 @@ class AiCheckServiceTest {
     @Mock lateinit var resumeEvaluator: ResumeEvaluatorPort
     @Mock lateinit var companyFitEvaluator: CompanyFitEvaluatorPort
     @Mock lateinit var personalityEvaluator: PersonalityEvaluatorPort
+    @Mock lateinit var actClearReportPort: ActClearReportPort
     @Mock lateinit var progressPort: QuestProgressPort
 
     private lateinit var service: AiCheckService
@@ -34,7 +35,7 @@ class AiCheckServiceTest {
         service = AiCheckService(
             essayEvaluator, blogEvaluator, systemDesignEvaluator, interviewEvaluator,
             jdAnalysisEvaluator, resumeEvaluator, companyFitEvaluator, personalityEvaluator,
-            progressPort
+            actClearReportPort, progressPort
         )
         // progressPort.save 기본 응답 (저장 시 반환값 필요)
         whenever(progressPort.save(any())).thenAnswer { it.arguments[0] }

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/ActClearReportResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/ActClearReportResult.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain.model.evaluation
+
+data class ActClearReportResult(
+    val actId: Int = 0,
+    val actTitle: String = "",
+    val overallScore: Int = 0,
+    val grade: String = "D",
+    val developerClass: String = "",
+    val achievements: List<String> = emptyList(),
+    val nextActHint: String = "",
+    val encouragement: String = "",
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/ActClearReportPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/ActClearReportPort.kt
@@ -1,0 +1,7 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.evaluation.ActClearReportResult
+
+interface ActClearReportPort {
+    fun generate(actId: Int, actTitle: String, questScores: Map<String, Int>): ActClearReportResult
+}

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, ActClearReportResult } from '@/types/api.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail } from '@/features/quest-detail'
+import { ActClearReportCard } from '@/features/ai-check'
 import { useUserId } from '@/hooks/useUserId'
-import { fetchProgress, completeQuest } from '@/lib/apiClient'
+import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
 
-type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest }
+type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest } | { kind: 'act-clear'; act: Act; report: ActClearReportResult }
 
 export function App() {
   const userId = useUserId()
@@ -52,28 +53,39 @@ export function App() {
     }
   }
 
-  const handleComplete = (questId: string, xp: number, actId: number) => {
+  const triggerActClearReport = (act: Act) => {
+    fetchActClearReport(userId, act.id, `${act.title} ${act.subtitle}`)
+      .then((report) => setView({ kind: 'act-clear', act, report }))
+      .catch(() => setView({ kind: 'map' }))
+  }
+
+  const isBossQuest = (questId: string) => questId.endsWith('-BOSS')
+
+  const handleComplete = (questId: string, xp: number, actId: number, act: Act) => {
     setCompleted((prev) => ({ ...prev, [questId]: true }))
-    completeQuest(userId, questId, actId, xp).catch(() => {
-      // 저장 실패해도 로컬 상태는 유지
-    })
+    completeQuest(userId, questId, actId, xp).catch(() => {})
+    if (isBossQuest(questId)) triggerActClearReport(act)
   }
 
   const handleAiResult = (result: AiEvaluationResult) => {
     setAiResult(result)
     if (view.kind === 'detail') {
       if (result.passed) {
-        setCompleted((prev) => ({ ...prev, [view.quest.id]: true }))
-        setAiScores((prev) => ({ ...prev, [view.quest.id]: result.score }))
+        const { quest, act } = view
+        setCompleted((prev) => ({ ...prev, [quest.id]: true }))
+        setAiScores((prev) => ({ ...prev, [quest.id]: result.score }))
+        if (isBossQuest(quest.id)) triggerActClearReport(act)
       }
     }
   }
 
   const handleMockInterviewComplete = (score: number) => {
     if (view.kind === 'detail') {
+      const { quest, act } = view
       if (score >= 70) {
-        setCompleted((prev) => ({ ...prev, [view.quest.id]: true }))
-        setAiScores((prev) => ({ ...prev, [view.quest.id]: score }))
+        setCompleted((prev) => ({ ...prev, [quest.id]: true }))
+        setAiScores((prev) => ({ ...prev, [quest.id]: score }))
+        if (isBossQuest(quest.id)) triggerActClearReport(act)
       }
     }
   }
@@ -89,7 +101,7 @@ export function App() {
         color: '#F8FAFC',
       }}
     >
-      {view.kind === 'detail' && (
+      {(view.kind === 'detail' || view.kind === 'act-clear') && (
         <button
           onClick={() => setView({ kind: 'map' })}
           style={{
@@ -106,13 +118,15 @@ export function App() {
         </button>
       )}
 
-      {view.kind === 'map' ? (
+      {view.kind === 'map' && (
         <QuestMap
           onSelectAct={handleSelectAct}
           completed={completed}
           getActProgress={getActProgress}
         />
-      ) : (
+      )}
+
+      {view.kind === 'detail' && (
         <QuestDetail
           quest={view.quest}
           act={view.act}
@@ -124,6 +138,14 @@ export function App() {
           onAiResult={handleAiResult}
           onComplete={handleComplete}
           onMockInterviewComplete={handleMockInterviewComplete}
+        />
+      )}
+
+      {view.kind === 'act-clear' && (
+        <ActClearReportCard
+          report={view.report}
+          actColor={view.act.color}
+          onContinue={() => setView({ kind: 'map' })}
         />
       )}
     </div>

--- a/fe/src/features/ai-check/components/ActClearReportCard.tsx
+++ b/fe/src/features/ai-check/components/ActClearReportCard.tsx
@@ -1,0 +1,138 @@
+import type { ActClearReportResult } from '@/types/api.types'
+
+const GRADE_COLOR: Record<string, string> = {
+  S: '#F59E0B', A: '#10B981', B: '#60A5FA', C: '#A78BFA', D: '#EF4444',
+}
+
+interface ActClearReportCardProps {
+  report: ActClearReportResult
+  actColor: string
+  onContinue: () => void
+}
+
+export function ActClearReportCard({ report, actColor, onContinue }: ActClearReportCardProps) {
+  const gradeColor = GRADE_COLOR[report.grade] ?? '#475569'
+
+  return (
+    <div
+      style={{
+        background: `linear-gradient(160deg, ${actColor}08, rgba(6,6,16,0.9))`,
+        border: `1px solid ${actColor}30`,
+        borderRadius: 16,
+        padding: 24,
+        marginTop: 16,
+        animation: 'slideIn 0.5s ease',
+      }}
+    >
+      {/* Header */}
+      <div style={{ textAlign: 'center', marginBottom: 24 }}>
+        <div style={{ fontSize: 36, marginBottom: 8 }}>🏆</div>
+        <div style={{ fontSize: 10, letterSpacing: 4, color: actColor, marginBottom: 6 }}>
+          ACT {report.actId} CLEAR
+        </div>
+        <div style={{ fontSize: 20, fontWeight: 'bold', color: '#F8FAFC' }}>{report.actTitle}</div>
+      </div>
+
+      {/* Score & Grade */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: 24,
+          marginBottom: 20,
+          padding: '16px',
+          background: 'rgba(0,0,0,0.3)',
+          borderRadius: 12,
+        }}
+      >
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: '#475569', marginBottom: 4 }}>종합 점수</div>
+          <div style={{ fontSize: 28, fontWeight: 'bold', color: '#F8FAFC' }}>{report.overallScore}</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: '#475569', marginBottom: 4 }}>등급</div>
+          <div style={{ fontSize: 28, fontWeight: 'bold', color: gradeColor }}>{report.grade}</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: '#475569', marginBottom: 4 }}>클래스</div>
+          <div style={{ fontSize: 13, fontWeight: 'bold', color: actColor, maxWidth: 100 }}>
+            {report.developerClass}
+          </div>
+        </div>
+      </div>
+
+      {/* Achievements */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: 10, letterSpacing: 3, color: '#475569', marginBottom: 10 }}>
+          ACHIEVEMENTS
+        </div>
+        {report.achievements.map((achievement, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              gap: 8,
+              marginBottom: 8,
+              fontSize: 13,
+              color: '#94A3B8',
+              lineHeight: 1.5,
+            }}
+          >
+            <span style={{ color: actColor }}>✦</span>
+            {achievement}
+          </div>
+        ))}
+      </div>
+
+      {/* Next Act Hint */}
+      <div
+        style={{
+          background: 'rgba(0,0,0,0.3)',
+          border: '1px solid rgba(255,255,255,0.06)',
+          borderRadius: 10,
+          padding: '12px 14px',
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ fontSize: 10, letterSpacing: 3, color: '#475569', marginBottom: 6 }}>
+          NEXT ACT HINT
+        </div>
+        <div style={{ fontSize: 13, color: '#CBD5E1', lineHeight: 1.6 }}>{report.nextActHint}</div>
+      </div>
+
+      {/* Encouragement */}
+      <div
+        style={{
+          fontSize: 13,
+          color: '#64748B',
+          fontStyle: 'italic',
+          textAlign: 'center',
+          marginBottom: 20,
+          lineHeight: 1.6,
+        }}
+      >
+        "{report.encouragement}"
+      </div>
+
+      {/* Continue Button */}
+      <button
+        className="hov-btn"
+        onClick={onContinue}
+        style={{
+          width: '100%',
+          padding: '13px',
+          background: `linear-gradient(135deg, ${actColor}, ${actColor}80)`,
+          border: 'none',
+          borderRadius: 10,
+          color: '#060610',
+          fontSize: 14,
+          fontWeight: 'bold',
+          cursor: 'pointer',
+          fontFamily: "'Courier New', monospace",
+        }}
+      >
+        퀘스트 맵으로 →
+      </button>
+    </div>
+  )
+}

--- a/fe/src/features/ai-check/index.ts
+++ b/fe/src/features/ai-check/index.ts
@@ -1,3 +1,4 @@
+export { ActClearReportCard } from './components/ActClearReportCard'
 export { AiCheckForm } from './components/AiCheckForm'
 export { AiResultCard } from './components/AiResultCard'
 export { InterviewResultCard } from './components/InterviewResultCard'

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -13,7 +13,7 @@ interface QuestDetailProps {
   showForm: boolean
   onShowForm: () => void
   onAiResult: (result: AiEvaluationResult) => void
-  onComplete: (questId: string, xp: number, actId: number) => void
+  onComplete: (questId: string, xp: number, actId: number, act: Act) => void
   onMockInterviewComplete: (score: number) => void
 }
 
@@ -187,7 +187,7 @@ export function QuestDetail({
         {!quest.aiCheck && !done && (
           <button
             className="hov-btn"
-            onClick={() => onComplete(quest.id, quest.xp, act.id)}
+            onClick={() => onComplete(quest.id, quest.xp, act.id, act)}
             style={{
               width: '100%',
               padding: '12px',

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, ProgressResult } from '@/types/api.types'
+import type { ApiResponse, ProgressResult, ActClearReportResult } from '@/types/api.types'
 
 const API_BASE = '/api/v1'
 
@@ -22,6 +22,22 @@ export async function completeQuest(
     body: JSON.stringify({ userId, questId, actId, earnedXp }),
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
+}
+
+export async function fetchActClearReport(
+  userId: string,
+  actId: number,
+  actTitle: string,
+): Promise<ActClearReportResult> {
+  const res = await fetch(`${API_BASE}/ai-check/act-clear-report`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, actId, actTitle }),
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json: ApiResponse<ActClearReportResult> = await res.json()
+  if (!json.success || json.data == null) throw new Error('ACT 클리어 리포트 생성 실패')
+  return json.data
 }
 
 export async function callAiCheck<T>(

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -19,6 +19,17 @@ export interface ProgressResult {
   questDetails: Record<string, QuestDetail>
 }
 
+export interface ActClearReportResult {
+  actId: number
+  actTitle: string
+  overallScore: number
+  grade: string
+  developerClass: string
+  achievements: string[]
+  nextActHint: string
+  encouragement: string
+}
+
 export interface AiEvaluationResult {
   score: number
   overallScore?: number


### PR DESCRIPTION
## Summary
- BE: ACT 클리어 시 AI 종합 리포트 생성 (`POST /api/v1/ai-check/act-clear-report`)
- BE: 해당 ACT의 quest scores를 DB에서 조회해 AI에 전달
- FE: BOSS 퀘스트 완료 시 자동으로 리포트 API 호출
- FE: ACT 클리어 화면 — 종합 점수, 등급, 개발자 클래스, 성취, 다음 ACT 힌트 표시

## Flow
BOSS 퀘스트 완료 → fetchActClearReport() → ActClearReportCard 표시 → 맵으로 이동