### PR TITLE
refactor(be): 감사 로그 이벤트화 (QuestEvaluatedEvent)

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -1,5 +1,6 @@
 package com.devquest.core.domain
 
+import com.devquest.core.domain.event.QuestEvaluatedEvent
 import com.devquest.core.domain.model.QuestHistory
 import com.devquest.core.domain.model.QuestProgress
 import com.devquest.core.domain.model.evaluation.*
@@ -9,6 +10,7 @@ import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -29,6 +31,7 @@ class AiCheckService(
     private val historyPort: QuestHistoryPort,
     private val bossPackageEvaluator: BossPackageEvaluatorPort,
     private val journeyReportPort: JourneyReportPort,
+    private val publisher: ApplicationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -150,7 +153,6 @@ class AiCheckService(
         )
         progressPort.save(progress)
         saveHistory(userId, questId, actId, score, passed, xp)
-        log.info("Quest progress saved: userId=$userId, questId=$questId, score=$score, passed=$passed, xp=$xp")
     }
 
     private fun saveHistory(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
@@ -171,6 +173,16 @@ class AiCheckService(
             earnedXp = xp
         )
         historyPort.save(history)
-        log.info("Quest history saved: userId=$userId, questId=$questId, score=$score, grade=$grade, passed=$passed")
+        publisher.publishEvent(
+            QuestEvaluatedEvent(
+                userId = userId,
+                questId = questId,
+                actId = actId,
+                score = score,
+                grade = grade,
+                passed = passed,
+                earnedXp = xp,
+            )
+        )
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestAuditEventListener.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestAuditEventListener.kt
@@ -1,0 +1,20 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.event.QuestEvaluatedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class QuestAuditEventListener {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @EventListener
+    fun on(event: QuestEvaluatedEvent) {
+        log.info(
+            "Quest evaluated: userId={}, questId={}, score={}, grade={}, passed={}, xp={}",
+            event.userId, event.questId, event.score, event.grade, event.passed, event.earnedXp
+        )
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 
 @ExtendWith(MockitoExtension::class)
 class AiCheckServiceTest {
@@ -33,6 +34,7 @@ class AiCheckServiceTest {
     @Mock lateinit var historyPort: QuestHistoryPort
     @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
     @Mock lateinit var journeyReportPort: JourneyReportPort
+    @Mock lateinit var publisher: ApplicationEventPublisher
 
     @InjectMocks
     private lateinit var service: AiCheckService

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/event/QuestEvaluatedEvent.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/event/QuestEvaluatedEvent.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.domain.event
+
+data class QuestEvaluatedEvent(
+    val userId: String,
+    val questId: String,
+    val actId: Int,
+    val score: Int,
+    val grade: String,
+    val passed: Boolean,
+    val earnedXp: Int,
+)


### PR DESCRIPTION
## Summary
- `QuestEvaluatedEvent` 도메인 이벤트 신규 (`core-domain/event/`, Spring 의존 없음)
- `AiCheckService`: `log.info` 직접 호출 제거, `ApplicationEventPublisher`로 이벤트 발행
- `QuestAuditEventListener` 신규: `@EventListener`로 이벤트 구독, 구조화된 로그 출력
- 비즈니스 로직과 로깅 관심사 분리 완료

## Test plan
- [ ] BE CI 통과 확인
- [ ] `AiCheckServiceTest` 전부 통과