### PR TITLE
feat: add 4-BOSS quest boss package evaluation

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,18 +7,28 @@
 
 | 브랜치 | 상태 | 설명 |
 |--------|------|------|
-| `main` | 최신 (PR #12 머지됨) | 기술스택 레벨 → 경력기간 변경 반영 |
-| `feat/interview-coach-be` | **PR #13 오픈** | BE 면접 코치 API |
-| `feat/interview-coach-fe` | **PR #14 오픈** | FE 면접 코치 UI |
+| `main` | PR #16 머지됨 | 퀘스트 히스토리 + 성장 대시보드 완료 |
+| `feat/4-boss-fe` | 작업 중 (PR #17 오픈) | 4-BOSS 지원 패키지 평가 (BE+FE) |
 
 ## 열린 PR
 
 | PR | 브랜치 | 상태 | 내용 |
 |----|--------|------|------|
-| [#13](https://github.com/bangddong/switch-job-quest/pull/13) | `feat/interview-coach-be` | 오픈, CI 대기 중 | 면접 코치 API 3개 (start/answer/report) |
-| [#14](https://github.com/bangddong/switch-job-quest/pull/14) | `feat/interview-coach-fe` | 오픈, CI 대기 중 | 면접 코치 4단계 코칭 UI |
+| [#17](https://github.com/bangddong/switch-job-quest/pull/17) | `feat/4-boss-fe` | 오픈 | 4-BOSS 지원 패키지 종합 AI 평가 (BE+FE) |
 
 ## 최근 결정 사항
+
+### 4-BOSS 지원 패키지 평가 (2026-04-02)
+- **BE**: `POST /api/v1/ai-check/boss-package` — 이력서+GitHub+블로그+목표포지션 종합 평가
+- **BE**: 5개 항목(이력서 임팩트/GitHub 일관성/기술 전문성/포지션 핏/차별화) 각 20점, 70점 이상 통과 시 700 XP
+- **FE**: `BossPackageResultCard` — 5개 점수 바 + 강점/개선사항/종합피드백 표시
+- **충돌 이슈**: 에이전트가 main worktree에서 `feat/4-boss-fe`로 체크아웃 → Claude가 직접 리베이스 해결
+
+### 퀘스트 히스토리 & 성장 대시보드 (2026-04-01)
+- **BE**: `quest_history` 테이블에 AI 평가 시도마다 기록 저장 (Port & Adapter 패턴)
+- **BE**: `GET /api/v1/progress/history`, `GET /api/v1/progress/history/{questId}` 추가
+- **FE**: `features/growth/` 신설 — ScoreTimeline(꺾은선), 퀘스트별 최고점(바 차트), 최근 시도 목록
+- **FE**: 퀘스트 맵 하단 "📈 성장 기록" 버튼으로 진입
 
 ### 멀티 에이전트 패턴 도입 (2026-03-31)
 - Claude가 기획자/오케스트레이터 역할 담당
@@ -34,17 +44,17 @@
 
 ## 다음 작업
 
-- [ ] PR #13 (BE) 머지 — CI 통과 확인 후, BE 먼저
-- [ ] PR #14 (FE) 머지 — BE 머지 후
+- [ ] PR #17 CI 확인 후 머지
 - [ ] Vercel 자동 배포 확인
-- [ ] 이후 방향: 4-BOSS 퀘스트 구현 또는 추가 기능 논의
+- [ ] 이후 방향: ACT V (5-BOSS) 구현 또는 UI 개선 논의
 
 ## 멀티 에이전트 운영 노하우
 
 - `settings.json` permissions 설정 필수 (Bash, Write, Edit, Read, Glob, Grep)
 - 에이전트는 `isolation: "worktree"` + `run_in_background: true` 조합으로 실행
+- **에이전트가 main worktree에서 브랜치 체크아웃하는 문제 발생** → 완료 후 `git branch --show-current` 확인 필수
 - 에이전트 완료 후 반드시 기획자(Claude)가 핵심 파일 직접 읽고 리뷰
-- 리뷰 후 보완 있으면 SendMessage로 이전 에이전트 컨텍스트 이어서 지시 가능
+- 리베이스 충돌 발생 시 Claude가 직접 처리
 
 ## 환경 메모
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -1,0 +1,56 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.support.AiEvaluationException
+import com.devquest.core.domain.model.evaluation.BossPackageResult
+import com.devquest.core.domain.port.BossPackageEvaluatorPort
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+@Component
+class BossPackageEvaluator(
+    private val chatClient: ChatClient
+) : BossPackageEvaluatorPort {
+
+    override fun evaluate(
+        resumeContent: String,
+        githubUrl: String,
+        blogUrl: String,
+        targetPosition: String
+    ): BossPackageResult {
+        val prompt = """
+            다음 지원 패키지를 종합 평가해주세요.
+
+            ## 목표 포지션: $targetPosition
+            ## GitHub URL: $githubUrl
+            ## 블로그 URL: ${blogUrl.ifBlank { "미제공" }}
+            ## 이력서 내용
+            $resumeContent
+
+            ## 평가 기준
+            1. 이력서 임팩트 (STAR 기법 활용, 수치화, 키워드 적합성): /20점
+            2. GitHub 일관성 (커밋 활동, README 품질, 프로젝트 구성): /20점
+            3. 기술 전문성 (블로그/GitHub 기반 기술 깊이): /20점
+            4. 포지션 핏 (목표 포지션과의 정합성): /20점
+            5. 차별화 포인트 (경쟁자 대비 강점): /20점
+
+            반드시 다음 JSON 형식으로만 응답하세요:
+            {
+                "overallScore": 75,
+                "resumeImpactScore": 16,
+                "githubConsistencyScore": 15,
+                "technicalDepthScore": 14,
+                "positionFitScore": 15,
+                "differentiationScore": 15,
+                "strengths": ["강점1", "강점2", "강점3"],
+                "improvements": ["개선사항1", "개선사항2"],
+                "overallFeedback": "종합 피드백..."
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(BossPackageResult::class.java)
+            ?: throw AiEvaluationException("지원 패키지 평가 실패")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
@@ -141,6 +141,19 @@ class AiCheckController(
         }
     }
 
+    @PostMapping("/boss-package")
+    fun checkBossPackage(@Valid @RequestBody request: BossPackageRequestDto): ApiResponse<*> {
+        return try {
+            val result = aiCheckService.checkBossPackage(
+                request.userId, request.resumeContent, request.githubUrl, request.blogUrl, request.targetPosition
+            )
+            ApiResponse.success(result)
+        } catch (e: Exception) {
+            log.error("Boss package check failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
+
     @PostMapping("/act-clear-report")
     fun generateActClearReport(@Valid @RequestBody request: ActClearReportRequestDto): ApiResponse<*> {
         return try {

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/BossPackageRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/BossPackageRequestDto.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class BossPackageRequestDto(
+    @field:NotBlank val userId: String = "",
+    @field:NotBlank val resumeContent: String = "",
+    @field:NotBlank val githubUrl: String = "",
+    @field:NotBlank val targetPosition: String = "",
+    val blogUrl: String = ""
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -26,7 +26,8 @@ class AiCheckService(
     private val skillAssessmentPort: SkillAssessmentPort,
     private val actClearReportPort: ActClearReportPort,
     private val progressPort: QuestProgressPort,
-    private val historyPort: QuestHistoryPort
+    private val historyPort: QuestHistoryPort,
+    private val bossPackageEvaluator: BossPackageEvaluatorPort
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -105,6 +106,14 @@ class AiCheckService(
     fun checkPersonalityInterview(userId: String, question: String, answer: String): AiEvaluationResult {
         val result = personalityEvaluator.evaluate(question, answer)
         saveProgress(userId, "5-1", 5, result.score, result.passed, if (result.passed) (400 * result.xpMultiplier).toInt() else 0)
+        return result
+    }
+
+    @Transactional
+    fun checkBossPackage(userId: String, resumeContent: String, githubUrl: String, blogUrl: String, targetPosition: String): BossPackageResult {
+        val result = bossPackageEvaluator.evaluate(resumeContent, githubUrl, blogUrl, targetPosition)
+        val passed = result.overallScore >= passScore
+        saveProgress(userId, "4-BOSS", 4, result.overallScore, passed, if (passed) 700 else 0)
         return result
     }
 

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -30,6 +30,7 @@ class AiCheckServiceTest {
     @Mock lateinit var actClearReportPort: ActClearReportPort
     @Mock lateinit var progressPort: QuestProgressPort
     @Mock lateinit var historyPort: QuestHistoryPort
+    @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
 
     private lateinit var service: AiCheckService
 
@@ -38,7 +39,7 @@ class AiCheckServiceTest {
         service = AiCheckService(
             essayEvaluator, blogEvaluator, systemDesignEvaluator, interviewEvaluator,
             jdAnalysisEvaluator, resumeEvaluator, companyFitEvaluator, personalityEvaluator,
-            skillAssessmentPort, actClearReportPort, progressPort, historyPort
+            skillAssessmentPort, actClearReportPort, progressPort, historyPort, bossPackageEvaluator
         )
         // progressPort.save 기본 응답 (저장 시 반환값 필요)
         whenever(progressPort.save(any())).thenAnswer { it.arguments[0] }
@@ -243,6 +244,33 @@ class AiCheckServiceTest {
         assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
         assertThat(captor.firstValue.earnedXp).isEqualTo(350)
         assertThat(captor.firstValue.questId).isEqualTo("3-2")
+    }
+
+    // ===== checkBossPackage 테스트 =====
+
+    @Test
+    fun `checkBossPackage - 70점 이상이면 COMPLETED로 저장한다`() {
+        val mockResult = BossPackageResult(
+            overallScore = 80,
+            resumeImpactScore = 16,
+            githubConsistencyScore = 16,
+            technicalDepthScore = 16,
+            positionFitScore = 16,
+            differentiationScore = 16,
+            strengths = listOf("강점1", "강점2"),
+            improvements = listOf("개선사항1"),
+            overallFeedback = "우수한 지원 패키지입니다."
+        )
+        whenever(bossPackageEvaluator.evaluate(any(), any(), any(), any())).thenReturn(mockResult)
+
+        service.checkBossPackage("user-1", "이력서 내용", "https://github.com/user", "", "시니어 백엔드")
+
+        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
+        verify(progressPort).save(captor.capture())
+        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
+        assertThat(captor.firstValue.earnedXp).isEqualTo(700)
+        assertThat(captor.firstValue.aiScore).isEqualTo(80)
+        assertThat(captor.firstValue.questId).isEqualTo("4-BOSS")
     }
 
     // ===== checkPersonalityInterview 테스트 =====

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/BossPackageResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/BossPackageResult.kt
@@ -1,0 +1,13 @@
+package com.devquest.core.domain.model.evaluation
+
+data class BossPackageResult(
+    val overallScore: Int = 0,
+    val resumeImpactScore: Int = 0,
+    val githubConsistencyScore: Int = 0,
+    val technicalDepthScore: Int = 0,
+    val positionFitScore: Int = 0,
+    val differentiationScore: Int = 0,
+    val strengths: List<String> = emptyList(),
+    val improvements: List<String> = emptyList(),
+    val overallFeedback: String = ""
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/BossPackageEvaluatorPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/BossPackageEvaluatorPort.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.evaluation.BossPackageResult
+
+interface BossPackageEvaluatorPort {
+    fun evaluate(
+        resumeContent: String,
+        githubUrl: String,
+        blogUrl: String,
+        targetPosition: String
+    ): BossPackageResult
+}

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, ActClearReportResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, ActClearReportResult } from '@/types/api.types'
 import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail } from '@/features/quest-detail'
@@ -20,7 +20,7 @@ export function App() {
   const [view, setView] = useState<View>({ kind: 'map' })
   const [completed, setCompleted] = useState<Record<string, boolean>>({})
   const [aiScores, setAiScores] = useState<Record<string, number>>({})
-  const [aiResult, setAiResult] = useState<AiEvaluationResult | null>(null)
+  const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | null>(null)
   const [showForm, setShowForm] = useState(false)
 
   useEffect(() => {
@@ -78,13 +78,20 @@ export function App() {
     if (isBossQuest(questId)) triggerActClearReport(act)
   }
 
-  const handleAiResult = (result: AiEvaluationResult) => {
+  const handleAiResult = (result: AiEvaluationResult | BossPackageResult) => {
     setAiResult(result)
     if (view.kind === 'detail') {
-      if (result.passed) {
-        const { quest, act } = view
+      const { quest, act } = view
+      const isBoss = quest.id === '4-BOSS'
+      const score = isBoss
+        ? (result as BossPackageResult).overallScore
+        : (result as AiEvaluationResult).score
+      const passed = isBoss
+        ? (result as BossPackageResult).overallScore >= 70
+        : (result as AiEvaluationResult).passed
+      if (passed) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))
-        setAiScores((prev) => ({ ...prev, [quest.id]: result.score }))
+        setAiScores((prev) => ({ ...prev, [quest.id]: score }))
         if (isBossQuest(quest.id)) triggerActClearReport(act)
       }
     }

--- a/fe/src/features/ai-check/api/aiCheckApi.ts
+++ b/fe/src/features/ai-check/api/aiCheckApi.ts
@@ -1,4 +1,4 @@
-import type { AiEvaluationResult, InterviewEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, InterviewEvaluationResult } from '@/types/api.types'
 import { callAiCheck } from '@/lib/apiClient'
 
 export async function submitAiCheck(
@@ -7,6 +7,13 @@ export async function submitAiCheck(
   userId: string,
 ): Promise<AiEvaluationResult> {
   return callAiCheck<AiEvaluationResult>(endpoint, body, userId)
+}
+
+export async function submitBossPackage(
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<BossPackageResult> {
+  return callAiCheck<BossPackageResult>('boss-package', body, userId)
 }
 
 export async function submitMockInterview(

--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
-import type { AiEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
 import { useUserId } from '@/hooks/useUserId'
 import { AI_FORMS } from '../constants/formConfig'
-import { submitAiCheck } from '../api/aiCheckApi'
+import { submitAiCheck, submitBossPackage } from '../api/aiCheckApi'
 import { TechStackInput } from './TechStackInput'
 
 interface AiCheckFormProps {
   questId: string
-  onResult: (result: AiEvaluationResult) => void
+  onResult: (result: AiEvaluationResult | BossPackageResult) => void
 }
 
 export function AiCheckForm({ questId, onResult }: AiCheckFormProps) {
@@ -34,7 +34,10 @@ export function AiCheckForm({ questId, onResult }: AiCheckFormProps) {
     setError('')
     try {
       const body = cfg.transform(values)
-      const result = await submitAiCheck(cfg.endpoint, body, userId)
+      const result =
+        questId === '4-BOSS'
+          ? await submitBossPackage(body, userId)
+          : await submitAiCheck(cfg.endpoint, body, userId)
       onResult(result)
     } catch (e) {
       setError('서버 연결 오류: ' + (e instanceof Error ? e.message : String(e)))

--- a/fe/src/features/ai-check/components/AiResultCard.tsx
+++ b/fe/src/features/ai-check/components/AiResultCard.tsx
@@ -1,4 +1,4 @@
-import type { AiEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
 import { ScoreRing } from '@/components/ui/ScoreRing'
 import { GradeTag } from '@/components/ui/GradeTag'
 import { PASS_THRESHOLD } from '@/constants/scoring'
@@ -155,6 +155,131 @@ export function AiResultCard({ result }: AiResultCardProps) {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+interface BossPackageResultCardProps {
+  result: BossPackageResult
+}
+
+const SCORE_ITEMS: Array<{ key: keyof BossPackageResult; label: string; color: string }> = [
+  { key: 'resumeImpactScore', label: '이력서 임팩트', color: '#4ECDC4' },
+  { key: 'githubConsistencyScore', label: 'GitHub 일관성', color: '#A78BFA' },
+  { key: 'technicalDepthScore', label: '기술 깊이', color: '#60A5FA' },
+  { key: 'positionFitScore', label: '포지션 적합도', color: '#F59E0B' },
+  { key: 'differentiationScore', label: '차별화 점수', color: '#10B981' },
+]
+
+export function BossPackageResultCard({ result }: BossPackageResultCardProps) {
+  const passed = result.overallScore >= 70
+  const grade = getGrade(result.overallScore)
+
+  return (
+    <div
+      style={{
+        background: passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
+        border: `1px solid ${passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
+        borderRadius: 14,
+        padding: 22,
+        marginTop: 18,
+        animation: 'slideIn 0.5s ease',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 18 }}>
+        <ScoreRing score={result.overallScore} />
+        <div style={{ flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+            <GradeTag grade={grade} />
+            <span
+              style={{ fontSize: 13, color: passed ? '#10B981' : '#EF4444', fontWeight: 'bold' }}
+            >
+              {passed ? '✓ 통과 — 지원 패키지 완성!' : '✗ 미통과 — 패키지 보완 필요'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ marginBottom: 18 }}>
+        <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 10 }}>
+          📊 SCORE BREAKDOWN
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {SCORE_ITEMS.map(({ key, label, color }) => {
+            const score = result[key] as number
+            return (
+              <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ fontSize: 12, color: '#64748B', minWidth: 110 }}>{label}</span>
+                <div
+                  style={{
+                    flex: 1,
+                    background: 'rgba(255,255,255,0.05)',
+                    borderRadius: 4,
+                    height: 6,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${score}%`,
+                      height: '100%',
+                      background: color,
+                      borderRadius: 4,
+                    }}
+                  />
+                </div>
+                <span style={{ fontSize: 12, color, minWidth: 30, textAlign: 'right' }}>
+                  {score}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {result.strengths.length > 0 && (
+        <div style={{ marginBottom: 14 }}>
+          <div style={{ fontSize: 10, color: '#10B981', letterSpacing: 3, marginBottom: 8 }}>
+            ✓ STRENGTHS
+          </div>
+          {result.strengths.map((s, i) => (
+            <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
+              <span style={{ color: '#10B981' }}>▸ </span>
+              {s}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {result.improvements.length > 0 && (
+        <div style={{ marginBottom: 14 }}>
+          <div style={{ fontSize: 10, color: '#F59E0B', letterSpacing: 3, marginBottom: 8 }}>
+            ↑ IMPROVEMENTS
+          </div>
+          {result.improvements.map((imp, i) => (
+            <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
+              <span style={{ color: '#F59E0B' }}>▸ </span>
+              {imp}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div
+        style={{
+          background: 'rgba(15,23,42,0.7)',
+          borderRadius: 10,
+          padding: '14px 16px',
+          borderLeft: '3px solid #4ECDC4',
+        }}
+      >
+        <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 8 }}>
+          💬 OVERALL FEEDBACK
+        </div>
+        <p style={{ color: '#94A3B8', fontSize: 13, margin: 0, lineHeight: 1.7 }}>
+          {result.overallFeedback}
+        </p>
+      </div>
     </div>
   )
 }

--- a/fe/src/features/ai-check/constants/formConfig.ts
+++ b/fe/src/features/ai-check/constants/formConfig.ts
@@ -61,6 +61,17 @@ export const AI_FORMS: AiFormsMap = {
     ],
     transform: (v) => v,
   },
+  '4-BOSS': {
+    label: '지원 패키지 최종 점검',
+    endpoint: 'boss-package',
+    fields: [
+      { key: 'resumeContent', label: '최종 이력서', type: 'textarea', placeholder: '이력서 전문을 붙여넣어 주세요...', rows: 8 },
+      { key: 'githubUrl', label: 'GitHub 프로필 URL', type: 'text', placeholder: 'https://github.com/username' },
+      { key: 'blogUrl', label: '기술 블로그 URL (선택)', type: 'text', placeholder: 'https://your-blog.com' },
+      { key: 'targetPosition', label: '목표 포지션', type: 'text', placeholder: '예: 시니어 백엔드 개발자' },
+    ],
+    transform: (v) => v,
+  },
   '5-1': {
     label: '인성 면접 연습',
     endpoint: 'personality-interview',

--- a/fe/src/features/ai-check/index.ts
+++ b/fe/src/features/ai-check/index.ts
@@ -1,6 +1,6 @@
 export { ActClearReportCard } from './components/ActClearReportCard'
 export { AiCheckForm } from './components/AiCheckForm'
-export { AiResultCard } from './components/AiResultCard'
+export { AiResultCard, BossPackageResultCard } from './components/AiResultCard'
 export { InterviewResultCard } from './components/InterviewResultCard'
 export { MockInterviewPanel } from './components/MockInterviewPanel'
 export { AI_FORMS } from './constants/formConfig'

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -1,7 +1,7 @@
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
 import { QUEST_TYPE_CONFIG } from '@/features/quest-map'
-import { AiCheckForm, AiResultCard, MockInterviewPanel } from '@/features/ai-check'
+import { AiCheckForm, AiResultCard, BossPackageResultCard, MockInterviewPanel } from '@/features/ai-check'
 import { AI_FORMS } from '@/features/ai-check'
 
 interface QuestDetailProps {
@@ -9,10 +9,10 @@ interface QuestDetailProps {
   act: Act
   completed: Record<string, boolean>
   aiScores: Record<string, number>
-  aiResult: AiEvaluationResult | null
+  aiResult: AiEvaluationResult | BossPackageResult | null
   showForm: boolean
   onShowForm: () => void
-  onAiResult: (result: AiEvaluationResult) => void
+  onAiResult: (result: AiEvaluationResult | BossPackageResult) => void
   onComplete: (questId: string, xp: number, actId: number, act: Act) => void
   onMockInterviewComplete: (score: number) => void
 }
@@ -181,7 +181,11 @@ export function QuestDetail({
         )}
 
         {/* AI Result */}
-        {aiResult && !isMock && <AiResultCard result={aiResult} />}
+        {aiResult && !isMock && (
+          quest.id === '4-BOSS'
+            ? <BossPackageResultCard result={aiResult as BossPackageResult} />
+            : <AiResultCard result={aiResult as AiEvaluationResult} />
+        )}
 
         {/* Manual complete */}
         {!quest.aiCheck && !done && (

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -56,6 +56,18 @@ export interface QuestHistoryItem {
   createdAt: string
 }
 
+export interface BossPackageResult {
+  overallScore: number
+  resumeImpactScore: number
+  githubConsistencyScore: number
+  technicalDepthScore: number
+  positionFitScore: number
+  differentiationScore: number
+  strengths: string[]
+  improvements: string[]
+  overallFeedback: string
+}
+
 export interface InterviewEvaluationResult {
   score: number
   passed: boolean


### PR DESCRIPTION
## Summary
**BE**
- `BossPackageEvaluatorPort` 인터페이스 추가
- `BossPackageResult` 도메인 모델 (5개 항목 점수 + 강점/개선사항/종합피드백)
- `BossPackageEvaluator` AI 어댑터 (지원 패키지 종합 평가 프롬프트)
- `POST /api/v1/ai-check/boss-package` 엔드포인트 추가
- 70점 이상 통과 시 700 XP 지급, `4-BOSS` questId로 진행 저장

**FE**
- `4-BOSS` 폼 설정 추가 (이력서/GitHub URL/블로그 URL/목표 포지션)
- `BossPackageResult` 타입 추가
- `BossPackageResultCard` — 5개 항목 점수 + 강점/개선사항/종합피드백 카드
- `handleAiResult` — `BossPackageResult.overallScore` 기준 통과 판정

## Test plan
- [ ] BE CI (빌드+테스트) 통과
- [ ] FE CI (빌드) 통과
- [ ] 4-BOSS 퀘스트 폼 렌더링 확인
- [ ] AI 평가 후 결과 카드 표시 확인
- [ ] 70점 이상 시 퀘스트 완료 처리 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)