### PR TITLE
feat(fe): add character creation screen on first visit

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,16 +1,20 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
 import type { AiEvaluationResult, ActClearReportResult } from '@/types/api.types'
+import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail } from '@/features/quest-detail'
 import { ActClearReportCard } from '@/features/ai-check'
+import { CharacterCreate } from '@/features/character'
 import { useUserId } from '@/hooks/useUserId'
+import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
 
 type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest } | { kind: 'act-clear'; act: Act; report: ActClearReportResult }
 
 export function App() {
   const userId = useUserId()
+  const { character, setCharacter } = useCharacter()
   const [view, setView] = useState<View>({ kind: 'map' })
   const [completed, setCompleted] = useState<Record<string, boolean>>({})
   const [aiScores, setAiScores] = useState<Record<string, number>>({})
@@ -43,6 +47,11 @@ export function App() {
     },
     [completed],
   )
+
+  const handleCharacterComplete = (c: Character) => {
+    setCharacter(c)
+    setView({ kind: 'map' })
+  }
 
   const handleSelectAct = (act: Act) => {
     if (act.quests.length > 0) {
@@ -90,6 +99,23 @@ export function App() {
     }
   }
 
+  if (character === null) {
+    return (
+      <div
+        style={{
+          maxWidth: 480,
+          margin: '0 auto',
+          padding: '0 20px',
+          minHeight: '100vh',
+          fontFamily: "'Courier New', monospace",
+          color: '#F8FAFC',
+        }}
+      >
+        <CharacterCreate onComplete={handleCharacterComplete} />
+      </div>
+    )
+  }
+
   return (
     <div
       style={{
@@ -123,6 +149,7 @@ export function App() {
           onSelectAct={handleSelectAct}
           completed={completed}
           getActProgress={getActProgress}
+          character={character}
         />
       )}
 

--- a/fe/src/features/character/components/CharacterCreate.tsx
+++ b/fe/src/features/character/components/CharacterCreate.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import type { Character, CharacterRole, CharacterYears } from '@/types/character.types'
+
+interface CharacterCreateProps {
+  onComplete: (character: Character) => void
+}
+
+const ROLES: CharacterRole[] = ['백엔드', '프론트엔드', '풀스택', '데이터/ML', 'DevOps']
+const YEARS: CharacterYears[] = ['신입', '1-3년', '3-5년', '5년+']
+
+const ROLE_ICONS: Record<CharacterRole, string> = {
+  '백엔드': '⚙️',
+  '프론트엔드': '🎨',
+  '풀스택': '⚡',
+  '데이터/ML': '🧠',
+  'DevOps': '🔧',
+}
+
+export function CharacterCreate({ onComplete }: CharacterCreateProps) {
+  const [nickname, setNickname] = useState('')
+  const [role, setRole] = useState<CharacterRole | null>(null)
+  const [years, setYears] = useState<CharacterYears | null>(null)
+
+  const canSubmit = nickname.trim().length > 0 && role !== null && years !== null
+
+  const handleSubmit = () => {
+    if (!canSubmit || role === null || years === null) return
+    onComplete({ nickname: nickname.trim(), role, years })
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: '40px 0',
+        animation: 'slideIn 0.4s ease',
+      }}
+    >
+      {/* 헤더 */}
+      <div style={{ textAlign: 'center', marginBottom: 40 }}>
+        <div style={{ fontSize: 10, letterSpacing: 6, color: '#1E293B', marginBottom: 12 }}>
+          CHARACTER CREATION
+        </div>
+        <div style={{ fontSize: 40, marginBottom: 16 }}>⚔️</div>
+        <h1 style={{ fontSize: 22, fontWeight: 'bold', margin: '0 0 8px', color: '#F8FAFC', letterSpacing: 1 }}>
+          새로운 모험가여
+        </h1>
+        <p style={{ fontSize: 13, color: '#475569', margin: 0, lineHeight: 1.6 }}>
+          이직이라는 던전에 입장하기 전,<br />
+          자신의 캐릭터를 설정하라
+        </p>
+      </div>
+
+      {/* 닉네임 */}
+      <div style={{ marginBottom: 28 }}>
+        <div style={{ fontSize: 10, letterSpacing: 4, color: '#4ECDC4', marginBottom: 10 }}>
+          NICKNAME
+        </div>
+        <input
+          type="text"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="개발자 닉네임을 입력하세요"
+          maxLength={20}
+          style={{
+            width: '100%',
+            padding: '12px 14px',
+            background: '#0A0E1A',
+            border: `1px solid ${nickname.trim() ? 'rgba(78,205,196,0.4)' : 'rgba(255,255,255,0.08)'}`,
+            borderRadius: 8,
+            color: '#F8FAFC',
+            fontSize: 14,
+            fontFamily: "'Courier New', monospace",
+            outline: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+
+      {/* 직군 */}
+      <div style={{ marginBottom: 28 }}>
+        <div style={{ fontSize: 10, letterSpacing: 4, color: '#4ECDC4', marginBottom: 10 }}>
+          CLASS
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {ROLES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRole(r)}
+              style={{
+                padding: '9px 14px',
+                background: role === r ? 'rgba(78,205,196,0.15)' : '#0A0E1A',
+                border: `1px solid ${role === r ? 'rgba(78,205,196,0.5)' : 'rgba(255,255,255,0.08)'}`,
+                borderRadius: 8,
+                color: role === r ? '#4ECDC4' : '#64748B',
+                fontSize: 13,
+                fontFamily: "'Courier New', monospace",
+                cursor: 'pointer',
+                transition: 'all 0.15s ease',
+              }}
+            >
+              {ROLE_ICONS[r]} {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 경력 */}
+      <div style={{ marginBottom: 40 }}>
+        <div style={{ fontSize: 10, letterSpacing: 4, color: '#4ECDC4', marginBottom: 10 }}>
+          EXPERIENCE
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {YEARS.map((y) => (
+            <button
+              key={y}
+              onClick={() => setYears(y)}
+              style={{
+                flex: 1,
+                padding: '10px 8px',
+                background: years === y ? 'rgba(78,205,196,0.15)' : '#0A0E1A',
+                border: `1px solid ${years === y ? 'rgba(78,205,196,0.5)' : 'rgba(255,255,255,0.08)'}`,
+                borderRadius: 8,
+                color: years === y ? '#4ECDC4' : '#64748B',
+                fontSize: 12,
+                fontFamily: "'Courier New', monospace",
+                cursor: 'pointer',
+                transition: 'all 0.15s ease',
+              }}
+            >
+              {y}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 시작 버튼 */}
+      <button
+        onClick={handleSubmit}
+        disabled={!canSubmit}
+        className={canSubmit ? 'hov-btn' : ''}
+        style={{
+          width: '100%',
+          padding: '15px',
+          background: canSubmit
+            ? 'linear-gradient(135deg, #4ECDC4, #4ECDC480)'
+            : 'rgba(255,255,255,0.04)',
+          border: `1px solid ${canSubmit ? 'transparent' : 'rgba(255,255,255,0.06)'}`,
+          borderRadius: 10,
+          color: canSubmit ? '#060610' : '#334155',
+          fontSize: 15,
+          fontWeight: 'bold',
+          fontFamily: "'Courier New', monospace",
+          cursor: canSubmit ? 'pointer' : 'not-allowed',
+          transition: 'all 0.2s ease',
+          letterSpacing: 1,
+        }}
+      >
+        ⚔️ 모험 시작
+      </button>
+    </div>
+  )
+}

--- a/fe/src/features/character/index.ts
+++ b/fe/src/features/character/index.ts
@@ -1,0 +1,1 @@
+export { CharacterCreate } from './components/CharacterCreate'

--- a/fe/src/features/quest-map/components/QuestMap.tsx
+++ b/fe/src/features/quest-map/components/QuestMap.tsx
@@ -1,4 +1,5 @@
 import type { Act } from '@/types/quest.types'
+import type { Character } from '@/types/character.types'
 import { ACTS, ACT_UNLOCK_THRESHOLD } from '../constants/questData'
 import { ActCard } from './ActCard'
 import { StatsPanel } from './StatsPanel'
@@ -7,22 +8,23 @@ interface QuestMapProps {
   onSelectAct: (act: Act) => void
   completed: Record<string, boolean>
   getActProgress: (act: Act) => number
+  character: Character
 }
 
-export function QuestMap({ onSelectAct, completed, getActProgress }: QuestMapProps) {
+export function QuestMap({ onSelectAct, completed, getActProgress, character }: QuestMapProps) {
   const completedCount = Object.keys(completed).length
 
   return (
     <div style={{ animation: 'slideIn 0.4s ease' }}>
       <div style={{ textAlign: 'center', padding: '40px 0 24px' }}>
         <div style={{ fontSize: 10, letterSpacing: 6, color: '#1E293B', marginBottom: 5 }}>
-          5YR BACKEND DEVELOPER
+          {character.years} {character.role.toUpperCase()}
         </div>
         <h1 style={{ fontSize: 30, fontWeight: 'bold', margin: 0, letterSpacing: 2, color: '#F8FAFC' }}>
-          이직 퀘스트
+          {character.nickname}
         </h1>
         <p style={{ color: '#334155', fontSize: 12, marginTop: 8 }}>
-          Spring AI 기반 퀘스트 검사 · 퀘스트 완료로 이직 성공
+          이직 퀘스트 · Spring AI 검사 기반
         </p>
       </div>
 

--- a/fe/src/hooks/useCharacter.ts
+++ b/fe/src/hooks/useCharacter.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import type { Character } from '@/types/character.types'
+
+const STORAGE_KEY = 'devquest-character'
+
+function loadCharacter(): Character | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Character) : null
+  } catch {
+    return null
+  }
+}
+
+function saveCharacter(character: Character): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(character))
+  } catch {
+    // ignore
+  }
+}
+
+export function useCharacter() {
+  const [character, setCharacterState] = useState<Character | null>(loadCharacter)
+
+  const setCharacter = (c: Character) => {
+    saveCharacter(c)
+    setCharacterState(c)
+  }
+
+  return { character, setCharacter }
+}

--- a/fe/src/types/character.types.ts
+++ b/fe/src/types/character.types.ts
@@ -1,0 +1,8 @@
+export type CharacterRole = '백엔드' | '프론트엔드' | '풀스택' | '데이터/ML' | 'DevOps'
+export type CharacterYears = '신입' | '1-3년' | '3-5년' | '5년+'
+
+export interface Character {
+  nickname: string
+  role: CharacterRole
+  years: CharacterYears
+}


### PR DESCRIPTION
## Summary
- 첫 방문 시 캐릭터 생성 화면 표시 (닉네임, 직군, 경력 선택)
- 캐릭터 정보를 localStorage(`devquest-character`)에 저장
- 퀘스트 맵 헤더에 닉네임 및 직군/경력 표시

## Changes
- `fe/src/types/character.types.ts` — `Character`, `CharacterRole`, `CharacterYears` 타입
- `fe/src/hooks/useCharacter.ts` — localStorage 읽기/쓰기 훅
- `fe/src/features/character/components/CharacterCreate.tsx` — 캐릭터 생성 UI
- `fe/src/app/App.tsx` — `character === null` 시 캐릭터 생성 화면 우선 렌더링
- `fe/src/features/quest-map/components/QuestMap.tsx` — `character` prop으로 헤더 동적 표시

## Test plan
- [ ] 첫 방문 시 캐릭터 생성 화면 표시 확인
- [ ] 닉네임/직군/경력 모두 입력 전 "모험 시작" 버튼 비활성화 확인
- [ ] 완료 후 퀘스트 맵으로 이동, 헤더에 닉네임 표시 확인
- [ ] 재방문 시 캐릭터 생성 화면 건너뛰고 퀘스트 맵 바로 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)