### PR TITLE
refactor(be): BOSS 퀘스트 AI 모델 라우팅 (haiku→sonnet)

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
@@ -1,15 +1,43 @@
 package com.devquest.client.ai.config
 
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.models.messages.Model
+import org.springframework.ai.anthropic.AnthropicChatModel
+import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatModel
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 
 @Configuration
 class AiClientConfig {
 
     @Bean
+    @Primary
     fun chatClient(chatModel: ChatModel): ChatClient {
         return ChatClient.builder(chatModel).build()
+    }
+
+    @Bean("bossChatClient")
+    fun bossChatClient(
+        @Value("\${devquest.ai.boss-model:claude-sonnet-4-5}") bossModel: String,
+        @Value("\${devquest.ai.boss-max-tokens:4000}") bossMaxTokens: Int,
+        @Value("\${spring.ai.anthropic.api-key}") apiKey: String,
+    ): ChatClient {
+        val anthropicClient = AnthropicOkHttpClient.builder()
+            .apiKey(apiKey)
+            .build()
+        val options = AnthropicChatOptions.builder()
+            .model(Model.of(bossModel))
+            .maxTokens(bossMaxTokens)
+            .temperature(0.3)
+            .build()
+        val model = AnthropicChatModel.builder()
+            .anthropicClient(anthropicClient)
+            .options(options)
+            .build()
+        return ChatClient.builder(model).build()
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -4,11 +4,12 @@ import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.BossPackageResult
 import com.devquest.core.domain.port.BossPackageEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
 @Component
 class BossPackageEvaluator(
-    private val chatClient: ChatClient
+    @Qualifier("bossChatClient") private val chatClient: ChatClient
 ) : BossPackageEvaluatorPort {
 
     override fun evaluate(

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
@@ -8,11 +8,12 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
 @Component
 class CompanyFitEvaluator(
-    private val chatClient: ChatClient
+    @Qualifier("bossChatClient") private val chatClient: ChatClient
 ) : CompanyFitEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -4,11 +4,12 @@ import com.devquest.core.domain.model.evaluation.JourneyReportResult
 import com.devquest.core.domain.port.JourneyReportPort
 import com.devquest.core.domain.support.AiEvaluationException
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
 @Component
 class JourneyReportGenerator(
-    private val chatClient: ChatClient
+    @Qualifier("bossChatClient") private val chatClient: ChatClient
 ) : JourneyReportPort {
 
     override fun generate(

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
@@ -7,11 +7,12 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
 @Component
 class MockInterviewEvaluator(
-    private val chatClient: ChatClient
+    @Qualifier("bossChatClient") private val chatClient: ChatClient
 ) : InterviewEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()

--- a/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
+++ b/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
@@ -7,3 +7,8 @@ spring:
           model: claude-haiku-4-5-20251001
           max-tokens: 2000
           temperature: 0.3
+
+devquest:
+  ai:
+    boss-model: claude-sonnet-4-5
+    boss-max-tokens: 4000

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -1,5 +1,6 @@
 package com.devquest.core.domain
 
+import com.devquest.core.domain.event.QuestEvaluatedEvent
 import com.devquest.core.domain.model.QuestHistory
 import com.devquest.core.domain.model.QuestProgress
 import com.devquest.core.domain.model.evaluation.*
@@ -7,8 +8,8 @@ import com.devquest.core.domain.port.*
 import com.devquest.core.enums.QuestStatus
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -29,9 +30,8 @@ class AiCheckService(
     private val historyPort: QuestHistoryPort,
     private val bossPackageEvaluator: BossPackageEvaluatorPort,
     private val journeyReportPort: JourneyReportPort,
+    private val publisher: ApplicationEventPublisher,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     @Value("\${devquest.ai.pass-score:70}")
     private val passScore: Int = 70
 
@@ -150,7 +150,6 @@ class AiCheckService(
         )
         progressPort.save(progress)
         saveHistory(userId, questId, actId, score, passed, xp)
-        log.info("Quest progress saved: userId=$userId, questId=$questId, score=$score, passed=$passed, xp=$xp")
     }
 
     private fun saveHistory(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
@@ -171,6 +170,16 @@ class AiCheckService(
             earnedXp = xp
         )
         historyPort.save(history)
-        log.info("Quest history saved: userId=$userId, questId=$questId, score=$score, grade=$grade, passed=$passed")
+        publisher.publishEvent(
+            QuestEvaluatedEvent(
+                userId = userId,
+                questId = questId,
+                actId = actId,
+                score = score,
+                grade = grade,
+                passed = passed,
+                earnedXp = xp,
+            )
+        )
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestAuditEventListener.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestAuditEventListener.kt
@@ -1,0 +1,20 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.event.QuestEvaluatedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class QuestAuditEventListener {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @EventListener
+    fun on(event: QuestEvaluatedEvent) {
+        log.info(
+            "Quest evaluated: userId={}, questId={}, score={}, grade={}, passed={}, xp={}",
+            event.userId, event.questId, event.score, event.grade, event.passed, event.earnedXp
+        )
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 
 @ExtendWith(MockitoExtension::class)
 class AiCheckServiceTest {
@@ -33,6 +34,7 @@ class AiCheckServiceTest {
     @Mock lateinit var historyPort: QuestHistoryPort
     @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
     @Mock lateinit var journeyReportPort: JourneyReportPort
+    @Mock lateinit var publisher: ApplicationEventPublisher
 
     @InjectMocks
     private lateinit var service: AiCheckService

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/event/QuestEvaluatedEvent.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/event/QuestEvaluatedEvent.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.domain.event
+
+data class QuestEvaluatedEvent(
+    val userId: String,
+    val questId: String,
+    val actId: Int,
+    val score: Int,
+    val grade: String,
+    val passed: Boolean,
+    val earnedXp: Int,
+)


### PR DESCRIPTION
## Summary
- `AiClientConfig`에 `bossChatClient` 빈 추가 (claude-sonnet-4-5, max-tokens 4000)
- BOSS Evaluator 4개(`CompanyFit`, `MockInterview`, `BossPackage`, `JourneyReport`)에 `@Qualifier("bossChatClient")` 주입
- 모델명/토큰 설정은 `client-ai-anthropic.yml`의 `devquest.ai.*`로 외부화

## Test plan
- [ ] BE CI 통과 확인
- [ ] 컴파일 에러 없음 확인