### PR TITLE
test(be): Copilot 리뷰 follow-up — QuestXpPolicy 테스트 + 예외 처리 + publishEvent 검증

### DIFF
--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -92,6 +92,7 @@ class AiCheckServiceTest {
         assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
         assertThat(captor.firstValue.earnedXp).isEqualTo(500)
         assertThat(captor.firstValue.aiScore).isEqualTo(70)
+        verify(publisher).publishEvent(any<com.devquest.core.domain.event.QuestEvaluatedEvent>())
     }
 
     @Test
@@ -126,6 +127,7 @@ class AiCheckServiceTest {
         assertThat(captor.firstValue.earnedXp).isEqualTo(500)
         assertThat(captor.firstValue.aiScore).isEqualTo(85)
         assertThat(captor.firstValue.questId).isEqualTo("4-1")
+        verify(publisher).publishEvent(any<com.devquest.core.domain.event.QuestEvaluatedEvent>())
     }
 
     @Test

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/QuestXpPolicy.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/QuestXpPolicy.kt
@@ -21,7 +21,9 @@ object QuestXpPolicy {
 
     fun calculate(questId: String, passed: Boolean, score: Int = 0, xpMultiplier: Double = 1.0): Int {
         if (!passed) return 0
-        val base = baseXp[questId] ?: return 0
+        val base = requireNotNull(baseXp[questId]) {
+            "Unknown questId for XP policy: $questId"
+        }
         return when (questId) {
             "1-2" -> base * score / 100                          // score 비례
             "2-1", "2-3", "3-1", "5-1" -> (base * xpMultiplier).toInt()         // multiplier 적용

--- a/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/QuestXpPolicyTest.kt
+++ b/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/QuestXpPolicyTest.kt
@@ -1,0 +1,57 @@
+package com.devquest.core.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class QuestXpPolicyTest {
+
+    @Test
+    fun `passed=false이면 questId에 관계없이 0 반환`() {
+        assertThat(QuestXpPolicy.calculate("1-2", false, score = 80)).isEqualTo(0)
+        assertThat(QuestXpPolicy.calculate("2-1", false, xpMultiplier = 1.5)).isEqualTo(0)
+        assertThat(QuestXpPolicy.calculate("1-BOSS", false)).isEqualTo(0)
+    }
+
+    @Test
+    fun `1-2는 score 비례로 계산`() {
+        // baseXp["1-2"] = 200, score=80 → 200 * 80 / 100 = 160
+        val result = QuestXpPolicy.calculate("1-2", true, score = 80)
+        assertThat(result).isEqualTo(160)
+    }
+
+    @Test
+    fun `2-1은 xpMultiplier 적용`() {
+        // baseXp["2-1"] = 600, xpMultiplier=1.5 → (600 * 1.5).toInt() = 900
+        val result = QuestXpPolicy.calculate("2-1", true, xpMultiplier = 1.5)
+        assertThat(result).isEqualTo(900)
+    }
+
+    @Test
+    fun `5-1은 xpMultiplier 적용`() {
+        // baseXp["5-1"] = 400, xpMultiplier=1.2 → (400 * 1.2).toInt() = 480
+        val result = QuestXpPolicy.calculate("5-1", true, xpMultiplier = 1.2)
+        assertThat(result).isEqualTo(480)
+    }
+
+    @Test
+    fun `1-BOSS는 고정 XP 반환`() {
+        // baseXp["1-BOSS"] = 500
+        val result = QuestXpPolicy.calculate("1-BOSS", true)
+        assertThat(result).isEqualTo(500)
+    }
+
+    @Test
+    fun `4-BOSS는 고정 XP 반환`() {
+        // baseXp["4-BOSS"] = 700
+        val result = QuestXpPolicy.calculate("4-BOSS", true)
+        assertThat(result).isEqualTo(700)
+    }
+
+    @Test
+    fun `미등록 questId이면 IllegalArgumentException 발생`() {
+        assertThatThrownBy { QuestXpPolicy.calculate("unknown", true) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("unknown")
+    }
+}


### PR DESCRIPTION
## Summary
Copilot 리뷰 코멘트 반영 (PR #24, #25 머지 후 follow-up)

- `QuestXpPolicy`: 미등록 questId 조용한 0 반환 → `requireNotNull` 예외로 변경
- `QuestXpPolicyTest` 신규: 고정/score비례/multiplier/미등록 5개 케이스 단위 테스트
- `AiCheckServiceTest`: `publisher.publishEvent` 실제 호출 여부 검증 추가 (2개 케이스)

## Test plan
- [ ] BE CI 통과 확인
- [ ] `QuestXpPolicyTest` 전체 통과
- [ ] `AiCheckServiceTest` 전체 통과