### PR TITLE
feat(fe): Sprint 4 — 온보딩 스토리텔링 인트로

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,26 +7,23 @@
 
 | 브랜치 | 상태 | 설명 |
 |--------|------|------|
-| `main` | PR #18 머지됨 | UX Sprint 1 (E+F) 완료 |
-| `feat/ux-sprint2` | 작업 중 (PR #19 오픈) | UX 포기 방지 Sprint 2 (B+C) |
+| `main` | PR #20 머지됨 | Sprint 1~3 모두 완료 |
+| `feat/ux-sprint4` | 작업 중 (PR #21 오픈) | UX 포기 방지 Sprint 4 (A: 온보딩) |
 
 ## 열린 PR
 
 | PR | 브랜치 | 상태 | 내용 |
 |----|--------|------|------|
-| [#19](https://github.com/bangddong/switch-job-quest/pull/19) | `feat/ux-sprint2` | 오픈 | 오늘의 미션 배너 + 퀘스트 브리핑 화면 |
+| [#21](https://github.com/bangddong/switch-job-quest/pull/21) | `feat/ux-sprint4` | 오픈 | 온보딩 스토리텔링 5슬라이드 인트로 |
 
 ## 최근 결정 사항
 
-### UX 포기 방지 시스템 Sprint 2 (2026-04-02)
-- **B. TodayMissionBanner**: QuestMap 상단 다음 추천 퀘스트 배너 (QUEST_NEXT 연결 그래프 활용)
-- **C. QuestBriefingView**: 퀘스트 진입 전 브리핑 화면 (XP/소요시간/AI검사/태스크 미리보기)
-- `briefing` View kind 추가 → ActCard 클릭 + 배너 CTA 모두 브리핑 거쳐 QuestDetail 진입
-
-### UX 포기 방지 시스템 Sprint 1 (2026-04-02)
-- **기획**: 6개 포기 지점 분석 → 7개 기능(A-G) → 4개 스프린트 로드맵 (`.claude/docs/ux-retention-plan.md`)
-- **E. NextQuestCard**: AI 통과 시 다음 퀘스트 연결 카드 표시
-- **F. RetryCoachCard**: AI 실패 시 개선 포인트 + "이전 답변 불러오기" 버튼
+### UX 포기 방지 시스템 — 전체 완료 (2026-04-02)
+- **Sprint 1** (PR #18): E (다음 퀘스트 연결 카드) + F (재도전 코치 + 이전 답변 불러오기)
+- **Sprint 2** (PR #19): B (오늘의 미션 배너) + C (퀘스트 브리핑 화면)
+- **Sprint 3** (PR #20): D (필드별 작성 가이드 `?` 버튼) + G (복귀 배너, BE lastCompletedAt)
+- **Sprint 4** (PR #21): A (온보딩 스토리텔링 5슬라이드 인트로)
+- 기획 문서: `.claude/docs/ux-retention-plan.md`
 
 ### 4-BOSS 지원 패키지 평가 (2026-04-02)
 - **BE**: `POST /api/v1/ai-check/boss-package` — 이력서+GitHub+블로그+목표포지션 종합 평가
@@ -34,27 +31,22 @@
 
 ### 퀘스트 히스토리 & 성장 대시보드 (2026-04-01)
 - **BE**: `quest_history` 테이블에 AI 평가 시도마다 기록 저장 (Port & Adapter 패턴)
-- **BE**: `GET /api/v1/progress/history`, `GET /api/v1/progress/history/{questId}` 추가
-- **FE**: `features/growth/` 신설 — ScoreTimeline(꺾은선), 퀘스트별 최고점(바 차트), 최근 시도 목록
-- **FE**: 퀘스트 맵 하단 "📈 성장 기록" 버튼으로 진입
+- **FE**: `features/growth/` — ScoreTimeline, 퀘스트별 최고점 바 차트, 최근 시도 목록
 
 ### 멀티 에이전트 패턴 도입 (2026-03-31)
 - Claude가 기획자/오케스트레이터 역할 담당
 - BE/FE 각각 독립 에이전트(isolation: worktree)로 병렬 작업
-- 에이전트 권한 문제 → `~/.claude/settings.json`에 permissions 추가로 해결
 - 에이전트 완료 후 기획자(Claude)가 코드 리뷰 → 보완 지시 또는 직접 수정 후 PR
 
 ### 면접 코치 기능 (2026-03-31)
 - **컨셉**: 전담 코치가 처음부터 끝까지 함께하는 1:1 코칭 세션
-- **흐름**: JD 입력 → JD 분석 → 질문별 Q&A + 즉시 피드백 → 종합 리포트
-- **BE**: Stateless API (클라이언트가 히스토리 전달), `InterviewCoachPort` Port & Adapter 패턴
+- **BE**: Stateless API, `InterviewCoachPort` Port & Adapter 패턴
 - **FE**: `features/interview-coach/` 신규 feature, CoachBubble 말풍선 UI
 
 ## 다음 작업
 
-- [ ] PR #19 CI 확인 후 머지
-- [ ] Sprint 3 (추후): D (필드별 작성 가이드) + G (복귀 배너, BE 필요)
-- [ ] Sprint 4 (추후): A (온보딩 스토리텔링)
+- [ ] PR #21 CI 확인 후 머지 (온보딩 인트로)
+- [ ] ACT V 구현: 5-1 (인성면접 연습), 5-BOSS
 
 ## 멀티 에이전트 운영 노하우
 

--- a/.github/workflows/be-ci.yml
+++ b/.github/workflows/be-ci.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   test:
+    name: BE CI / test
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build:
+    name: FE CI / build
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -5,7 +5,7 @@ import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail, QuestBriefingView } from '@/features/quest-detail'
 import { ActClearReportCard } from '@/features/ai-check'
-import { CharacterCreate } from '@/features/character'
+import { CharacterCreate, OnboardingIntro } from '@/features/character'
 import { InterviewCoach } from '@/features/interview-coach'
 import { GrowthDashboard } from '@/features/growth'
 import { useUserId } from '@/hooks/useUserId'
@@ -30,6 +30,7 @@ export function App() {
   const [aiScores, setAiScores] = useState<Record<string, number>>({})
   const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | null>(null)
   const [showForm, setShowForm] = useState(false)
+  const [showIntro, setShowIntro] = useState(true)
 
   useEffect(() => {
     fetchProgress(userId)
@@ -144,17 +145,11 @@ export function App() {
 
   if (character === null) {
     return (
-      <div
-        style={{
-          maxWidth: 480,
-          margin: '0 auto',
-          padding: '0 20px',
-          minHeight: '100vh',
-          fontFamily: "'Courier New', monospace",
-          color: '#F8FAFC',
-        }}
-      >
-        <CharacterCreate onComplete={handleCharacterComplete} />
+      <div style={{ maxWidth: 480, margin: '0 auto', padding: '0 20px', minHeight: '100vh', fontFamily: "'Courier New', monospace", color: '#F8FAFC' }}>
+        {showIntro
+          ? <OnboardingIntro onComplete={() => setShowIntro(false)} />
+          : <CharacterCreate onComplete={handleCharacterComplete} />
+        }
       </div>
     )
   }

--- a/fe/src/features/character/components/OnboardingIntro.tsx
+++ b/fe/src/features/character/components/OnboardingIntro.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+
+interface OnboardingIntroProps {
+  onComplete: () => void
+}
+
+const SLIDES = [
+  {
+    icon: '💻',
+    tag: '2026년 봄',
+    title: '매일 같은 코드',
+    body: '한 개발자가 퇴근 후 모니터를 멍하니 바라보고 있었다.\n3년째 같은 레거시를 고치며, 성장이 멈춘 느낌이 들었다.',
+  },
+  {
+    icon: '😶',
+    tag: '어느 날',
+    title: '이게 맞는 건가...',
+    body: '좋은 팀, 괜찮은 연봉. 그런데도 어딘가 허전했다.\n더 어려운 문제를 풀고 싶었다. 더 성장하고 싶었다.',
+  },
+  {
+    icon: '☕',
+    tag: '결심',
+    title: '이직을 해보자',
+    body: '커피 한 잔을 마시며 마음을 굳혔다.\n"지금이 아니면 언제?"',
+  },
+  {
+    icon: '🤯',
+    tag: '현실',
+    title: '그런데... 어디서부터?',
+    body: '기술 스택 정리, 이력서 작성, GitHub 정비, 모의 면접...\n뭐부터 해야 할지조차 모르겠다.',
+  },
+  {
+    icon: '⚔️',
+    tag: 'DEVQUEST',
+    title: '당신의 이직 퀘스트',
+    body: '단계별 퀘스트로 이직 준비의 모든 것을 완성하라.\nAI가 함께 검사하고, 피드백하고, 성장시킨다.',
+    isCta: true,
+  },
+]
+
+export function OnboardingIntro({ onComplete }: OnboardingIntroProps) {
+  const [step, setStep] = useState(0)
+  const slide = SLIDES[step]!
+  const isLast = step === SLIDES.length - 1
+
+  const handleNext = () => {
+    if (isLast) {
+      onComplete()
+    } else {
+      setStep(step + 1)
+    }
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '40px 0' }}>
+      {/* Progress dots */}
+      <div style={{ display: 'flex', gap: 6, justifyContent: 'center', marginBottom: 48 }}>
+        {SLIDES.map((_, i) => (
+          <div key={i} style={{
+            width: i === step ? 20 : 6,
+            height: 6,
+            borderRadius: 3,
+            background: i === step ? '#4ECDC4' : i < step ? 'rgba(78,205,196,0.4)' : 'rgba(255,255,255,0.08)',
+            transition: 'all 0.3s ease',
+          }} />
+        ))}
+      </div>
+
+      {/* Slide content — key triggers re-animation */}
+      <div key={step} style={{ textAlign: 'center', animation: 'slideIn 0.3s ease', flex: 1 }}>
+        <div style={{ fontSize: 52, marginBottom: 16 }}>{slide.icon}</div>
+        <div style={{ fontSize: 10, letterSpacing: 5, color: '#334155', marginBottom: 8 }}>{slide.tag}</div>
+        <h2 style={{ fontSize: 24, fontWeight: 'bold', color: '#F8FAFC', margin: '0 0 16px' }}>{slide.title}</h2>
+        <p style={{ fontSize: 14, color: '#475569', lineHeight: 1.9, margin: 0, whiteSpace: 'pre-line' }}>{slide.body}</p>
+      </div>
+
+      {/* Buttons */}
+      <div style={{ marginTop: 48 }}>
+        {'isCta' in slide && slide.isCta ? (
+          <button
+            onClick={handleNext}
+            className="hov-btn"
+            style={{
+              width: '100%',
+              padding: '16px',
+              background: 'linear-gradient(135deg, #4ECDC4, #4ECDC480)',
+              border: 'none',
+              borderRadius: 10,
+              color: '#060610',
+              fontSize: 16,
+              fontWeight: 'bold',
+              cursor: 'pointer',
+              fontFamily: "'Courier New', monospace",
+              letterSpacing: 1,
+            }}
+          >
+            ⚔️ 여정 시작하기
+          </button>
+        ) : (
+          <>
+            <button
+              onClick={handleNext}
+              className="hov-btn"
+              style={{
+                width: '100%',
+                padding: '14px',
+                background: 'transparent',
+                border: '1px solid rgba(78,205,196,0.3)',
+                borderRadius: 10,
+                color: '#4ECDC4',
+                fontSize: 14,
+                fontWeight: 'bold',
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+                marginBottom: 12,
+              }}
+            >
+              다음 →
+            </button>
+            <button
+              onClick={onComplete}
+              style={{
+                width: '100%',
+                padding: '8px',
+                background: 'transparent',
+                border: 'none',
+                color: '#1E293B',
+                fontSize: 12,
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              건너뛰기
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/character/index.ts
+++ b/fe/src/features/character/index.ts
@@ -1,1 +1,2 @@
 export { CharacterCreate } from './components/CharacterCreate'
+export { OnboardingIntro } from './components/OnboardingIntro'


### PR DESCRIPTION
## Summary

포기 방지 시스템 Sprint 4 — 첫 진입 시 이직 동기 부여 내러티브

- **A. 온보딩 스토리텔링**: 캐릭터 생성 전 5슬라이드 RPG 인트로 스크린

## Changes

- `OnboardingIntro.tsx` (신규) — 5슬라이드 RPG 내러티브 인트로
  - 진행 도트 (active: 넓은 teal, past: 희미한 teal, future: 다크)
  - `key={step}`으로 슬라이드 전환마다 `slideIn` 애니메이션 재실행
  - 비 CTA 슬라이드: "다음 →" + "건너뛰기" 버튼
  - 마지막 슬라이드: "⚔️ 여정 시작하기" teal CTA
- `fe/src/features/character/index.ts` — `OnboardingIntro` export 추가
- `App.tsx` — `showIntro` state 추가, `character === null` 시 인트로 먼저 표시

## Narrative flow

```
Slide 1: 💻 "2026년 봄 — 매일 같은 코드"
Slide 2: 😶 "어느 날 — 이게 맞는 건가..."
Slide 3: ☕ "결심 — 이직을 해보자"
Slide 4: 🤯 "현실 — 그런데... 어디서부터?"
Slide 5: ⚔️ "DEVQUEST — 당신의 이직 퀘스트" [여정 시작하기]
    ↓
CharacterCreate (캐릭터 생성)
    ↓
QuestMap (퀘스트 맵)
```

## Test plan

- [ ] 첫 방문 시 (character 없음) 온보딩 인트로 표시 확인
- [ ] "다음 →" 클릭마다 슬라이드 전환 + 진행 도트 업데이트 확인
- [ ] "건너뛰기" 클릭 시 바로 캐릭터 생성 화면으로 이동 확인
- [ ] 마지막 슬라이드 "⚔️ 여정 시작하기" → 캐릭터 생성 화면 확인
- [ ] 캐릭터 생성 완료 후 다시 방문 시 인트로 스킵 (character 존재) 확인
- [ ] `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)