### PR TITLE
feat(fe): add interview coach UI with 4-step coaching flow

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -6,11 +6,12 @@ import { QuestMap } from '@/features/quest-map'
 import { QuestDetail } from '@/features/quest-detail'
 import { ActClearReportCard } from '@/features/ai-check'
 import { CharacterCreate } from '@/features/character'
+import { InterviewCoach } from '@/features/interview-coach'
 import { useUserId } from '@/hooks/useUserId'
 import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
 
-type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest } | { kind: 'act-clear'; act: Act; report: ActClearReportResult }
+type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest } | { kind: 'act-clear'; act: Act; report: ActClearReportResult } | { kind: 'interview-coach' }
 
 export function App() {
   const userId = useUserId()
@@ -127,7 +128,7 @@ export function App() {
         color: '#F8FAFC',
       }}
     >
-      {(view.kind === 'detail' || view.kind === 'act-clear') && (
+      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach') && (
         <button
           onClick={() => setView({ kind: 'map' })}
           style={{
@@ -147,6 +148,7 @@ export function App() {
       {view.kind === 'map' && (
         <QuestMap
           onSelectAct={handleSelectAct}
+          onOpenCoach={() => setView({ kind: 'interview-coach' })}
           completed={completed}
           getActProgress={getActProgress}
           character={character}
@@ -174,6 +176,10 @@ export function App() {
           actColor={view.act.color}
           onContinue={() => setView({ kind: 'map' })}
         />
+      )}
+
+      {view.kind === 'interview-coach' && (
+        <InterviewCoach userId={userId} />
       )}
     </div>
   )

--- a/fe/src/features/interview-coach/api/interviewCoachApi.ts
+++ b/fe/src/features/interview-coach/api/interviewCoachApi.ts
@@ -1,0 +1,56 @@
+import type { ApiResponse } from '@/types/api.types'
+import type { CoachSessionResult, CoachAnswerResult, CoachAnswerHistory, CoachReportResult } from '../types/coach.types'
+
+const API_BASE = '/api/v1/coach'
+
+async function callCoach<T>(path: string, body: Record<string, unknown>): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`
+    try {
+      const err: ApiResponse<unknown> = await res.json()
+      if (err.message) message = err.message
+    } catch { /* ignore */ }
+    throw new Error(message)
+  }
+  const json: ApiResponse<T> = await res.json()
+  if (!json.success || json.data == null) throw new Error(json.message ?? '코치 API 오류')
+  return json.data
+}
+
+export async function startCoachSession(
+  userId: string,
+  jdText: string,
+  targetRole: string,
+): Promise<CoachSessionResult> {
+  return callCoach<CoachSessionResult>('/session/start', { userId, jdText, targetRole })
+}
+
+export async function submitCoachAnswer(
+  userId: string,
+  question: string,
+  answer: string,
+  questionIndex: number,
+  totalQuestions: number,
+): Promise<CoachAnswerResult> {
+  return callCoach<CoachAnswerResult>('/session/answer', {
+    userId,
+    question,
+    answer,
+    questionIndex,
+    totalQuestions,
+  })
+}
+
+export async function generateCoachReport(
+  userId: string,
+  targetRole: string,
+  jdSummary: string,
+  answers: CoachAnswerHistory[],
+): Promise<CoachReportResult> {
+  return callCoach<CoachReportResult>('/session/report', { userId, targetRole, jdSummary, answers })
+}

--- a/fe/src/features/interview-coach/components/CoachAnalysis.tsx
+++ b/fe/src/features/interview-coach/components/CoachAnalysis.tsx
@@ -1,0 +1,116 @@
+import type { CoachSessionResult } from '../types/coach.types'
+import { CoachBubble } from './CoachBubble'
+
+interface CoachAnalysisProps {
+  session: CoachSessionResult
+  targetRole: string
+  onBegin: () => void
+}
+
+export function CoachAnalysis({ session, targetRole, onBegin }: CoachAnalysisProps) {
+  return (
+    <div>
+      <CoachBubble
+        message={`JD 분석을 완료했습니다!\n\n${session.jdSummary}`}
+      />
+
+      <div
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          padding: 16,
+          marginBottom: 16,
+        }}
+      >
+        <p style={{ fontSize: 11, color: '#4ECDC4', margin: '0 0 10px', letterSpacing: 1 }}>
+          핵심 역량
+        </p>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {session.keyCompetencies.map((c, i) => (
+            <span
+              key={i}
+              style={{
+                background: 'rgba(167,139,250,0.15)',
+                border: '1px solid rgba(167,139,250,0.3)',
+                borderRadius: 20,
+                padding: '4px 12px',
+                fontSize: 12,
+                color: '#A78BFA',
+              }}
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <CoachBubble
+        message={`${targetRole} 직무에 맞는 면접 질문 ${session.questions.length}개를 준비했습니다.\n\n준비되셨으면 면접을 시작해볼까요? 각 질문에 성실하게 답변해주시면 즉시 피드백을 드리겠습니다.`}
+      />
+
+      <div
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          padding: 16,
+          marginBottom: 20,
+        }}
+      >
+        <p style={{ fontSize: 11, color: '#475569', margin: '0 0 12px', letterSpacing: 1 }}>
+          오늘의 면접 질문 목록
+        </p>
+        {session.questions.map((q) => (
+          <div
+            key={q.index}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              padding: '6px 0',
+              borderBottom: '1px solid rgba(255,255,255,0.04)',
+            }}
+          >
+            <span
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: '50%',
+                background: 'rgba(78,205,196,0.1)',
+                border: '1px solid rgba(78,205,196,0.3)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 11,
+                color: '#4ECDC4',
+                flexShrink: 0,
+              }}
+            >
+              {q.index + 1}
+            </span>
+            <span style={{ fontSize: 12, color: '#475569' }}>{q.competency} 관련 질문</span>
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={onBegin}
+        style={{
+          width: '100%',
+          background: 'linear-gradient(135deg, #4ECDC4, #A78BFA)',
+          border: 'none',
+          borderRadius: 8,
+          padding: '12px 24px',
+          color: '#060610',
+          fontSize: 14,
+          fontWeight: 700,
+          fontFamily: "'Courier New', monospace",
+          cursor: 'pointer',
+        }}
+      >
+        면접 시작하기 →
+      </button>
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/components/CoachBubble.tsx
+++ b/fe/src/features/interview-coach/components/CoachBubble.tsx
@@ -1,0 +1,42 @@
+interface CoachBubbleProps {
+  message: string
+  type?: 'coach' | 'system'
+}
+
+export function CoachBubble({ message, type = 'coach' }: CoachBubbleProps) {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginBottom: 16 }}>
+      {type === 'coach' && (
+        <div
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            background: 'linear-gradient(135deg, #4ECDC4, #A78BFA)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 18,
+            flexShrink: 0,
+          }}
+        >
+          🎯
+        </div>
+      )}
+      <div
+        style={{
+          background: type === 'coach' ? '#0F172A' : 'rgba(78,205,196,0.08)',
+          border: `1px solid ${type === 'coach' ? 'rgba(255,255,255,0.08)' : 'rgba(78,205,196,0.2)'}`,
+          borderRadius: type === 'coach' ? '4px 12px 12px 12px' : 8,
+          padding: '12px 16px',
+          color: '#F1F5F9',
+          fontSize: 14,
+          lineHeight: 1.6,
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {message}
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/components/CoachOnboarding.tsx
+++ b/fe/src/features/interview-coach/components/CoachOnboarding.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { CoachBubble } from './CoachBubble'
+
+interface CoachOnboardingProps {
+  onStart: (targetRole: string, jdText: string) => void
+  loading: boolean
+}
+
+export function CoachOnboarding({ onStart, loading }: CoachOnboardingProps) {
+  const [targetRole, setTargetRole] = useState('')
+  const [jdText, setJdText] = useState('')
+
+  const canSubmit = targetRole.trim().length > 0 && jdText.trim().length > 0 && !loading
+
+  return (
+    <div>
+      <CoachBubble
+        message={`안녕하세요! 저는 당신의 전담 면접 코치입니다. 🎯\n\n지원할 직무와 채용공고(JD)를 알려주시면, 처음부터 끝까지 함께 면접을 준비해드리겠습니다.\n\n먼저 아래 정보를 입력해주세요.`}
+      />
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginTop: 8 }}>
+        <div>
+          <label style={{ display: 'block', fontSize: 12, color: '#4ECDC4', marginBottom: 6 }}>
+            목표 직무
+          </label>
+          <input
+            type="text"
+            value={targetRole}
+            onChange={(e) => setTargetRole(e.target.value)}
+            placeholder="예: 백엔드 개발자 (5년차)"
+            style={{
+              width: '100%',
+              background: '#0A0E1A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              padding: '10px 14px',
+              color: '#F8FAFC',
+              fontSize: 14,
+              fontFamily: "'Courier New', monospace",
+              boxSizing: 'border-box',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        <div>
+          <label style={{ display: 'block', fontSize: 12, color: '#4ECDC4', marginBottom: 6 }}>
+            채용공고 (JD) 붙여넣기
+          </label>
+          <textarea
+            value={jdText}
+            onChange={(e) => setJdText(e.target.value)}
+            placeholder="채용공고 내용을 그대로 붙여넣어 주세요. 직무 설명, 자격 요건, 우대사항 등을 포함하면 더 정확한 질문이 생성됩니다."
+            rows={8}
+            style={{
+              width: '100%',
+              background: '#0A0E1A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              padding: '10px 14px',
+              color: '#F8FAFC',
+              fontSize: 13,
+              fontFamily: "'Courier New', monospace",
+              boxSizing: 'border-box',
+              resize: 'vertical',
+              outline: 'none',
+              lineHeight: 1.6,
+            }}
+          />
+        </div>
+
+        <button
+          onClick={() => onStart(targetRole.trim(), jdText.trim())}
+          disabled={!canSubmit}
+          style={{
+            background: canSubmit ? 'linear-gradient(135deg, #4ECDC4, #A78BFA)' : 'rgba(255,255,255,0.05)',
+            border: 'none',
+            borderRadius: 8,
+            padding: '12px 24px',
+            color: canSubmit ? '#060610' : '#475569',
+            fontSize: 14,
+            fontWeight: 700,
+            fontFamily: "'Courier New', monospace",
+            cursor: canSubmit ? 'pointer' : 'not-allowed',
+            transition: 'opacity 0.2s',
+          }}
+        >
+          {loading ? '코치가 JD를 분석 중입니다...' : '코칭 시작하기 →'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/components/CoachQASession.tsx
+++ b/fe/src/features/interview-coach/components/CoachQASession.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import type { CoachQuestion, CoachAnswerResult, CoachAnswerHistory } from '../types/coach.types'
+import { CoachBubble } from './CoachBubble'
+
+interface CoachQASessionProps {
+  questions: CoachQuestion[]
+  userId: string
+  onSubmitAnswer: (question: string, answer: string, index: number, total: number) => Promise<CoachAnswerResult>
+  onComplete: (history: CoachAnswerHistory[]) => void
+}
+
+export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQASessionProps) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [answer, setAnswer] = useState('')
+  const [feedback, setFeedback] = useState<CoachAnswerResult | null>(null)
+  const [history, setHistory] = useState<CoachAnswerHistory[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const current = questions[currentIndex]!
+  const isLast = currentIndex === questions.length - 1
+
+  const handleSubmit = async () => {
+    if (!answer.trim() || loading) return
+    setLoading(true)
+    try {
+      const result = await onSubmitAnswer(current.question, answer.trim(), currentIndex, questions.length)
+      setFeedback(result)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleNext = () => {
+    const newHistory: CoachAnswerHistory[] = [
+      ...history,
+      { question: current.question, answer: answer.trim(), feedback: feedback?.feedback ?? '' },
+    ]
+    setHistory(newHistory)
+
+    if (isLast) {
+      onComplete(newHistory)
+    } else {
+      setCurrentIndex((i) => i + 1)
+      setAnswer('')
+      setFeedback(null)
+    }
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 20,
+        }}
+      >
+        <span style={{ fontSize: 12, color: '#475569' }}>면접 진행 중</span>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {questions.map((_, i) => (
+            <div
+              key={i}
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background:
+                  i < currentIndex
+                    ? '#10B981'
+                    : i === currentIndex
+                      ? '#4ECDC4'
+                      : 'rgba(255,255,255,0.1)',
+              }}
+            />
+          ))}
+        </div>
+        <span style={{ fontSize: 12, color: '#4ECDC4' }}>
+          {currentIndex + 1} / {questions.length}
+        </span>
+      </div>
+
+      <CoachBubble message={current.question} />
+
+      {!feedback && (
+        <div style={{ marginTop: 8 }}>
+          <textarea
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            placeholder="답변을 입력해주세요. 구체적인 경험과 수치를 포함하면 더 좋은 평가를 받을 수 있습니다."
+            rows={6}
+            style={{
+              width: '100%',
+              background: '#0A0E1A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              padding: '10px 14px',
+              color: '#F8FAFC',
+              fontSize: 13,
+              fontFamily: "'Courier New', monospace",
+              boxSizing: 'border-box',
+              resize: 'vertical',
+              outline: 'none',
+              lineHeight: 1.6,
+              marginBottom: 12,
+            }}
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!answer.trim() || loading}
+            style={{
+              width: '100%',
+              background:
+                answer.trim() && !loading
+                  ? 'linear-gradient(135deg, #4ECDC4, #A78BFA)'
+                  : 'rgba(255,255,255,0.05)',
+              border: 'none',
+              borderRadius: 8,
+              padding: '12px 24px',
+              color: answer.trim() && !loading ? '#060610' : '#475569',
+              fontSize: 14,
+              fontWeight: 700,
+              fontFamily: "'Courier New', monospace",
+              cursor: answer.trim() && !loading ? 'pointer' : 'not-allowed',
+            }}
+          >
+            {loading ? '코치가 답변을 검토 중...' : '답변 제출'}
+          </button>
+        </div>
+      )}
+
+      {feedback && (
+        <div style={{ marginTop: 8 }}>
+          <div
+            style={{
+              background: '#0A0E1A',
+              border: '1px solid rgba(255,255,255,0.06)',
+              borderRadius: 8,
+              padding: '10px 14px',
+              marginBottom: 12,
+              color: '#94A3B8',
+              fontSize: 13,
+              lineHeight: 1.6,
+            }}
+          >
+            {answer}
+          </div>
+
+          <CoachBubble message={feedback.feedback} />
+
+          {feedback.improvements.length > 0 && (
+            <div
+              style={{
+                background: 'rgba(245,158,11,0.08)',
+                border: '1px solid rgba(245,158,11,0.2)',
+                borderRadius: 8,
+                padding: 14,
+                marginBottom: 12,
+              }}
+            >
+              <p style={{ fontSize: 11, color: '#F59E0B', margin: '0 0 8px', letterSpacing: 1 }}>
+                개선 포인트
+              </p>
+              {feedback.improvements.map((imp, i) => (
+                <p key={i} style={{ fontSize: 13, color: '#F1F5F9', margin: '4px 0', lineHeight: 1.5 }}>
+                  • {imp}
+                </p>
+              ))}
+            </div>
+          )}
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: 16,
+            }}
+          >
+            <span style={{ fontSize: 12, color: '#475569' }}>{feedback.encouragement}</span>
+            <span
+              style={{
+                fontSize: 20,
+                fontWeight: 700,
+                color: feedback.score >= 80 ? '#10B981' : feedback.score >= 60 ? '#F59E0B' : '#EF4444',
+              }}
+            >
+              {feedback.score}점
+            </span>
+          </div>
+
+          <button
+            onClick={handleNext}
+            style={{
+              width: '100%',
+              background: 'linear-gradient(135deg, #4ECDC4, #A78BFA)',
+              border: 'none',
+              borderRadius: 8,
+              padding: '12px 24px',
+              color: '#060610',
+              fontSize: 14,
+              fontWeight: 700,
+              fontFamily: "'Courier New', monospace",
+              cursor: 'pointer',
+            }}
+          >
+            {isLast ? '종합 평가 받기 →' : '다음 질문 →'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/components/CoachReport.tsx
+++ b/fe/src/features/interview-coach/components/CoachReport.tsx
@@ -1,0 +1,100 @@
+import type { CoachReportResult } from '../types/coach.types'
+import { CoachBubble } from './CoachBubble'
+
+interface CoachReportProps {
+  report: CoachReportResult
+  targetRole: string
+  onRestart: () => void
+}
+
+export function CoachReport({ report, targetRole, onRestart }: CoachReportProps) {
+  const likelihood = report.passLikelihood
+  const likelihoodColor =
+    likelihood >= 80 ? '#10B981' : likelihood >= 60 ? '#F59E0B' : '#EF4444'
+
+  return (
+    <div>
+      <CoachBubble
+        message={`오늘 면접 준비 정말 수고하셨습니다! 🎉\n\n${report.finalAdvice}`}
+      />
+
+      <div
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          padding: 20,
+          marginBottom: 16,
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ fontSize: 11, color: '#475569', margin: '0 0 8px', letterSpacing: 1 }}>
+          {targetRole} 합격 가능성
+        </p>
+        <p style={{ fontSize: 48, fontWeight: 700, color: likelihoodColor, margin: '0 0 4px' }}>
+          {likelihood}%
+        </p>
+        <p style={{ fontSize: 12, color: '#475569', margin: 0 }}>
+          종합 점수 {report.overallScore}점
+        </p>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 16 }}>
+        <div
+          style={{
+            flex: 1,
+            background: 'rgba(16,185,129,0.08)',
+            border: '1px solid rgba(16,185,129,0.2)',
+            borderRadius: 8,
+            padding: 14,
+          }}
+        >
+          <p style={{ fontSize: 11, color: '#10B981', margin: '0 0 10px', letterSpacing: 1 }}>
+            강점
+          </p>
+          {report.strengths.map((s, i) => (
+            <p key={i} style={{ fontSize: 12, color: '#F1F5F9', margin: '4px 0', lineHeight: 1.5 }}>
+              ✓ {s}
+            </p>
+          ))}
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            background: 'rgba(239,68,68,0.08)',
+            border: '1px solid rgba(239,68,68,0.2)',
+            borderRadius: 8,
+            padding: 14,
+          }}
+        >
+          <p style={{ fontSize: 11, color: '#EF4444', margin: '0 0 10px', letterSpacing: 1 }}>
+            보완점
+          </p>
+          {report.weaknesses.map((w, i) => (
+            <p key={i} style={{ fontSize: 12, color: '#F1F5F9', margin: '4px 0', lineHeight: 1.5 }}>
+              △ {w}
+            </p>
+          ))}
+        </div>
+      </div>
+
+      <button
+        onClick={onRestart}
+        style={{
+          width: '100%',
+          background: 'rgba(255,255,255,0.05)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          padding: '12px 24px',
+          color: '#94A3B8',
+          fontSize: 14,
+          fontFamily: "'Courier New', monospace",
+          cursor: 'pointer',
+        }}
+      >
+        다시 시작하기
+      </button>
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/components/InterviewCoach.tsx
+++ b/fe/src/features/interview-coach/components/InterviewCoach.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import type { CoachStep, CoachSessionResult, CoachAnswerResult, CoachAnswerHistory, CoachReportResult } from '../types/coach.types'
+import { startCoachSession, submitCoachAnswer, generateCoachReport } from '../api/interviewCoachApi'
+import { CoachOnboarding } from './CoachOnboarding'
+import { CoachAnalysis } from './CoachAnalysis'
+import { CoachQASession } from './CoachQASession'
+import { CoachReport } from './CoachReport'
+
+interface InterviewCoachProps {
+  userId: string
+}
+
+export function InterviewCoach({ userId }: InterviewCoachProps) {
+  const [step, setStep] = useState<CoachStep>('onboarding')
+  const [loading, setLoading] = useState(false)
+  const [targetRole, setTargetRole] = useState('')
+  const [session, setSession] = useState<CoachSessionResult | null>(null)
+  const [report, setReport] = useState<CoachReportResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleStart = async (role: string, jdText: string) => {
+    setError(null)
+    setLoading(true)
+    setStep('analyzing')
+    setTargetRole(role)
+    try {
+      const result = await startCoachSession(userId, jdText, role)
+      setSession(result)
+      setStep('analysis')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '오류가 발생했습니다')
+      setStep('onboarding')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSubmitAnswer = async (
+    question: string,
+    answer: string,
+    index: number,
+    total: number,
+  ): Promise<CoachAnswerResult> => {
+    return submitCoachAnswer(userId, question, answer, index, total)
+  }
+
+  const handleQAComplete = async (history: CoachAnswerHistory[]) => {
+    if (!session) return
+    setStep('reporting')
+    try {
+      const result = await generateCoachReport(userId, targetRole, session.jdSummary, history)
+      setReport(result)
+      setStep('report')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '리포트 생성 오류')
+      setStep('qa')
+    }
+  }
+
+  const handleRestart = () => {
+    setStep('onboarding')
+    setSession(null)
+    setReport(null)
+    setTargetRole('')
+    setError(null)
+  }
+
+  return (
+    <div style={{ paddingTop: 8 }}>
+      <div style={{ marginBottom: 24 }}>
+        <p style={{ fontSize: 11, color: '#4ECDC4', margin: '0 0 4px', letterSpacing: 2 }}>
+          AI INTERVIEW COACH
+        </p>
+        <h2 style={{ fontSize: 20, fontWeight: 700, color: '#F8FAFC', margin: 0 }}>
+          전담 면접 코치
+        </h2>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            background: 'rgba(239,68,68,0.1)',
+            border: '1px solid rgba(239,68,68,0.3)',
+            borderRadius: 8,
+            padding: '10px 14px',
+            marginBottom: 16,
+            fontSize: 13,
+            color: '#EF4444',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {(step === 'onboarding' || step === 'analyzing') && (
+        <CoachOnboarding onStart={handleStart} loading={loading} />
+      )}
+
+      {step === 'analysis' && session && (
+        <CoachAnalysis
+          session={session}
+          targetRole={targetRole}
+          onBegin={() => setStep('qa')}
+        />
+      )}
+
+      {step === 'qa' && session && (
+        <CoachQASession
+          questions={session.questions}
+          userId={userId}
+          onSubmitAnswer={handleSubmitAnswer}
+          onComplete={handleQAComplete}
+        />
+      )}
+
+      {step === 'reporting' && (
+        <div style={{ textAlign: 'center', padding: '40px 0', color: '#475569', fontSize: 14 }}>
+          코치가 종합 평가를 작성 중입니다...
+        </div>
+      )}
+
+      {step === 'report' && report && (
+        <CoachReport report={report} targetRole={targetRole} onRestart={handleRestart} />
+      )}
+    </div>
+  )
+}

--- a/fe/src/features/interview-coach/index.ts
+++ b/fe/src/features/interview-coach/index.ts
@@ -1,0 +1,1 @@
+export { InterviewCoach } from './components/InterviewCoach'

--- a/fe/src/features/interview-coach/types/coach.types.ts
+++ b/fe/src/features/interview-coach/types/coach.types.ts
@@ -1,0 +1,34 @@
+export interface CoachQuestion {
+  index: number
+  question: string
+  competency: string
+}
+
+export interface CoachSessionResult {
+  jdSummary: string
+  keyCompetencies: string[]
+  questions: CoachQuestion[]
+}
+
+export interface CoachAnswerResult {
+  feedback: string
+  score: number
+  improvements: string[]
+  encouragement: string
+}
+
+export interface CoachAnswerHistory {
+  question: string
+  answer: string
+  feedback: string
+}
+
+export interface CoachReportResult {
+  overallScore: number
+  passLikelihood: number
+  strengths: string[]
+  weaknesses: string[]
+  finalAdvice: string
+}
+
+export type CoachStep = 'onboarding' | 'analyzing' | 'analysis' | 'qa' | 'reporting' | 'report'

--- a/fe/src/features/quest-map/components/QuestMap.tsx
+++ b/fe/src/features/quest-map/components/QuestMap.tsx
@@ -6,12 +6,13 @@ import { StatsPanel } from './StatsPanel'
 
 interface QuestMapProps {
   onSelectAct: (act: Act) => void
+  onOpenCoach: () => void
   completed: Record<string, boolean>
   getActProgress: (act: Act) => number
   character: Character
 }
 
-export function QuestMap({ onSelectAct, completed, getActProgress, character }: QuestMapProps) {
+export function QuestMap({ onSelectAct, onOpenCoach, completed, getActProgress, character }: QuestMapProps) {
   const completedCount = Object.keys(completed).length
 
   return (
@@ -63,6 +64,30 @@ export function QuestMap({ onSelectAct, completed, getActProgress, character }: 
           )
         })}
       </div>
+
+      <button
+        onClick={onOpenCoach}
+        style={{
+          width: '100%',
+          marginTop: 12,
+          background: 'rgba(167,139,250,0.08)',
+          border: '1px solid rgba(167,139,250,0.25)',
+          borderRadius: 10,
+          padding: '14px 20px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          cursor: 'pointer',
+          fontFamily: "'Courier New', monospace",
+        }}
+      >
+        <span style={{ fontSize: 22 }}>🎯</span>
+        <div style={{ textAlign: 'left' }}>
+          <p style={{ fontSize: 13, fontWeight: 700, color: '#A78BFA', margin: 0 }}>전담 면접 코치</p>
+          <p style={{ fontSize: 11, color: '#475569', margin: '2px 0 0' }}>JD 분석부터 종합 평가까지</p>
+        </div>
+        <span style={{ marginLeft: 'auto', color: '#475569', fontSize: 16 }}>→</span>
+      </button>
 
       <StatsPanel completedCount={completedCount} />
     </div>


### PR DESCRIPTION
## Summary
- 전담 면접 코치 FE 구현 (4단계 코칭 플로우)
- 퀘스트 맵에 "전담 면접 코치" 진입 버튼 추가
- BE PR #13과 연동

## 변경 파일
- `features/interview-coach/` (신규): types, api, components 5개, index
  - `CoachOnboarding` — JD/직무 입력
  - `CoachAnalysis` — JD 분석 결과 + 질문 미리보기
  - `CoachQASession` — 질문별 답변 입력 + 즉시 피드백
  - `CoachReport` — 합격 가능성 + 종합 리포트
  - `CoachBubble` — 코치 말풍선 컴포넌트
- `App.tsx`: `interview-coach` view 추가
- `QuestMap.tsx`: 코치 진입 버튼 추가

## Test plan
- [ ] 퀘스트 맵에서 "전담 면접 코치" 버튼 노출 확인
- [ ] JD 입력 → 분석 결과 화면 전환 확인
- [ ] 질문별 답변 제출 → 코치 피드백 말풍선 확인
- [ ] 마지막 질문 후 종합 리포트 확인
- [ ] "← 퀘스트 맵으로" 뒤로가기 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)