### PR TITLE
feat: ACT V 5-BOSS 취뽀 달성 화면 + 퀘스트 연결 정리 (BE+FE)

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,16 +7,26 @@
 
 | 브랜치 | 상태 | 설명 |
 |--------|------|------|
-| `main` | PR #20 머지됨 | Sprint 1~3 모두 완료 |
-| `feat/ux-sprint4` | 작업 중 (PR #21 오픈) | UX 포기 방지 Sprint 4 (A: 온보딩) |
+| `main` | PR #21 머지됨 | UX 포기 방지 Sprint 1~4 모두 완료 |
 
 ## 열린 PR
 
-| PR | 브랜치 | 상태 | 내용 |
-|----|--------|------|------|
-| [#21](https://github.com/bangddong/switch-job-quest/pull/21) | `feat/ux-sprint4` | 오픈 | 온보딩 스토리텔링 5슬라이드 인트로 |
+| PR | 브랜치 | 설명 |
+|----|--------|------|
+| #22 | `feat/act-v-final-boss` | ACT V 5-BOSS 취뽀 달성 화면 + 퀘스트 연결 정리 |
 
 ## 최근 결정 사항
+
+### CI check name 수정 (2026-04-02)
+- **원인**: job에 `name:` 없으면 check run = `"build"`, branch protection은 `"FE CI / build"` 요구 → 불일치
+- **수정**: `fe-ci.yml`에 `name: FE CI / build`, `be-ci.yml`에 `name: BE CI / test` 추가
+- **효과**: PR #21부터 `--admin` 없이 정상 머지 가능
+
+### ACT V 5-BOSS 취뽀 달성 화면 (2026-04-03)
+- **BE**: `POST /api/v1/ai-check/journey-report` — 전체 여정 AI 감성 회고 내러티브 생성
+- **FE**: `FinalBossView` — 합격 신고 입력 → 취뽀 타이틀/통계/AI 내러티브/마지막 한 마디
+- **FE**: `questConnections.ts` — ACT I~V 전 퀘스트 연결 완성 (10개 추가)
+- **공통**: GitHub Copilot 리뷰 코멘트 한국어 지시 추가
 
 ### UX 포기 방지 시스템 — 전체 완료 (2026-04-02)
 - **Sprint 1** (PR #18): E (다음 퀘스트 연결 카드) + F (재도전 코치 + 이전 답변 불러오기)
@@ -45,8 +55,8 @@
 
 ## 다음 작업
 
-- [ ] PR #21 CI 확인 후 머지 (온보딩 인트로)
-- [ ] ACT V 구현: 5-1 (인성면접 연습), 5-BOSS
+- [ ] PR #22 머지 후 5-2 수동 완료 UI 추가 검토
+- [ ] ACT V 전체 검증 (5-1 AI 폼 → 5-2 수동 → 5-BOSS)
 
 ## 멀티 에이전트 운영 노하우
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # GitHub Copilot Instructions — Switch Job Quest (DevQuest)
 
+**언어 규칙: 모든 리뷰 코멘트, 제안, 피드백은 반드시 한국어로 작성한다.**
+
 이직 준비 RPG 앱. 모노레포: `be/` (Kotlin + Spring Boot) + `fe/` (React 19 + TypeScript + Vite)
 퀘스트별 AI 평가(Anthropic API)를 핵심 기능으로 사용한다.
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -1,0 +1,69 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.core.domain.model.evaluation.JourneyReportResult
+import com.devquest.core.domain.port.JourneyReportPort
+import com.devquest.core.domain.support.AiEvaluationException
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+@Component
+class JourneyReportGenerator(
+    private val chatClient: ChatClient
+) : JourneyReportPort {
+
+    override fun generate(
+        companyName: String,
+        targetPosition: String,
+        questScores: Map<String, Int>,
+        totalXp: Int,
+        completedQuestCount: Int,
+    ): JourneyReportResult {
+        val scoresText = questScores.entries.joinToString("\n") { (questId, score) ->
+            "- $questId: ${score}점"
+        }
+        val lowestEntry = questScores.minByOrNull { it.value }
+        val highestEntry = questScores.maxByOrNull { it.value }
+
+        val prompt = """
+            5년차 백엔드 개발자가 이직 준비 RPG를 완주하고 [${companyName}] ${targetPosition} 포지션에 최종 합격했습니다.
+            이 개발자의 전체 여정을 돌아보는 감성적인 회고 리포트를 작성해주세요.
+
+            ## 여정 통계
+            - 완료한 퀘스트: ${completedQuestCount}개
+            - 획득한 총 XP: ${totalXp}
+            - 합격 회사: ${companyName}
+            - 합격 포지션: ${targetPosition}
+
+            ## 퀘스트별 점수
+            $scoresText
+
+            ## 작성 지침
+            - narrative: 3~4 문단의 감성적인 회고 내러티브.
+              * 처음 진단에서의 불안함, 중간에 힘들었던 순간, 포기하고 싶었던 순간, 결국 해낸 성취감을 생생하게 묘사.
+              * 구체적인 퀘스트 점수(특히 낮은 점수에서 성장하는 흐름)를 자연스럽게 녹여낼 것.
+              * "당신"을 2인칭으로 부르며 공감하는 톤. 과도하게 격식 없이, 진심 어린 어투.
+              * 마지막 문단에서 ${companyName} 합격으로 이어지는 클라이맥스를 연출할 것.
+            - lowestQuestId: 점수가 가장 낮았던 퀘스트 ID (예: "2-3")
+            - highestQuestId: 점수가 가장 높았던 퀘스트 ID (예: "4-1")
+            - finalMessage: 앞으로를 응원하는 짧고 강렬한 한 문장 (20자 이내)
+
+            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
+            {
+                "companyName": "${companyName}",
+                "targetPosition": "${targetPosition}",
+                "totalXp": ${totalXp},
+                "completedQuestCount": ${completedQuestCount},
+                "narrative": "...",
+                "lowestQuestId": "${lowestEntry?.key ?: ""}",
+                "highestQuestId": "${highestEntry?.key ?: ""}",
+                "finalMessage": "..."
+            }
+        """.trimIndent()
+
+        return chatClient.prompt()
+            .user(prompt)
+            .call()
+            .entity(JourneyReportResult::class.java)
+            ?: throw AiEvaluationException("취뽀 회고 리포트 생성 실패")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
@@ -154,6 +154,17 @@ class AiCheckController(
         }
     }
 
+    @PostMapping("/journey-report")
+    fun generateJourneyReport(@Valid @RequestBody request: JourneyReportRequestDto): ApiResponse<*> {
+        return try {
+            val result = aiCheckService.generateJourneyReport(request.userId, request.companyName, request.targetPosition)
+            ApiResponse.success(result)
+        } catch (e: Exception) {
+            log.error("Journey report generation failed", e)
+            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        }
+    }
+
     @PostMapping("/act-clear-report")
     fun generateActClearReport(@Valid @RequestBody request: ActClearReportRequestDto): ApiResponse<*> {
         return try {

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JourneyReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JourneyReportRequestDto.kt
@@ -1,0 +1,9 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class JourneyReportRequestDto(
+    @field:NotBlank val userId: String,
+    @field:NotBlank val companyName: String,
+    @field:NotBlank val targetPosition: String,
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -27,7 +27,8 @@ class AiCheckService(
     private val actClearReportPort: ActClearReportPort,
     private val progressPort: QuestProgressPort,
     private val historyPort: QuestHistoryPort,
-    private val bossPackageEvaluator: BossPackageEvaluatorPort
+    private val bossPackageEvaluator: BossPackageEvaluatorPort,
+    private val journeyReportPort: JourneyReportPort,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -115,6 +116,16 @@ class AiCheckService(
         val passed = result.overallScore >= passScore
         saveProgress(userId, "4-BOSS", 4, result.overallScore, passed, if (passed) 700 else 0)
         return result
+    }
+
+    fun generateJourneyReport(userId: String, companyName: String, targetPosition: String): JourneyReportResult {
+        val allProgress = progressPort.findAllByUserId(userId)
+        val questScores = allProgress
+            .filter { it.aiScore > 0 }
+            .associate { it.questId to it.aiScore }
+        val totalXp = allProgress.sumOf { it.earnedXp }
+        val completedQuestCount = allProgress.count { it.status == QuestStatus.COMPLETED }
+        return journeyReportPort.generate(companyName, targetPosition, questScores, totalXp, completedQuestCount)
     }
 
     fun generateActClearReport(userId: String, actId: Int, actTitle: String): ActClearReportResult {

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -31,6 +31,7 @@ class AiCheckServiceTest {
     @Mock lateinit var progressPort: QuestProgressPort
     @Mock lateinit var historyPort: QuestHistoryPort
     @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
+    @Mock lateinit var journeyReportPort: JourneyReportPort
 
     private lateinit var service: AiCheckService
 
@@ -39,7 +40,8 @@ class AiCheckServiceTest {
         service = AiCheckService(
             essayEvaluator, blogEvaluator, systemDesignEvaluator, interviewEvaluator,
             jdAnalysisEvaluator, resumeEvaluator, companyFitEvaluator, personalityEvaluator,
-            skillAssessmentPort, actClearReportPort, progressPort, historyPort, bossPackageEvaluator
+            skillAssessmentPort, actClearReportPort, progressPort, historyPort, bossPackageEvaluator,
+            journeyReportPort
         )
         // progressPort.save 기본 응답 (저장 시 반환값 필요)
         whenever(progressPort.save(any())).thenAnswer { it.arguments[0] }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -33,19 +34,12 @@ class AiCheckServiceTest {
     @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
     @Mock lateinit var journeyReportPort: JourneyReportPort
 
+    @InjectMocks
     private lateinit var service: AiCheckService
 
     @BeforeEach
     fun setUp() {
-        service = AiCheckService(
-            essayEvaluator, blogEvaluator, systemDesignEvaluator, interviewEvaluator,
-            jdAnalysisEvaluator, resumeEvaluator, companyFitEvaluator, personalityEvaluator,
-            skillAssessmentPort, actClearReportPort, progressPort, historyPort, bossPackageEvaluator,
-            journeyReportPort
-        )
-        // progressPort.save 기본 응답 (저장 시 반환값 필요)
         whenever(progressPort.save(any())).thenAnswer { it.arguments[0] }
-        // historyPort.save 기본 응답
         whenever(historyPort.save(any())).thenAnswer { it.arguments[0] }
     }
 

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/JourneyReportResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/JourneyReportResult.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain.model.evaluation
+
+data class JourneyReportResult(
+    val companyName: String = "",
+    val targetPosition: String = "",
+    val totalXp: Int = 0,
+    val completedQuestCount: Int = 0,
+    val narrative: String = "",         // 감성적 회고 내러티브 (3~4 문단)
+    val lowestQuestId: String = "",     // 가장 힘들었던 퀘스트
+    val highestQuestId: String = "",    // 가장 빛났던 퀘스트
+    val finalMessage: String = "",      // 마지막 한 마디
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/JourneyReportPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/JourneyReportPort.kt
@@ -1,0 +1,13 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.evaluation.JourneyReportResult
+
+interface JourneyReportPort {
+    fun generate(
+        companyName: String,
+        targetPosition: String,
+        questScores: Map<String, Int>,   // questId -> score
+        totalXp: Int,
+        completedQuestCount: Int,
+    ): JourneyReportResult
+}

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -224,6 +224,7 @@ export function App() {
 
       {view.kind === 'detail' && (
         <QuestDetail
+          userId={userId}
           quest={view.quest}
           act={view.act}
           completed={completed}

--- a/fe/src/features/quest-detail/components/FinalBossView.tsx
+++ b/fe/src/features/quest-detail/components/FinalBossView.tsx
@@ -1,0 +1,301 @@
+import { useState } from 'react'
+import type { JourneyReportResult } from '@/types/api.types'
+import { fetchJourneyReport } from '@/lib/apiClient'
+
+const QUEST_LABEL: Record<string, string> = {
+  '1-1': '기술 스택 진단',
+  '1-2': '이직 동기 에세이',
+  '1-BOSS': '개발자 클래스 판별',
+  '2-2': '기술 블로그',
+  '2-3': '시스템 설계',
+  '2-BOSS': '모의 기술 면접',
+  '3-2': 'JD 역분석',
+  '4-1': '이력서 STAR 검토',
+  '4-BOSS': '지원 패키지 점검',
+  '5-1': '인성 면접 연습',
+}
+
+interface JourneyTimelineProps {
+  lowestQuestId: string
+  highestQuestId: string
+  totalXp: number
+  completedQuestCount: number
+}
+
+function JourneyTimeline({ lowestQuestId, highestQuestId, totalXp, completedQuestCount }: JourneyTimelineProps) {
+  return (
+    <div
+      style={{
+        background: 'rgba(10,14,26,0.8)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: 12,
+        padding: '18px 20px',
+        marginBottom: 18,
+      }}
+    >
+      <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 14 }}>
+        📊 여정 통계
+      </div>
+      <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
+        <div style={statCardStyle('#F59E0B')}>
+          <div style={{ fontSize: 22, fontWeight: 'bold', color: '#F59E0B' }}>{totalXp.toLocaleString()}</div>
+          <div style={{ fontSize: 10, color: '#64748B', marginTop: 2 }}>총 획득 XP</div>
+        </div>
+        <div style={statCardStyle('#4ECDC4')}>
+          <div style={{ fontSize: 22, fontWeight: 'bold', color: '#4ECDC4' }}>{completedQuestCount}</div>
+          <div style={{ fontSize: 10, color: '#64748B', marginTop: 2 }}>완료 퀘스트</div>
+        </div>
+      </div>
+
+      {lowestQuestId && QUEST_LABEL[lowestQuestId] && (
+        <div style={{ marginBottom: 8 }}>
+          <span style={{ fontSize: 11, color: '#475569' }}>가장 힘들었던 퀘스트 </span>
+          <span style={{ fontSize: 11, color: '#EF4444', fontWeight: 'bold' }}>
+            ↓ {QUEST_LABEL[lowestQuestId] ?? lowestQuestId}
+          </span>
+        </div>
+      )}
+      {highestQuestId && QUEST_LABEL[highestQuestId] && (
+        <div>
+          <span style={{ fontSize: 11, color: '#475569' }}>가장 빛났던 퀘스트 </span>
+          <span style={{ fontSize: 11, color: '#10B981', fontWeight: 'bold' }}>
+            ↑ {QUEST_LABEL[highestQuestId] ?? highestQuestId}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function statCardStyle(color: string): React.CSSProperties {
+  return {
+    flex: 1,
+    minWidth: 100,
+    background: `${color}08`,
+    border: `1px solid ${color}25`,
+    borderRadius: 10,
+    padding: '12px 16px',
+    textAlign: 'center',
+  }
+}
+
+interface NarrativeCardProps {
+  report: JourneyReportResult
+}
+
+function NarrativeCard({ report }: NarrativeCardProps) {
+  const paragraphs = report.narrative.split(/\n\n+/).filter(Boolean)
+
+  return (
+    <div
+      style={{
+        background: 'rgba(78,205,196,0.03)',
+        border: '1px solid rgba(78,205,196,0.18)',
+        borderRadius: 14,
+        padding: '22px 20px',
+        marginBottom: 18,
+      }}
+    >
+      <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 16 }}>
+        📖 당신의 이야기
+      </div>
+      {paragraphs.map((para, i) => (
+        <p
+          key={i}
+          style={{
+            color: '#94A3B8',
+            fontSize: 14,
+            lineHeight: 1.85,
+            margin: 0,
+            marginBottom: i < paragraphs.length - 1 ? 16 : 0,
+          }}
+        >
+          {para}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+interface FinalBossViewProps {
+  userId: string
+  onComplete: (xp: number) => void
+}
+
+export function FinalBossView({ userId, onComplete }: FinalBossViewProps) {
+  const [companyName, setCompanyName] = useState('')
+  const [targetPosition, setTargetPosition] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [report, setReport] = useState<JourneyReportResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!companyName.trim() || !targetPosition.trim()) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await fetchJourneyReport(userId, companyName.trim(), targetPosition.trim())
+      setReport(result)
+      onComplete(2000)
+    } catch {
+      setError('리포트 생성에 실패했어요. 다시 시도해주세요.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (report) {
+    return (
+      <div style={{ animation: 'slideIn 0.6s ease' }}>
+        {/* 취뽀 타이틀 */}
+        <div
+          style={{
+            textAlign: 'center',
+            padding: '32px 0 24px',
+          }}
+        >
+          <div style={{ fontSize: 52, marginBottom: 12 }}>🏆</div>
+          <div
+            style={{
+              fontSize: 11,
+              color: '#F59E0B',
+              letterSpacing: 4,
+              marginBottom: 8,
+            }}
+          >
+            QUEST CLEAR — 취뽀 달성
+          </div>
+          <div style={{ fontSize: 22, fontWeight: 'bold', color: '#F8FAFC', marginBottom: 6 }}>
+            {report.companyName}
+          </div>
+          <div style={{ fontSize: 14, color: '#64748B' }}>{report.targetPosition}</div>
+        </div>
+
+        {/* 여정 통계 */}
+        <JourneyTimeline
+          lowestQuestId={report.lowestQuestId}
+          highestQuestId={report.highestQuestId}
+          totalXp={report.totalXp}
+          completedQuestCount={report.completedQuestCount}
+        />
+
+        {/* AI 회고 내러티브 */}
+        <NarrativeCard report={report} />
+
+        {/* 마지막 한 마디 */}
+        <div
+          style={{
+            textAlign: 'center',
+            padding: '20px 0',
+            borderTop: '1px solid rgba(255,255,255,0.05)',
+          }}
+        >
+          <div style={{ fontSize: 10, color: '#475569', letterSpacing: 3, marginBottom: 10 }}>
+            FINAL MESSAGE
+          </div>
+          <div
+            style={{
+              fontSize: 16,
+              color: '#4ECDC4',
+              fontWeight: 'bold',
+              fontStyle: 'italic',
+            }}
+          >
+            "{report.finalMessage}"
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ animation: 'slideIn 0.4s ease' }}>
+      <div
+        style={{
+          textAlign: 'center',
+          padding: '28px 0 20px',
+        }}
+      >
+        <div style={{ fontSize: 44, marginBottom: 10 }}>🎯</div>
+        <div style={{ fontSize: 11, color: '#F59E0B', letterSpacing: 3, marginBottom: 6 }}>
+          FINAL BOSS
+        </div>
+        <div style={{ fontSize: 16, color: '#F8FAFC', fontWeight: 'bold', marginBottom: 6 }}>
+          합격 신고하기
+        </div>
+        <div style={{ fontSize: 13, color: '#475569', lineHeight: 1.6 }}>
+          어느 회사에 합격했나요?<br />
+          당신의 여정을 AI가 회고해드릴게요.
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 18 }}>
+        <div>
+          <label style={{ fontSize: 11, color: '#64748B', letterSpacing: 2, display: 'block', marginBottom: 6 }}>
+            합격 회사
+          </label>
+          <input
+            value={companyName}
+            onChange={(e) => setCompanyName(e.target.value)}
+            placeholder="예: 카카오"
+            style={inputStyle}
+          />
+        </div>
+        <div>
+          <label style={{ fontSize: 11, color: '#64748B', letterSpacing: 2, display: 'block', marginBottom: 6 }}>
+            합격 포지션
+          </label>
+          <input
+            value={targetPosition}
+            onChange={(e) => setTargetPosition(e.target.value)}
+            placeholder="예: 시니어 백엔드 개발자"
+            style={inputStyle}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ fontSize: 12, color: '#EF4444', marginBottom: 12, textAlign: 'center' }}>
+          {error}
+        </div>
+      )}
+
+      <button
+        className="hov-btn"
+        onClick={handleSubmit}
+        disabled={loading || !companyName.trim() || !targetPosition.trim()}
+        style={{
+          width: '100%',
+          padding: '14px',
+          background: loading
+            ? 'rgba(245,158,11,0.05)'
+            : 'linear-gradient(135deg, #F59E0B, #D97706)',
+          border: loading ? '1px solid rgba(245,158,11,0.3)' : 'none',
+          borderRadius: 10,
+          color: loading ? '#F59E0B' : '#060610',
+          fontSize: 14,
+          fontWeight: 'bold',
+          cursor: loading || !companyName.trim() || !targetPosition.trim() ? 'not-allowed' : 'pointer',
+          fontFamily: "'Courier New', monospace",
+          opacity: !companyName.trim() || !targetPosition.trim() ? 0.5 : 1,
+          transition: 'all 0.2s ease',
+        }}
+      >
+        {loading ? '🔮 여정을 돌아보는 중...' : '🏆 취뽀 달성 신고하기'}
+      </button>
+    </div>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '11px 14px',
+  background: '#0A0E1A',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: 8,
+  color: '#F1F5F9',
+  fontSize: 14,
+  fontFamily: "'Courier New', monospace",
+  boxSizing: 'border-box',
+  outline: 'none',
+}

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -7,8 +7,10 @@ import { AI_FORMS } from '@/features/ai-check'
 import { QUEST_NEXT } from '../constants/questConnections'
 import { NextQuestCard } from './NextQuestCard'
 import { RetryCoachCard } from './RetryCoachCard'
+import { FinalBossView } from './FinalBossView'
 
 interface QuestDetailProps {
+  userId: string
   quest: Quest
   act: Act
   completed: Record<string, boolean>
@@ -42,6 +44,7 @@ function isPassed(questId: string, aiResult: AiEvaluationResult | BossPackageRes
 }
 
 export function QuestDetail({
+  userId,
   quest,
   act,
   completed,
@@ -56,6 +59,7 @@ export function QuestDetail({
 }: QuestDetailProps) {
   const qc = QUEST_TYPE_CONFIG[quest.type]
   const done = !!completed[quest.id]
+  const isFinalBoss = quest.id === '5-BOSS'
   const isMock = quest.id === '2-BOSS'
   const hasForm = quest.id in AI_FORMS
   const [lastSubmittedValues, setLastSubmittedValues] = useState<Record<string, unknown>>({})
@@ -69,6 +73,17 @@ export function QuestDetail({
   const handleRetry = () => {
     setRetryInitialValues(lastSubmittedValues)
     onShowForm()
+  }
+
+  if (isFinalBoss && !done) {
+    return (
+      <div style={{ animation: 'slideIn 0.4s ease' }}>
+        <FinalBossView
+          userId={userId}
+          onComplete={(xp) => onComplete(quest.id, xp, act.id, act)}
+        />
+      </div>
+    )
   }
 
   return (

--- a/fe/src/features/quest-detail/constants/questConnections.ts
+++ b/fe/src/features/quest-detail/constants/questConnections.ts
@@ -1,8 +1,23 @@
 export const QUEST_NEXT: Record<string, { questId: string; message: string }> = {
+  // ACT I
   '1-1': { questId: '1-2', message: '진단 결과를 바탕으로 이직 동기를 정리해봐요' },
   '1-2': { questId: '1-BOSS', message: '1-1, 1-2 결과를 종합해 개발자 클래스를 판별해요' },
+  '1-BOSS': { questId: '2-1', message: '클래스 판별 완료! 이제 약점을 집중 강화할 시간이에요' },
+  // ACT II
+  '2-1': { questId: '2-2', message: '공략한 기술을 블로그 글로 정리해 깊이를 증명해봐요' },
   '2-2': { questId: '2-3', message: '블로그에서 보인 기술 깊이를 시스템 설계에도 발휘해봐요' },
   '2-3': { questId: '2-BOSS', message: '설계 경험을 AI 모의 면접에서 어필해봐요' },
+  '2-4': { questId: '2-BOSS', message: '코딩 테스트까지 끝냈어요! 이제 실전 면접으로 마무리해요' },
+  '2-BOSS': { questId: '3-1', message: '기술력 증명 완료! 이제 나에게 맞는 회사를 찾아봐요' },
+  // ACT III
+  '3-1': { questId: '3-2', message: '리스트업한 회사의 JD를 역분석해 요구사항을 파악해봐요' },
   '3-2': { questId: '3-BOSS', message: 'JD 분석을 바탕으로 최종 지원 타겟을 확정해요' },
-  '4-1': { questId: '4-BOSS', message: '이력서와 GitHub를 함께 최종 점검해요' },
+  '3-BOSS': { questId: '4-1', message: '타겟 확정! 이제 합격을 위한 장비를 제작할 시간이에요' },
+  // ACT IV
+  '4-1': { questId: '4-2', message: '이력서 검토 완료! GitHub 프로필도 함께 정비해봐요' },
+  '4-2': { questId: '4-BOSS', message: '이력서와 GitHub를 함께 최종 점검해요' },
+  '4-BOSS': { questId: '5-1', message: '지원 패키지 완성! 마지막 관문 인성 면접을 준비해봐요' },
+  // ACT V
+  '5-1': { questId: '5-2', message: '인성 면접 준비 완료! 이제 실전 지원을 시작할 시간이에요' },
+  '5-2': { questId: '5-BOSS', message: '지원서 제출 완료! 최후의 보스와 맞설 준비가 됐나요?' },
 }

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem } from '@/types/api.types'
+import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult } from '@/types/api.types'
 
 const API_BASE = '/api/v1'
 
@@ -53,6 +53,22 @@ export async function fetchQuestHistory(userId: string, questId: string): Promis
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
   if (!json.success || json.data == null) throw new Error('퀘스트 히스토리 조회 실패')
+  return json.data
+}
+
+export async function fetchJourneyReport(
+  userId: string,
+  companyName: string,
+  targetPosition: string,
+): Promise<JourneyReportResult> {
+  const res = await fetch(`${API_BASE}/ai-check/journey-report`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, companyName, targetPosition }),
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json: ApiResponse<JourneyReportResult> = await res.json()
+  if (!json.success || json.data == null) throw new Error('여정 리포트 생성 실패')
   return json.data
 }
 

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -69,6 +69,17 @@ export interface BossPackageResult {
   overallFeedback: string
 }
 
+export interface JourneyReportResult {
+  companyName: string
+  targetPosition: string
+  totalXp: number
+  completedQuestCount: number
+  narrative: string
+  lowestQuestId: string
+  highestQuestId: string
+  finalMessage: string
+}
+
 export interface InterviewEvaluationResult {
   score: number
   passed: boolean


### PR DESCRIPTION
## Summary

- **BE**: `POST /api/v1/ai-check/journey-report` 신규 엔드포인트 — 사용자 전체 여정 데이터를 AI가 감성 회고 내러티브로 생성
- **FE**: 5-BOSS 전용 `FinalBossView` — 합격 신고 입력 → AI 취뽀 회고 리포트 렌더링
- **FE**: `questConnections.ts` — ACT I~V 전 퀘스트 연결 완성 (1-BOSS→2-1, 2-BOSS→3-1, 4-BOSS→5-1 등 10개 추가)
- **공통**: GitHub Copilot 리뷰 코멘트 한국어 지시 추가

## 변경 파일

### BE (신규 4개, 수정 2개)
- `JourneyReportResult.kt` — 도메인 모델 (narrative, finalMessage, lowestQuestId, highestQuestId)
- `JourneyReportPort.kt` — Port 인터페이스
- `JourneyReportGenerator.kt` — AI 어댑터 (개인화 감성 내러티브 프롬프트)
- `JourneyReportRequestDto.kt` — 요청 DTO
- `AiCheckService.kt` — `generateJourneyReport()` 추가 (DB에서 전체 점수/XP 자동 수집)
- `AiCheckController.kt` — `/journey-report` 엔드포인트 추가

### FE (신규 1개, 수정 5개)
- `FinalBossView.tsx` — 합격 신고 입력 → 로딩 → 취뽀 타이틀/통계/AI 내러티브/마지막 한 마디
- `questConnections.ts` — ACT 전 구간 연결 완성
- `QuestDetail.tsx` — `userId` prop 추가, 5-BOSS 분기 처리
- `api.types.ts` — `JourneyReportResult` 타입 추가
- `apiClient.ts` — `fetchJourneyReport()` 추가
- `App.tsx` — `QuestDetail`에 `userId` 전달

## UX 흐름
```
5-BOSS 선택 → 합격 회사명 + 포지션 입력
→ "🔮 여정을 돌아보는 중..."
→ 🏆 취뽀 달성 화면
  · 총 XP / 완료 퀘스트 수
  · 가장 힘들었던 / 빛났던 퀘스트
  · AI 감성 회고 내러티브 (3~4 문단)
  · 마지막 한 마디
→ 퀘스트 완료 처리 (+2000 XP)
```

## Test plan
- [ ] 5-BOSS 퀘스트 진입 시 `FinalBossView` 렌더링 확인
- [ ] 회사명/포지션 미입력 시 버튼 비활성화 확인
- [ ] 합격 신고 후 AI 내러티브 정상 렌더링 확인
- [ ] 퀘스트 완료 처리 및 XP 적립 확인
- [ ] 각 ACT 완료 후 다음 퀘스트 연결 카드 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)