### PR TITLE
feat(be): add interview coach session API

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
@@ -1,0 +1,146 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
+import com.devquest.core.domain.model.evaluation.CoachAnswerResult
+import com.devquest.core.domain.model.evaluation.CoachReportResult
+import com.devquest.core.domain.model.evaluation.CoachSessionResult
+import com.devquest.core.domain.port.InterviewCoachPort
+import com.devquest.core.domain.support.AiEvaluationException
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+@Component
+class InterviewCoachEvaluator(
+    private val chatClient: ChatClient
+) : InterviewCoachPort {
+
+    override fun startSession(jdText: String, targetRole: String): CoachSessionResult {
+        val prompt = """
+            당신은 10년 이상의 경험을 가진 시니어 개발자 면접관 겸 커리어 코치입니다.
+            아래 JD(채용공고)를 분석하고, 해당 포지션의 기술 면접을 위한 맞춤형 질문 5개를 생성하세요.
+
+            ## 목표 포지션
+            ${targetRole}
+
+            ## 채용공고 (JD)
+            ${jdText}
+
+            ## 작업
+            1. JD를 분석하여 핵심 역량 3~5가지를 추출하세요.
+            2. 각 핵심 역량을 검증할 수 있는 기술 면접 질문을 총 5개 생성하세요.
+            3. 질문은 실무 경험을 드러낼 수 있는 구체적인 질문으로 작성하세요.
+            4. 질문 index는 0부터 시작합니다.
+
+            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
+            {
+                "jdSummary": "JD 핵심 내용 2~3문장 요약",
+                "keyCompetencies": ["핵심역량1", "핵심역량2", "핵심역량3"],
+                "questions": [
+                    {"index": 0, "question": "질문 내용", "competency": "관련 핵심역량"},
+                    {"index": 1, "question": "질문 내용", "competency": "관련 핵심역량"},
+                    {"index": 2, "question": "질문 내용", "competency": "관련 핵심역량"},
+                    {"index": 3, "question": "질문 내용", "competency": "관련 핵심역량"},
+                    {"index": 4, "question": "질문 내용", "competency": "관련 핵심역량"}
+                ]
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(CoachSessionResult::class.java)
+            ?: throw AiEvaluationException("면접 세션 시작 실패")
+    }
+
+    override fun evaluateAnswer(question: String, answer: String, questionIndex: Int, totalQuestions: Int): CoachAnswerResult {
+        val prompt = """
+            당신은 10년 이상의 경험을 가진 시니어 개발자 면접관 겸 커리어 코치입니다.
+            지원자의 면접 답변을 STAR 기법(Situation, Task, Action, Result) 기준으로 평가하고, 격려와 개선점을 제공하세요.
+
+            ## 면접 질문 (${questionIndex + 1}번 / 전체 ${totalQuestions}개)
+            ${question}
+
+            ## 지원자 답변
+            ${answer}
+
+            ## 평가 기준 (총 100점)
+            - Situation/Task (25점): 상황과 과제를 명확히 설명했는가
+            - Action (40점): 본인이 취한 구체적인 행동을 기술했는가
+            - Result (25점): 측정 가능한 결과나 배운 점을 제시했는가
+            - 전달력/논리성 (10점): 답변이 명확하고 논리적인가
+
+            ## 응답 규칙
+            - feedback: 답변의 강점과 아쉬운 점을 2~3문장으로 구체적으로 서술
+            - score: 0~100 사이의 정수 점수
+            - improvements: 개선할 수 있는 구체적인 방법 2~3가지 (짧고 실천 가능하게)
+            - encouragement: 지원자를 격려하는 한 문장 (따뜻하고 진정성 있게)
+
+            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
+            {
+                "feedback": "답변 피드백 내용",
+                "score": 75,
+                "improvements": ["개선점1", "개선점2", "개선점3"],
+                "encouragement": "격려 메시지"
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(CoachAnswerResult::class.java)
+            ?: throw AiEvaluationException("답변 평가 실패")
+    }
+
+    override fun generateReport(targetRole: String, jdSummary: String, answers: List<CoachAnswerHistory>): CoachReportResult {
+        val answersText = answers.mapIndexed { idx, it ->
+            """
+            [질문 ${idx + 1}]
+            질문: ${it.question}
+            답변: ${it.answer}
+            피드백: ${it.feedback}
+            """.trimIndent()
+        }.joinToString("\n\n")
+
+        val prompt = """
+            당신은 10년 이상의 경험을 가진 시니어 개발자 면접관 겸 커리어 코치입니다.
+            지원자의 전체 면접 세션을 종합 분석하여 최종 리포트를 작성하세요.
+
+            ## 목표 포지션
+            ${targetRole}
+
+            ## JD 요약
+            ${jdSummary}
+
+            ## 전체 질문/답변/피드백 내역
+            ${answersText}
+
+            ## 작업
+            1. 전체 답변을 종합하여 전반적인 면접 성과를 평가하세요.
+            2. 지원자의 강점과 약점을 구체적으로 분석하세요.
+            3. 합격 가능성을 현실적으로 판단하세요.
+            4. 실질적인 최종 조언을 제공하세요.
+
+            ## 응답 규칙
+            - overallScore: 전체 세션 종합 점수 (0~100 정수)
+            - passLikelihood: 이 포지션 합격 가능성 % (0~100 정수, 현실적으로 평가)
+            - strengths: 면접에서 드러난 강점 2~3가지 (구체적으로)
+            - weaknesses: 보완이 필요한 약점 2~3가지 (건설적으로)
+            - finalAdvice: 이직 준비를 위한 최종 조언 3~4문장 (실천 가능한 방향으로)
+
+            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
+            {
+                "overallScore": 78,
+                "passLikelihood": 65,
+                "strengths": ["강점1", "강점2", "강점3"],
+                "weaknesses": ["약점1", "약점2"],
+                "finalAdvice": "최종 조언 내용"
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(CoachReportResult::class.java)
+            ?: throw AiEvaluationException("종합 리포트 생성 실패")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
@@ -1,0 +1,211 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
+import com.devquest.core.domain.model.evaluation.CoachAnswerResult
+import com.devquest.core.domain.model.evaluation.CoachReportResult
+import com.devquest.core.domain.model.evaluation.CoachSessionResult
+import com.devquest.core.domain.model.evaluation.CoachQuestion
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class InterviewCoachEvaluatorTest {
+
+    private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val evaluator = InterviewCoachEvaluator(chatClient)
+
+    // ── startSession ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `startSession - AI가 null을 반환하면 AiEvaluationException 발생`() {
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachSessionResult::class.java)
+        ).thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.startSession(jdText = "백엔드 개발자 모집합니다.", targetRole = "시니어 백엔드 개발자")
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("면접 세션 시작 실패")
+    }
+
+    @Test
+    fun `startSession - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
+        val expected = CoachSessionResult(
+            jdSummary = "Spring Boot 기반 백엔드 개발자 모집",
+            keyCompetencies = listOf("Spring Boot", "JPA", "MSA"),
+            questions = listOf(
+                CoachQuestion(0, "JPA N+1 문제를 어떻게 해결하셨나요?", "JPA"),
+                CoachQuestion(1, "MSA 환경에서 트랜잭션 처리 경험을 공유해주세요.", "MSA"),
+            )
+        )
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachSessionResult::class.java)
+        ).thenReturn(expected)
+
+        val result = evaluator.startSession(
+            jdText = "Spring Boot 기반 백엔드 개발자를 모집합니다. JPA, MSA 경험 우대.",
+            targetRole = "시니어 백엔드 개발자"
+        )
+
+        assertThat(result.jdSummary).isEqualTo("Spring Boot 기반 백엔드 개발자 모집")
+        assertThat(result.keyCompetencies).hasSize(3)
+        assertThat(result.questions).hasSize(2)
+    }
+
+    @Test
+    fun `startSession - 프롬프트에 JD 내용과 목표 포지션이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().user(capture(promptCaptor)).call().entity(CoachSessionResult::class.java)
+        ).thenReturn(CoachSessionResult())
+
+        evaluator.startSession(
+            jdText = "Kotlin과 Spring Boot를 사용하는 팀입니다.",
+            targetRole = "백엔드 개발자"
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("Kotlin과 Spring Boot를 사용하는 팀입니다.")
+        assertThat(prompt).contains("백엔드 개발자")
+        assertThat(prompt).contains("핵심 역량")
+    }
+
+    // ── evaluateAnswer ────────────────────────────────────────────────────────
+
+    @Test
+    fun `evaluateAnswer - AI가 null을 반환하면 AiEvaluationException 발생`() {
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachAnswerResult::class.java)
+        ).thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluateAnswer(
+                question = "JPA N+1 문제를 어떻게 해결하셨나요?",
+                answer = "fetch join을 사용했습니다.",
+                questionIndex = 0,
+                totalQuestions = 5,
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("답변 평가 실패")
+    }
+
+    @Test
+    fun `evaluateAnswer - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
+        val expected = CoachAnswerResult(
+            feedback = "STAR 기법을 잘 활용한 답변입니다.",
+            score = 82,
+            improvements = listOf("결과 수치를 더 구체적으로 제시하면 좋겠습니다."),
+            encouragement = "좋은 경험을 잘 전달하셨어요. 계속 화이팅!"
+        )
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachAnswerResult::class.java)
+        ).thenReturn(expected)
+
+        val result = evaluator.evaluateAnswer(
+            question = "JPA N+1 문제를 어떻게 해결하셨나요?",
+            answer = "fetch join과 @EntityGraph를 상황에 맞게 활용했습니다.",
+            questionIndex = 1,
+            totalQuestions = 5,
+        )
+
+        assertThat(result.score).isEqualTo(82)
+        assertThat(result.feedback).contains("STAR")
+        assertThat(result.encouragement).isNotBlank()
+    }
+
+    @Test
+    fun `evaluateAnswer - 프롬프트에 질문 번호와 전체 문제 수가 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().user(capture(promptCaptor)).call().entity(CoachAnswerResult::class.java)
+        ).thenReturn(CoachAnswerResult())
+
+        evaluator.evaluateAnswer(
+            question = "테스트 질문",
+            answer = "테스트 답변",
+            questionIndex = 2,
+            totalQuestions = 5,
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("3번")
+        assertThat(prompt).contains("전체 5개")
+    }
+
+    // ── generateReport ────────────────────────────────────────────────────────
+
+    @Test
+    fun `generateReport - AI가 null을 반환하면 AiEvaluationException 발생`() {
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachReportResult::class.java)
+        ).thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.generateReport(
+                targetRole = "시니어 백엔드 개발자",
+                jdSummary = "Spring Boot 기반 백엔드 개발자 모집",
+                answers = listOf(CoachAnswerHistory("질문", "답변", "피드백"))
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("종합 리포트 생성 실패")
+    }
+
+    @Test
+    fun `generateReport - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
+        val expected = CoachReportResult(
+            overallScore = 78,
+            passLikelihood = 65,
+            strengths = listOf("기술적 깊이", "문제 해결 능력"),
+            weaknesses = listOf("결과 수치화 부족"),
+            finalAdvice = "STAR 기법 연습을 꾸준히 하면 합격 가능성이 높아집니다."
+        )
+        whenever(
+            chatClient.prompt().user(any<String>()).call().entity(CoachReportResult::class.java)
+        ).thenReturn(expected)
+
+        val result = evaluator.generateReport(
+            targetRole = "시니어 백엔드 개발자",
+            jdSummary = "Spring Boot 기반 백엔드 개발자 모집",
+            answers = listOf(
+                CoachAnswerHistory("JPA N+1 문제를 어떻게 해결하셨나요?", "fetch join을 사용했습니다.", "구체적인 결과 수치가 부족합니다.")
+            )
+        )
+
+        assertThat(result.overallScore).isEqualTo(78)
+        assertThat(result.passLikelihood).isEqualTo(65)
+        assertThat(result.strengths).hasSize(2)
+        assertThat(result.finalAdvice).isNotBlank()
+    }
+
+    @Test
+    fun `generateReport - 프롬프트에 목표 포지션과 JD 요약이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().user(capture(promptCaptor)).call().entity(CoachReportResult::class.java)
+        ).thenReturn(CoachReportResult())
+
+        evaluator.generateReport(
+            targetRole = "시니어 백엔드 개발자",
+            jdSummary = "Kotlin 기반 서비스 개발",
+            answers = listOf(CoachAnswerHistory("질문", "답변", "피드백"))
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("시니어 백엔드 개발자")
+        assertThat(prompt).contains("Kotlin 기반 서비스 개발")
+        assertThat(prompt).contains("합격 가능성")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/InterviewCoachController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/InterviewCoachController.kt
@@ -1,0 +1,66 @@
+package com.devquest.core.api.controller.v1
+
+import com.devquest.core.api.controller.v1.request.CoachAnswerRequestDto
+import com.devquest.core.api.controller.v1.request.CoachReportRequestDto
+import com.devquest.core.api.controller.v1.request.CoachSessionStartRequestDto
+import com.devquest.core.domain.InterviewCoachService
+import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
+import com.devquest.core.support.error.CoreException
+import com.devquest.core.support.error.ErrorType
+import com.devquest.core.support.response.ApiResponse
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/coach")
+class InterviewCoachController(
+    private val interviewCoachService: InterviewCoachService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/session/start")
+    fun startSession(@Valid @RequestBody request: CoachSessionStartRequestDto): ApiResponse<*> {
+        return try {
+            ApiResponse.success(interviewCoachService.startSession(request.jdText, request.targetRole))
+        } catch (e: Exception) {
+            log.error("Interview coach session start failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
+
+    @PostMapping("/session/answer")
+    fun submitAnswer(@Valid @RequestBody request: CoachAnswerRequestDto): ApiResponse<*> {
+        return try {
+            ApiResponse.success(
+                interviewCoachService.evaluateAnswer(
+                    request.question,
+                    request.answer,
+                    request.questionIndex,
+                    request.totalQuestions,
+                )
+            )
+        } catch (e: Exception) {
+            log.error("Interview coach answer evaluation failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
+
+    @PostMapping("/session/report")
+    fun generateReport(@Valid @RequestBody request: CoachReportRequestDto): ApiResponse<*> {
+        return try {
+            val answers = request.answers.map {
+                CoachAnswerHistory(question = it.question, answer = it.answer, feedback = it.feedback)
+            }
+            ApiResponse.success(
+                interviewCoachService.generateReport(request.targetRole, request.jdSummary, answers)
+            )
+        } catch (e: Exception) {
+            log.error("Interview coach report generation failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachAnswerRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachAnswerRequestDto.kt
@@ -1,0 +1,13 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+
+data class CoachAnswerRequestDto(
+    @field:NotBlank val userId: String,
+    @field:NotBlank val question: String,
+    @field:NotBlank val answer: String,
+    @field:Min(0) val questionIndex: Int,
+    @field:Positive val totalQuestions: Int,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachReportRequestDto.kt
@@ -1,0 +1,17 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CoachAnswerHistoryDto(
+    val question: String,
+    val answer: String,
+    val feedback: String,
+)
+
+data class CoachReportRequestDto(
+    @field:NotBlank val userId: String,
+    @field:NotBlank val targetRole: String,
+    @field:NotBlank val jdSummary: String,
+    @field:Size(min = 1, max = 10) val answers: List<CoachAnswerHistoryDto>,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachSessionStartRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachSessionStartRequestDto.kt
@@ -1,0 +1,10 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CoachSessionStartRequestDto(
+    @field:NotBlank val userId: String,
+    @field:NotBlank @field:Size(min = 10, max = 5000) val jdText: String,
+    @field:NotBlank val targetRole: String,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/InterviewCoachService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/InterviewCoachService.kt
@@ -6,24 +6,20 @@ import com.devquest.core.domain.model.evaluation.CoachReportResult
 import com.devquest.core.domain.model.evaluation.CoachSessionResult
 import com.devquest.core.domain.port.InterviewCoachPort
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class InterviewCoachService(
     private val interviewCoachPort: InterviewCoachPort,
 ) {
 
-    @Transactional(readOnly = true)
     fun startSession(jdText: String, targetRole: String): CoachSessionResult {
         return interviewCoachPort.startSession(jdText, targetRole)
     }
 
-    @Transactional(readOnly = true)
     fun evaluateAnswer(question: String, answer: String, questionIndex: Int, totalQuestions: Int): CoachAnswerResult {
         return interviewCoachPort.evaluateAnswer(question, answer, questionIndex, totalQuestions)
     }
 
-    @Transactional(readOnly = true)
     fun generateReport(targetRole: String, jdSummary: String, answers: List<CoachAnswerHistory>): CoachReportResult {
         return interviewCoachPort.generateReport(targetRole, jdSummary, answers)
     }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/InterviewCoachService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/InterviewCoachService.kt
@@ -1,0 +1,30 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
+import com.devquest.core.domain.model.evaluation.CoachAnswerResult
+import com.devquest.core.domain.model.evaluation.CoachReportResult
+import com.devquest.core.domain.model.evaluation.CoachSessionResult
+import com.devquest.core.domain.port.InterviewCoachPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class InterviewCoachService(
+    private val interviewCoachPort: InterviewCoachPort,
+) {
+
+    @Transactional(readOnly = true)
+    fun startSession(jdText: String, targetRole: String): CoachSessionResult {
+        return interviewCoachPort.startSession(jdText, targetRole)
+    }
+
+    @Transactional(readOnly = true)
+    fun evaluateAnswer(question: String, answer: String, questionIndex: Int, totalQuestions: Int): CoachAnswerResult {
+        return interviewCoachPort.evaluateAnswer(question, answer, questionIndex, totalQuestions)
+    }
+
+    @Transactional(readOnly = true)
+    fun generateReport(targetRole: String, jdSummary: String, answers: List<CoachAnswerHistory>): CoachReportResult {
+        return interviewCoachPort.generateReport(targetRole, jdSummary, answers)
+    }
+}

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachAnswerResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachAnswerResult.kt
@@ -1,0 +1,8 @@
+package com.devquest.core.domain.model.evaluation
+
+data class CoachAnswerResult(
+    val feedback: String = "",
+    val score: Int = 0,
+    val improvements: List<String> = emptyList(),
+    val encouragement: String = "",
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachReportResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachReportResult.kt
@@ -1,0 +1,15 @@
+package com.devquest.core.domain.model.evaluation
+
+data class CoachAnswerHistory(
+    val question: String,
+    val answer: String,
+    val feedback: String,
+)
+
+data class CoachReportResult(
+    val overallScore: Int = 0,
+    val passLikelihood: Int = 0,
+    val strengths: List<String> = emptyList(),
+    val weaknesses: List<String> = emptyList(),
+    val finalAdvice: String = "",
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachSessionResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/CoachSessionResult.kt
@@ -1,0 +1,13 @@
+package com.devquest.core.domain.model.evaluation
+
+data class CoachQuestion(
+    val index: Int,
+    val question: String,
+    val competency: String,
+)
+
+data class CoachSessionResult(
+    val jdSummary: String = "",
+    val keyCompetencies: List<String> = emptyList(),
+    val questions: List<CoachQuestion> = emptyList(),
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/InterviewCoachPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/InterviewCoachPort.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
+import com.devquest.core.domain.model.evaluation.CoachAnswerResult
+import com.devquest.core.domain.model.evaluation.CoachReportResult
+import com.devquest.core.domain.model.evaluation.CoachSessionResult
+
+interface InterviewCoachPort {
+    fun startSession(jdText: String, targetRole: String): CoachSessionResult
+    fun evaluateAnswer(question: String, answer: String, questionIndex: Int, totalQuestions: Int): CoachAnswerResult
+    fun generateReport(targetRole: String, jdSummary: String, answers: List<CoachAnswerHistory>): CoachReportResult
+}


### PR DESCRIPTION
## Summary
- 전담 면접 코치 BE API 3개 추가 (start / answer / report)
- JD 분석 + 맞춤 질문 생성, 질문별 즉시 피드백, 종합 리포트 생성
- Port & Adapter 패턴 준수, core-domain에 Spring 어노테이션 없음

## 변경 파일
- `core-domain`: `InterviewCoachPort`, `CoachSessionResult`, `CoachAnswerResult`, `CoachReportResult`
- `client-ai`: `InterviewCoachEvaluator` (한국어 코치 페르소나 프롬프트, STAR 기법 평가)
- `core-api`: `InterviewCoachController`, `InterviewCoachService`, Request DTO 3개
- `client-ai/test`: `InterviewCoachEvaluatorTest` (9개 테스트)

## Test plan
- [ ] `POST /api/v1/coach/session/start` — JD 붙여넣기 후 질문 5개 생성 확인
- [ ] `POST /api/v1/coach/session/answer` — 답변 제출 후 피드백/점수 반환 확인
- [ ] `POST /api/v1/coach/session/report` — 전체 답변 제출 후 종합 리포트 반환 확인
- [ ] 단위 테스트 9개 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)