### PR TITLE
feat(fe): Sprint 2 — 오늘의 미션 배너 + 퀘스트 브리핑 화면

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,22 +7,30 @@
 
 | 브랜치 | 상태 | 설명 |
 |--------|------|------|
-| `main` | PR #16 머지됨 | 퀘스트 히스토리 + 성장 대시보드 완료 |
-| `feat/4-boss-fe` | 작업 중 (PR #17 오픈) | 4-BOSS 지원 패키지 평가 (BE+FE) |
+| `main` | PR #18 머지됨 | UX Sprint 1 (E+F) 완료 |
+| `feat/ux-sprint2` | 작업 중 (PR #19 오픈) | UX 포기 방지 Sprint 2 (B+C) |
 
 ## 열린 PR
 
 | PR | 브랜치 | 상태 | 내용 |
 |----|--------|------|------|
-| [#17](https://github.com/bangddong/switch-job-quest/pull/17) | `feat/4-boss-fe` | 오픈 | 4-BOSS 지원 패키지 종합 AI 평가 (BE+FE) |
+| [#19](https://github.com/bangddong/switch-job-quest/pull/19) | `feat/ux-sprint2` | 오픈 | 오늘의 미션 배너 + 퀘스트 브리핑 화면 |
 
 ## 최근 결정 사항
 
+### UX 포기 방지 시스템 Sprint 2 (2026-04-02)
+- **B. TodayMissionBanner**: QuestMap 상단 다음 추천 퀘스트 배너 (QUEST_NEXT 연결 그래프 활용)
+- **C. QuestBriefingView**: 퀘스트 진입 전 브리핑 화면 (XP/소요시간/AI검사/태스크 미리보기)
+- `briefing` View kind 추가 → ActCard 클릭 + 배너 CTA 모두 브리핑 거쳐 QuestDetail 진입
+
+### UX 포기 방지 시스템 Sprint 1 (2026-04-02)
+- **기획**: 6개 포기 지점 분석 → 7개 기능(A-G) → 4개 스프린트 로드맵 (`.claude/docs/ux-retention-plan.md`)
+- **E. NextQuestCard**: AI 통과 시 다음 퀘스트 연결 카드 표시
+- **F. RetryCoachCard**: AI 실패 시 개선 포인트 + "이전 답변 불러오기" 버튼
+
 ### 4-BOSS 지원 패키지 평가 (2026-04-02)
 - **BE**: `POST /api/v1/ai-check/boss-package` — 이력서+GitHub+블로그+목표포지션 종합 평가
-- **BE**: 5개 항목(이력서 임팩트/GitHub 일관성/기술 전문성/포지션 핏/차별화) 각 20점, 70점 이상 통과 시 700 XP
 - **FE**: `BossPackageResultCard` — 5개 점수 바 + 강점/개선사항/종합피드백 표시
-- **충돌 이슈**: 에이전트가 main worktree에서 `feat/4-boss-fe`로 체크아웃 → Claude가 직접 리베이스 해결
 
 ### 퀘스트 히스토리 & 성장 대시보드 (2026-04-01)
 - **BE**: `quest_history` 테이블에 AI 평가 시도마다 기록 저장 (Port & Adapter 패턴)
@@ -44,9 +52,9 @@
 
 ## 다음 작업
 
-- [ ] PR #17 CI 확인 후 머지
-- [ ] Vercel 자동 배포 확인
-- [ ] 이후 방향: ACT V (5-BOSS) 구현 또는 UI 개선 논의
+- [ ] PR #19 CI 확인 후 머지
+- [ ] Sprint 3 (추후): D (필드별 작성 가이드) + G (복귀 배너, BE 필요)
+- [ ] Sprint 4 (추후): A (온보딩 스토리텔링)
 
 ## 멀티 에이전트 운영 노하우
 

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -3,7 +3,7 @@ import type { Act, Quest } from '@/types/quest.types'
 import type { AiEvaluationResult, BossPackageResult, ActClearReportResult } from '@/types/api.types'
 import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
-import { QuestDetail } from '@/features/quest-detail'
+import { QuestDetail, QuestBriefingView } from '@/features/quest-detail'
 import { ActClearReportCard } from '@/features/ai-check'
 import { CharacterCreate } from '@/features/character'
 import { InterviewCoach } from '@/features/interview-coach'
@@ -13,7 +13,13 @@ import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
 import { ACTS } from '@/features/quest-map/constants/questData'
 
-type View = { kind: 'map' } | { kind: 'detail'; act: Act; quest: Quest } | { kind: 'act-clear'; act: Act; report: ActClearReportResult } | { kind: 'interview-coach' } | { kind: 'growth' }
+type View =
+  | { kind: 'map' }
+  | { kind: 'briefing'; act: Act; quest: Quest }
+  | { kind: 'detail'; act: Act; quest: Quest }
+  | { kind: 'act-clear'; act: Act; report: ActClearReportResult }
+  | { kind: 'interview-coach' }
+  | { kind: 'growth' }
 
 export function App() {
   const userId = useUserId()
@@ -58,10 +64,22 @@ export function App() {
 
   const handleSelectAct = (act: Act) => {
     if (act.quests.length > 0) {
-      const quest = act.quests[0]!
+      const quest = act.quests.find((q) => !completed[q.id]) ?? act.quests[act.quests.length - 1]!
       setAiResult(null)
       setShowForm(false)
-      setView({ kind: 'detail', act, quest })
+      setView({ kind: 'briefing', act, quest })
+    }
+  }
+
+  const handleSelectQuest = (act: Act, quest: Quest) => {
+    setAiResult(null)
+    setShowForm(false)
+    setView({ kind: 'briefing', act, quest })
+  }
+
+  const handleBriefingStart = () => {
+    if (view.kind === 'briefing') {
+      setView({ kind: 'detail', act: view.act, quest: view.quest })
     }
   }
 
@@ -150,7 +168,7 @@ export function App() {
         color: '#F8FAFC',
       }}
     >
-      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth') && (
+      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth' || view.kind === 'briefing') && (
         <button
           onClick={() => setView({ kind: 'map' })}
           style={{
@@ -171,6 +189,7 @@ export function App() {
         <>
           <QuestMap
             onSelectAct={handleSelectAct}
+            onSelectQuest={handleSelectQuest}
             onOpenCoach={() => setView({ kind: 'interview-coach' })}
             completed={completed}
             getActProgress={getActProgress}
@@ -195,6 +214,14 @@ export function App() {
             </button>
           </div>
         </>
+      )}
+
+      {view.kind === 'briefing' && (
+        <QuestBriefingView
+          quest={view.quest}
+          act={view.act}
+          onStart={handleBriefingStart}
+        />
       )}
 
       {view.kind === 'detail' && (

--- a/fe/src/features/quest-detail/components/QuestBriefingView.tsx
+++ b/fe/src/features/quest-detail/components/QuestBriefingView.tsx
@@ -1,0 +1,186 @@
+import type { Act, Quest } from '@/types/quest.types'
+import { QUEST_TYPE_CONFIG } from '@/features/quest-map/constants/questData'
+
+interface QuestBriefingViewProps {
+  quest: Quest
+  act: Act
+  onStart: () => void
+}
+
+const TIME_ESTIMATE: Record<string, string> = {
+  STUDY: '약 30분',
+  WRITE: '약 45분',
+  DISCOVER: '약 20분',
+  BUILD: '약 60분',
+  BOSS: '약 30분',
+}
+
+export function QuestBriefingView({ quest, act, onStart }: QuestBriefingViewProps) {
+  const typeConfig = QUEST_TYPE_CONFIG[quest.type]
+  const timeEstimate = TIME_ESTIMATE[quest.type] ?? '약 30분'
+
+  const containerStyle: React.CSSProperties = {
+    animation: 'slideIn 0.4s ease',
+    paddingTop: 20,
+  }
+
+  const actContextStyle: React.CSSProperties = {
+    color: '#334155',
+    fontSize: 11,
+    letterSpacing: 3,
+    margin: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  }
+
+  const badgeRowStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 16,
+    flexWrap: 'wrap',
+  }
+
+  const tagBadgeStyle: React.CSSProperties = {
+    background: typeConfig.bg,
+    border: `1px solid ${typeConfig.border}`,
+    borderRadius: 6,
+    padding: '3px 10px',
+    fontSize: 11,
+    color: typeConfig.border,
+  }
+
+  const xpBadgeStyle: React.CSSProperties = {
+    background: 'rgba(245,158,11,0.08)',
+    border: '1px solid rgba(245,158,11,0.3)',
+    borderRadius: 6,
+    padding: '3px 10px',
+    fontSize: 11,
+    color: '#F59E0B',
+  }
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: 22,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 8,
+    color: '#F8FAFC',
+  }
+
+  const descStyle: React.CSSProperties = {
+    fontSize: 13,
+    color: '#475569',
+    lineHeight: 1.6,
+    margin: 0,
+  }
+
+  const separatorStyle: React.CSSProperties = {
+    borderTop: '1px solid rgba(255,255,255,0.06)',
+    paddingTop: 16,
+    marginTop: 16,
+  }
+
+  const sectionLabelStyle: React.CSSProperties = {
+    fontSize: 11,
+    letterSpacing: 3,
+    color: '#334155',
+    margin: '0 0 12px',
+  }
+
+  const infoChipsStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: 12,
+    flexWrap: 'wrap',
+  }
+
+  const infoChipStyle: React.CSSProperties = {
+    background: 'rgba(255,255,255,0.04)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: 8,
+    padding: '8px 12px',
+    fontSize: 12,
+    color: '#94A3B8',
+  }
+
+  const taskListStyle: React.CSSProperties = {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  }
+
+  const taskItemStyle: React.CSSProperties = {
+    fontSize: 13,
+    color: '#94A3B8',
+    display: 'flex',
+    gap: 10,
+  }
+
+  const taskNumberStyle: React.CSSProperties = {
+    color: act.color,
+    fontWeight: 'bold',
+    minWidth: 18,
+  }
+
+  const startButtonStyle: React.CSSProperties = {
+    width: '100%',
+    background: `linear-gradient(135deg, ${act.color}, ${act.color}80)`,
+    border: 'none',
+    borderRadius: 12,
+    padding: 14,
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: '#060610',
+    cursor: 'pointer',
+    marginTop: 20,
+    fontFamily: "'Courier New', monospace",
+  }
+
+  return (
+    <div style={containerStyle}>
+      <p style={actContextStyle}>
+        <span>{act.icon}</span>
+        <span>
+          {act.title} · {act.subtitle}
+        </span>
+      </p>
+
+      <div style={badgeRowStyle}>
+        <span style={{ fontSize: 22 }}>{typeConfig.icon}</span>
+        <span style={tagBadgeStyle}>{quest.tag}</span>
+        <span style={xpBadgeStyle}>+{quest.xp} XP</span>
+      </div>
+
+      <h2 style={titleStyle}>{quest.title}</h2>
+      <p style={descStyle}>{quest.desc}</p>
+
+      <div style={separatorStyle}>
+        <p style={sectionLabelStyle}>이 퀘스트에서</p>
+        <div style={infoChipsStyle}>
+          <span style={infoChipStyle}>🎁 +{quest.xp} XP 획득</span>
+          <span style={infoChipStyle}>⏱ {timeEstimate}</span>
+          {quest.aiCheck && <span style={infoChipStyle}>🤖 AI 검사</span>}
+        </div>
+      </div>
+
+      <div style={separatorStyle}>
+        <p style={sectionLabelStyle}>해야 할 일</p>
+        <ol style={taskListStyle}>
+          {quest.tasks.map((task, i) => (
+            <li key={i} style={taskItemStyle}>
+              <span style={taskNumberStyle}>{i + 1}.</span>
+              <span>{task}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <button style={startButtonStyle} onClick={onStart}>
+        시작하기 →
+      </button>
+    </div>
+  )
+}

--- a/fe/src/features/quest-detail/index.ts
+++ b/fe/src/features/quest-detail/index.ts
@@ -1,3 +1,4 @@
 export { ActView } from './components/ActView'
 export { QuestDetail } from './components/QuestDetail'
 export { QuestCard } from './components/QuestCard'
+export { QuestBriefingView } from './components/QuestBriefingView'

--- a/fe/src/features/quest-map/components/QuestMap.tsx
+++ b/fe/src/features/quest-map/components/QuestMap.tsx
@@ -1,18 +1,20 @@
-import type { Act } from '@/types/quest.types'
+import type { Act, Quest } from '@/types/quest.types'
 import type { Character } from '@/types/character.types'
 import { ACTS, ACT_UNLOCK_THRESHOLD } from '../constants/questData'
 import { ActCard } from './ActCard'
 import { StatsPanel } from './StatsPanel'
+import { TodayMissionBanner } from './TodayMissionBanner'
 
 interface QuestMapProps {
   onSelectAct: (act: Act) => void
+  onSelectQuest: (act: Act, quest: Quest) => void
   onOpenCoach: () => void
   completed: Record<string, boolean>
   getActProgress: (act: Act) => number
   character: Character
 }
 
-export function QuestMap({ onSelectAct, onOpenCoach, completed, getActProgress, character }: QuestMapProps) {
+export function QuestMap({ onSelectAct, onSelectQuest, onOpenCoach, completed, getActProgress, character }: QuestMapProps) {
   const completedCount = Object.keys(completed).length
 
   return (
@@ -46,6 +48,8 @@ export function QuestMap({ onSelectAct, onOpenCoach, completed, getActProgress, 
         <span style={{ color: '#475569' }}>Spring Boot 4.x + Spring AI 연동 필요</span>
         <span style={{ color: '#1E293B', marginLeft: 'auto' }}>localhost:8080</span>
       </div>
+
+      <TodayMissionBanner completed={completed} onStart={onSelectQuest} />
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         {ACTS.map((act, i) => {

--- a/fe/src/features/quest-map/components/TodayMissionBanner.tsx
+++ b/fe/src/features/quest-map/components/TodayMissionBanner.tsx
@@ -1,0 +1,98 @@
+import type { Act, Quest } from '@/types/quest.types'
+import { ACTS } from '../constants/questData'
+import { QUEST_NEXT } from '@/features/quest-detail/constants/questConnections'
+
+interface TodayMissionBannerProps {
+  completed: Record<string, boolean>
+  onStart: (act: Act, quest: Quest) => void
+}
+
+function findActForQuest(questId: string): { act: Act; quest: Quest } | null {
+  for (const act of ACTS) {
+    const quest = act.quests.find((q) => q.id === questId)
+    if (quest) return { act, quest }
+  }
+  return null
+}
+
+function findTodayMission(completed: Record<string, boolean>): { act: Act; quest: Quest; message: string } | null {
+  // Strategy 1: QUEST_NEXT connections — source completed, target not completed
+  for (const [sourceId, { questId: targetId, message }] of Object.entries(QUEST_NEXT)) {
+    if (completed[sourceId] && !completed[targetId]) {
+      const found = findActForQuest(targetId)
+      if (found) return { ...found, message }
+    }
+  }
+
+  // Strategy 2: Fallback — first incomplete quest in order
+  for (const act of ACTS) {
+    for (const quest of act.quests) {
+      if (!completed[quest.id]) {
+        return { act, quest, message: '다음 퀘스트를 시작해봐요' }
+      }
+    }
+  }
+
+  return null
+}
+
+export function TodayMissionBanner({ completed, onStart }: TodayMissionBannerProps) {
+  const mission = findTodayMission(completed)
+
+  if (!mission) return null
+
+  const { act, quest, message } = mission
+
+  const containerStyle: React.CSSProperties = {
+    border: '1px solid rgba(245,158,11,0.35)',
+    background: 'rgba(245,158,11,0.04)',
+    borderRadius: 12,
+    padding: 18,
+    marginBottom: 16,
+  }
+
+  const headerStyle: React.CSSProperties = {
+    fontSize: 11,
+    letterSpacing: 3,
+    color: '#F59E0B',
+    margin: 0,
+    marginBottom: 4,
+  }
+
+  const messageStyle: React.CSSProperties = {
+    fontSize: 12,
+    color: '#94A3B8',
+    margin: '4px 0 6px',
+  }
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: '#F8FAFC',
+    margin: '0 0 12px',
+  }
+
+  const buttonStyle: React.CSSProperties = {
+    width: '100%',
+    background: 'linear-gradient(135deg, #F59E0B, rgba(245,158,11,0.7))',
+    border: 'none',
+    borderRadius: 8,
+    padding: '10px 16px',
+    fontSize: 13,
+    fontWeight: 'bold',
+    color: '#060610',
+    cursor: 'pointer',
+    fontFamily: "'Courier New', monospace",
+  }
+
+  return (
+    <div style={containerStyle}>
+      <p style={headerStyle}>⚡ 오늘의 미션</p>
+      <p style={messageStyle}>{message}</p>
+      <p style={titleStyle}>{quest.title}</p>
+      <button style={buttonStyle} onClick={() => onStart(act, quest)}>
+        바로 시작하기 →
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

포기 방지 시스템 Sprint 2 구현 — 퀘스트 맵 진입 장벽 제거

- **B. 오늘의 미션 배너**: QuestMap 상단에 다음 추천 퀘스트 강조 표시 (`TodayMissionBanner`)
- **C. 퀘스트 브리핑 화면**: 퀘스트 진입 전 XP/소요시간/태스크 미리보기 화면 (`QuestBriefingView`)

## Changes

- `TodayMissionBanner.tsx` — QUEST_NEXT 연결 그래프로 다음 퀘스트 탐색, 없으면 첫 미완료 퀘스트 fallback
- `QuestBriefingView.tsx` — 퀘스트 아이콘/태그/XP/소요시간/AI검사 여부/태스크 리스트 → [시작하기] 버튼
- `QuestMap.tsx` — `TodayMissionBanner` 추가, `onSelectQuest` prop 추가
- `App.tsx` — `briefing` View kind 추가, `handleSelectQuest` / `handleBriefingStart` 함수 추가, `handleSelectAct`가 첫 미완료 퀘스트로 이동하도록 개선

## Flow

```
퀘스트 맵
 ├── 오늘의 미션 배너 [바로 시작하기 →] ─┐
 └── ActCard 클릭 ────────────────────────┼→ QuestBriefingView → QuestDetail
```

## Test plan

- [ ] 앱 첫 진입 시 "오늘의 미션" 배너에 1-1 퀘스트 표시 확인
- [ ] 1-1 완료 후 배너가 1-2로 업데이트 (QUEST_NEXT 연결 메시지 표시) 확인
- [ ] 배너 "바로 시작하기 →" 클릭 → 브리핑 화면 → [시작하기] → 퀘스트 상세 진입 확인
- [ ] ActCard 클릭 → 브리핑 화면 (첫 미완료 퀘스트) → 상세 진입 확인
- [ ] 브리핑 화면에 XP/소요시간/AI검사/태스크 정보 표시 확인
- [ ] 모든 퀘스트 완료 시 배너 미표시 확인
- [ ] `npm run build` 빌드 통과

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)