### PR TITLE
refactor(be): DTO userId 제거 + SecurityContext 추출 + try-catch 정리

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/AiCheckController.kt
@@ -3,11 +3,9 @@ package com.devquest.core.api.controller.v1
 import com.devquest.core.api.controller.v1.request.*
 import com.devquest.core.domain.AiCheckService
 import com.devquest.core.domain.port.CompanyInfo
-import com.devquest.core.support.error.CoreException
-import com.devquest.core.support.error.ErrorType
 import com.devquest.core.support.response.ApiResponse
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -15,82 +13,68 @@ import org.springframework.web.bind.annotation.*
 class AiCheckController(
     private val aiCheckService: AiCheckService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
 
     @PostMapping("/skill-assessment")
-    fun checkSkillAssessment(@Valid @RequestBody request: SkillAssessmentRequestDto): ApiResponse<*> {
-        return try {
-            ApiResponse.success(aiCheckService.checkSkillAssessment(request.userId, request.skills, request.targetRole))
-        } catch (e: Exception) {
-            log.error("Skill assessment failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun checkSkillAssessment(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: SkillAssessmentRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(aiCheckService.checkSkillAssessment(userId, request.skills, request.targetRole))
     }
 
     @PostMapping("/career-essay")
-    fun checkCareerEssay(@Valid @RequestBody request: CareerEssayRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkCareerEssay(
-                request.userId, request.dissatisfactions, request.goals, request.fiveYearVision
-            )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Career essay check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun checkCareerEssay(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: CareerEssayRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkCareerEssay(userId, request.dissatisfactions, request.goals, request.fiveYearVision)
+        )
     }
 
     @PostMapping("/company-fit")
-    fun analyzeCompanyFit(@Valid @RequestBody request: CompanyFitRequestDto): ApiResponse<*> {
-        return try {
-            val companies = request.companies.map {
-                CompanyInfo(it.name, it.culture, it.techStack, it.size, it.description)
-            }
-            val result = aiCheckService.analyzeCompanyFit(request.userId, request.preferences, companies)
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Company fit analysis failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+    fun analyzeCompanyFit(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: CompanyFitRequestDto,
+    ): ApiResponse<*> {
+        val companies = request.companies.map {
+            CompanyInfo(it.name, it.culture, it.techStack, it.size, it.description)
         }
+        return ApiResponse.success(aiCheckService.analyzeCompanyFit(userId, request.preferences, companies))
     }
 
     @PostMapping("/tech-blog")
-    fun checkTechBlog(@Valid @RequestBody request: TechBlogRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkTechBlog(
-                request.userId, request.questId, request.techTopic, request.title, request.content
-            )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Tech blog check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun checkTechBlog(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: TechBlogRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkTechBlog(userId, request.questId, request.techTopic, request.title, request.content)
+        )
     }
 
     @PostMapping("/system-design")
-    fun checkSystemDesign(@Valid @RequestBody request: SystemDesignRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkSystemDesign(
-                request.userId, request.questId, request.problemStatement, request.architectureDescription, request.considerations
+    fun checkSystemDesign(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: SystemDesignRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkSystemDesign(
+                userId, request.questId, request.problemStatement, request.architectureDescription, request.considerations
             )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("System design check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        )
     }
 
     @PostMapping("/mock-interview")
-    fun checkMockInterview(@Valid @RequestBody request: MockInterviewRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkMockInterview(
-                request.userId, request.questId, request.category, request.question, request.answer, request.questionId
+    fun checkMockInterview(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: MockInterviewRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkMockInterview(
+                userId, request.questId, request.category, request.question, request.answer, request.questionId
             )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Mock interview check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        )
     }
 
     @GetMapping("/mock-interview/questions")
@@ -103,76 +87,66 @@ class AiCheckController(
     }
 
     @PostMapping("/jd-analysis")
-    fun analyzeJd(@Valid @RequestBody request: JdAnalysisRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.analyzeJd(
-                request.userId, request.companyName, request.jobDescription, request.userSkills, request.userExperiences
+    fun analyzeJd(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: JdAnalysisRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.analyzeJd(
+                userId, request.companyName, request.jobDescription, request.userSkills, request.userExperiences
             )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("JD analysis failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        )
     }
 
     @PostMapping("/resume")
-    fun checkResume(@Valid @RequestBody request: ResumeCheckRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkResume(
-                request.userId, request.targetCompany, request.targetJd, request.resumeContent
-            )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Resume check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun checkResume(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: ResumeCheckRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkResume(userId, request.targetCompany, request.targetJd, request.resumeContent)
+        )
     }
 
     @PostMapping("/personality-interview")
-    fun checkPersonalityInterview(@Valid @RequestBody request: PersonalityInterviewRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkPersonalityInterview(
-                request.userId, request.question, request.answer
-            )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Personality interview check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun checkPersonalityInterview(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: PersonalityInterviewRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkPersonalityInterview(userId, request.question, request.answer)
+        )
     }
 
     @PostMapping("/boss-package")
-    fun checkBossPackage(@Valid @RequestBody request: BossPackageRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.checkBossPackage(
-                request.userId, request.resumeContent, request.githubUrl, request.blogUrl, request.targetPosition
+    fun checkBossPackage(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: BossPackageRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.checkBossPackage(
+                userId, request.resumeContent, request.githubUrl, request.blogUrl, request.targetPosition
             )
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Boss package check failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        )
     }
 
     @PostMapping("/journey-report")
-    fun generateJourneyReport(@Valid @RequestBody request: JourneyReportRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.generateJourneyReport(request.userId, request.companyName, request.targetPosition)
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Journey report generation failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun generateJourneyReport(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: JourneyReportRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.generateJourneyReport(userId, request.companyName, request.targetPosition)
+        )
     }
 
     @PostMapping("/act-clear-report")
-    fun generateActClearReport(@Valid @RequestBody request: ActClearReportRequestDto): ApiResponse<*> {
-        return try {
-            val result = aiCheckService.generateActClearReport(request.userId, request.actId, request.actTitle)
-            ApiResponse.success(result)
-        } catch (e: Exception) {
-            log.error("Act clear report generation failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+    fun generateActClearReport(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: ActClearReportRequestDto,
+    ): ApiResponse<*> {
+        return ApiResponse.success(
+            aiCheckService.generateActClearReport(userId, request.actId, request.actTitle)
+        )
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/InterviewCoachController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/InterviewCoachController.kt
@@ -5,11 +5,8 @@ import com.devquest.core.api.controller.v1.request.CoachReportRequestDto
 import com.devquest.core.api.controller.v1.request.CoachSessionStartRequestDto
 import com.devquest.core.domain.InterviewCoachService
 import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
-import com.devquest.core.support.error.CoreException
-import com.devquest.core.support.error.ErrorType
 import com.devquest.core.support.response.ApiResponse
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,47 +17,30 @@ import org.springframework.web.bind.annotation.RestController
 class InterviewCoachController(
     private val interviewCoachService: InterviewCoachService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     @PostMapping("/session/start")
     fun startSession(@Valid @RequestBody request: CoachSessionStartRequestDto): ApiResponse<*> {
-        return try {
-            ApiResponse.success(interviewCoachService.startSession(request.jdText, request.targetRole))
-        } catch (e: Exception) {
-            log.error("Interview coach session start failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        return ApiResponse.success(interviewCoachService.startSession(request.jdText, request.targetRole))
     }
 
     @PostMapping("/session/answer")
     fun submitAnswer(@Valid @RequestBody request: CoachAnswerRequestDto): ApiResponse<*> {
-        return try {
-            ApiResponse.success(
-                interviewCoachService.evaluateAnswer(
-                    request.question,
-                    request.answer,
-                    request.questionIndex,
-                    request.totalQuestions,
-                )
+        return ApiResponse.success(
+            interviewCoachService.evaluateAnswer(
+                request.question,
+                request.answer,
+                request.questionIndex,
+                request.totalQuestions,
             )
-        } catch (e: Exception) {
-            log.error("Interview coach answer evaluation failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-        }
+        )
     }
 
     @PostMapping("/session/report")
     fun generateReport(@Valid @RequestBody request: CoachReportRequestDto): ApiResponse<*> {
-        return try {
-            val answers = request.answers.map {
-                CoachAnswerHistory(question = it.question, answer = it.answer, feedback = it.feedback)
-            }
-            ApiResponse.success(
-                interviewCoachService.generateReport(request.targetRole, request.jdSummary, answers)
-            )
-        } catch (e: Exception) {
-            log.error("Interview coach report generation failed", e)
-            throw CoreException(ErrorType.AI_EVALUATION_FAILED)
+        val answers = request.answers.map {
+            CoachAnswerHistory(question = it.question, answer = it.answer, feedback = it.feedback)
         }
+        return ApiResponse.success(
+            interviewCoachService.generateReport(request.targetRole, request.jdSummary, answers)
+        )
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ProgressController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ProgressController.kt
@@ -6,12 +6,12 @@ import com.devquest.core.domain.ProgressService
 import com.devquest.core.domain.model.ProgressResult
 import com.devquest.core.support.response.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -19,26 +19,29 @@ import org.springframework.web.bind.annotation.RestController
 class ProgressController(
     private val progressService: ProgressService
 ) {
-    @GetMapping("/{userId}")
-    fun getProgress(@PathVariable userId: String): ApiResponse<ProgressResult> {
+    @GetMapping
+    fun getProgress(@AuthenticationPrincipal userId: String): ApiResponse<ProgressResult> {
         return ApiResponse.success(progressService.getProgress(userId))
     }
 
     @PostMapping("/complete")
-    fun completeQuest(@Valid @RequestBody request: QuestCompleteRequestDto): ApiResponse<Unit> {
-        progressService.completeQuest(request.userId, request.questId, request.actId, request.earnedXp)
+    fun completeQuest(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: QuestCompleteRequestDto,
+    ): ApiResponse<Unit> {
+        progressService.completeQuest(userId, request.questId, request.actId, request.earnedXp)
         return ApiResponse.success(Unit)
     }
 
     @GetMapping("/history")
-    fun getHistory(@RequestParam userId: String): ApiResponse<List<QuestHistoryResponseDto>> {
+    fun getHistory(@AuthenticationPrincipal userId: String): ApiResponse<List<QuestHistoryResponseDto>> {
         return ApiResponse.success(progressService.getHistory(userId).map { QuestHistoryResponseDto.from(it) })
     }
 
     @GetMapping("/history/{questId}")
     fun getQuestHistory(
+        @AuthenticationPrincipal userId: String,
         @PathVariable questId: String,
-        @RequestParam userId: String
     ): ApiResponse<List<QuestHistoryResponseDto>> {
         return ApiResponse.success(progressService.getQuestHistory(userId, questId).map { QuestHistoryResponseDto.from(it) })
     }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ActClearReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ActClearReportRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 
 data class ActClearReportRequestDto(
-    @field:NotBlank val userId: String,
     @field:Positive val actId: Int,
     @field:NotBlank val actTitle: String,
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/BossPackageRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/BossPackageRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class BossPackageRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val resumeContent: String = "",
     @field:NotBlank val githubUrl: String = "",
     @field:NotBlank val targetPosition: String = "",

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CareerEssayRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CareerEssayRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class CareerEssayRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:Size(min = 3, max = 5) val dissatisfactions: List<String> = emptyList(),
     @field:Size(min = 3, max = 5) val goals: List<String> = emptyList(),
     @field:NotBlank val fiveYearVision: String = ""

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachAnswerRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachAnswerRequestDto.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 
 data class CoachAnswerRequestDto(
-    @field:NotBlank val userId: String,
     @field:NotBlank val question: String,
     @field:NotBlank val answer: String,
     @field:Min(0) val questionIndex: Int,

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachReportRequestDto.kt
@@ -10,7 +10,6 @@ data class CoachAnswerHistoryDto(
 )
 
 data class CoachReportRequestDto(
-    @field:NotBlank val userId: String,
     @field:NotBlank val targetRole: String,
     @field:NotBlank val jdSummary: String,
     @field:Size(min = 1, max = 10) val answers: List<CoachAnswerHistoryDto>,

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachSessionStartRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CoachSessionStartRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class CoachSessionStartRequestDto(
-    @field:NotBlank val userId: String,
     @field:NotBlank @field:Size(min = 10, max = 5000) val jdText: String,
     @field:NotBlank val targetRole: String,
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CompanyFitRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CompanyFitRequestDto.kt
@@ -1,6 +1,5 @@
 package com.devquest.core.api.controller.v1.request
 
-import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class CompanyInfoDto(
@@ -12,7 +11,6 @@ data class CompanyInfoDto(
 )
 
 data class CompanyFitRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:Size(min = 1) val preferences: Map<String, String> = emptyMap(),
     @field:Size(min = 1) val companies: List<CompanyInfoDto> = emptyList()
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JdAnalysisRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JdAnalysisRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class JdAnalysisRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val companyName: String = "",
     @field:NotBlank val jobDescription: String = "",
     @field:Size(min = 1) val userSkills: List<String> = emptyList(),

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JourneyReportRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/JourneyReportRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class JourneyReportRequestDto(
-    @field:NotBlank val userId: String,
     @field:NotBlank val companyName: String,
     @field:NotBlank val targetPosition: String,
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/MockInterviewRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/MockInterviewRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class MockInterviewRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val questId: String = "",
     @field:NotBlank val questionId: String = "",
     @field:NotBlank val question: String = "",

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/PersonalityInterviewRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/PersonalityInterviewRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class PersonalityInterviewRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val question: String = "",
     @field:NotBlank val answer: String = ""
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/QuestCompleteRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/QuestCompleteRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 
 data class QuestCompleteRequestDto(
-    @field:NotBlank val userId: String,
     @field:NotBlank val questId: String,
     @field:Positive val actId: Int,
     @field:Positive val earnedXp: Int,

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ResumeCheckRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ResumeCheckRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class ResumeCheckRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val targetCompany: String = "",
     @field:NotBlank val targetJd: String = "",
     @field:NotBlank val resumeContent: String = ""

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/SkillAssessmentRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/SkillAssessmentRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class SkillAssessmentRequestDto(
-    @field:NotBlank val userId: String,
     @field:Size(min = 1, max = 10) val skills: List<String>,
     @field:NotBlank val targetRole: String,
 )

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/SystemDesignRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/SystemDesignRequestDto.kt
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class SystemDesignRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val questId: String = "",
     @field:NotBlank val problemStatement: String = "",
     @field:NotBlank val architectureDescription: String = "",

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/TechBlogRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/TechBlogRequestDto.kt
@@ -3,7 +3,6 @@ package com.devquest.core.api.controller.v1.request
 import jakarta.validation.constraints.NotBlank
 
 data class TechBlogRequestDto(
-    @field:NotBlank val userId: String = "",
     @field:NotBlank val questId: String = "",
     @field:NotBlank val techTopic: String = "",
     @field:NotBlank val title: String = "",

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/AiCheckControllerTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/AiCheckControllerTest.kt
@@ -4,6 +4,7 @@ import com.devquest.core.api.controller.ApiControllerAdvice
 import com.devquest.core.domain.AiCheckService
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.support.AiEvaluationException
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -12,6 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -27,10 +31,18 @@ class AiCheckControllerTest {
 
     @BeforeEach
     fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("user-1", null, emptyList())
         mockMvc = MockMvcBuilders
             .standaloneSetup(AiCheckController(aiCheckService))
             .setControllerAdvice(ApiControllerAdvice())
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
             .build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
     }
 
     // ===== /career-essay =====
@@ -44,7 +56,6 @@ class AiCheckControllerTest {
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                  "userId": "user-1",
                   "dissatisfactions": ["불만1", "불만2", "불만3"],
                   "goals": ["목표1", "목표2", "목표3"],
                   "fiveYearVision": "5년 후 CTO"
@@ -59,31 +70,11 @@ class AiCheckControllerTest {
     }
 
     @Test
-    fun `career-essay - userId 없으면 400 INVALID_REQUEST 반환`() {
-        mockMvc.post("/api/v1/ai-check/career-essay") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                  "userId": "",
-                  "dissatisfactions": ["불만1", "불만2", "불만3"],
-                  "goals": ["목표1", "목표2", "목표3"],
-                  "fiveYearVision": "5년 후 CTO"
-                }
-            """.trimIndent()
-        }.andExpect {
-            status { isBadRequest() }
-            jsonPath("$.result") { value("ERROR") }
-            jsonPath("$.error.code") { value("INVALID_REQUEST") }
-        }
-    }
-
-    @Test
     fun `career-essay - dissatisfactions 항목 수 부족 시 400 반환`() {
         mockMvc.post("/api/v1/ai-check/career-essay") {
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                  "userId": "user-1",
                   "dissatisfactions": ["불만1"],
                   "goals": ["목표1", "목표2", "목표3"],
                   "fiveYearVision": "5년 후 CTO"
@@ -115,7 +106,6 @@ class AiCheckControllerTest {
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                  "userId": "user-1",
                   "dissatisfactions": ["불만1", "불만2", "불만3"],
                   "goals": ["목표1", "목표2", "목표3"],
                   "fiveYearVision": "5년 후 CTO"
@@ -124,17 +114,6 @@ class AiCheckControllerTest {
         }.andExpect {
             status { isInternalServerError() }
             jsonPath("$.error.code") { value("AI_EVALUATION_FAILED") }
-        }
-    }
-
-    @Test
-    fun `career-essay - userId 필드 자체가 없으면 400 반환`() {
-        mockMvc.post("/api/v1/ai-check/career-essay") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """{"dissatisfactions":["불만1","불만2","불만3"],"goals":["목표1","목표2","목표3"],"fiveYearVision":"비전"}"""
-        }.andExpect {
-            status { isBadRequest() }
-            jsonPath("$.error.code") { value("INVALID_REQUEST") }
         }
     }
 
@@ -149,7 +128,6 @@ class AiCheckControllerTest {
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                  "userId": "user-1",
                   "preferences": {"culture": "수평적"},
                   "companies": [{"name":"카카오","culture":"수평","techStack":["Kotlin"],"size":"대기업","description":"카카오"}]
                 }
@@ -162,21 +140,10 @@ class AiCheckControllerTest {
     }
 
     @Test
-    fun `company-fit - userId 빈값이면 400 반환`() {
-        mockMvc.post("/api/v1/ai-check/company-fit") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"","preferences":{"culture":"수평"},"companies":[{"name":"A","culture":"","techStack":[],"size":"","description":""}]}"""
-        }.andExpect {
-            status { isBadRequest() }
-            jsonPath("$.error.code") { value("INVALID_REQUEST") }
-        }
-    }
-
-    @Test
     fun `company-fit - companies 빈 목록이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/company-fit") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","preferences":{"culture":"수평"},"companies":[]}"""
+            content = """{"preferences":{"culture":"수평"},"companies":[]}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -192,7 +159,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/tech-blog") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"2-1","techTopic":"Kotlin","title":"코루틴","content":"내용"}"""
+            content = """{"questId":"2-1","techTopic":"Kotlin","title":"코루틴","content":"내용"}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -204,7 +171,7 @@ class AiCheckControllerTest {
     fun `tech-blog - questId 빈값이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/tech-blog") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"","techTopic":"Kotlin","title":"코루틴","content":"내용"}"""
+            content = """{"questId":"","techTopic":"Kotlin","title":"코루틴","content":"내용"}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -220,7 +187,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/system-design") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"2-2","problemStatement":"문제","architectureDescription":"설계","considerations":["확장성"]}"""
+            content = """{"questId":"2-2","problemStatement":"문제","architectureDescription":"설계","considerations":["확장성"]}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -231,7 +198,7 @@ class AiCheckControllerTest {
     fun `system-design - considerations 빈 목록이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/system-design") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"2-2","problemStatement":"문제","architectureDescription":"설계","considerations":[]}"""
+            content = """{"questId":"2-2","problemStatement":"문제","architectureDescription":"설계","considerations":[]}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -247,7 +214,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/mock-interview") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"2-3","questionId":"q-1","question":"JVM이란?","answer":"JVM은...","category":"JVM"}"""
+            content = """{"questId":"2-3","questionId":"q-1","question":"JVM이란?","answer":"JVM은...","category":"JVM"}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -259,7 +226,7 @@ class AiCheckControllerTest {
     fun `mock-interview - answer 빈값이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/mock-interview") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"2-3","questionId":"q-1","question":"JVM이란?","answer":"","category":"JVM"}"""
+            content = """{"questId":"2-3","questionId":"q-1","question":"JVM이란?","answer":"","category":"JVM"}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -290,7 +257,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/jd-analysis") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","companyName":"카카오","jobDescription":"JD 내용","userSkills":["Kotlin"],"userExperiences":["3년 경력"]}"""
+            content = """{"companyName":"카카오","jobDescription":"JD 내용","userSkills":["Kotlin"],"userExperiences":["3년 경력"]}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -302,7 +269,7 @@ class AiCheckControllerTest {
     fun `jd-analysis - userSkills 빈 목록이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/jd-analysis") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","companyName":"카카오","jobDescription":"JD 내용","userSkills":[],"userExperiences":["3년"]}"""
+            content = """{"companyName":"카카오","jobDescription":"JD 내용","userSkills":[],"userExperiences":["3년"]}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -318,7 +285,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/resume") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","targetCompany":"카카오","targetJd":"JD","resumeContent":"이력서"}"""
+            content = """{"targetCompany":"카카오","targetJd":"JD","resumeContent":"이력서"}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -330,7 +297,7 @@ class AiCheckControllerTest {
     fun `resume - resumeContent 빈값이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/resume") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","targetCompany":"카카오","targetJd":"JD","resumeContent":""}"""
+            content = """{"targetCompany":"카카오","targetJd":"JD","resumeContent":""}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }
@@ -346,7 +313,7 @@ class AiCheckControllerTest {
 
         mockMvc.post("/api/v1/ai-check/personality-interview") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","question":"장단점은?","answer":"저는..."}"""
+            content = """{"question":"장단점은?","answer":"저는..."}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
@@ -358,7 +325,7 @@ class AiCheckControllerTest {
     fun `personality-interview - question 빈값이면 400 반환`() {
         mockMvc.post("/api/v1/ai-check/personality-interview") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","question":"","answer":"저는..."}"""
+            content = """{"question":"","answer":"저는..."}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.error.code") { value("INVALID_REQUEST") }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ProgressControllerTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ProgressControllerTest.kt
@@ -3,6 +3,7 @@ package com.devquest.core.api.controller.v1
 import com.devquest.core.api.controller.ApiControllerAdvice
 import com.devquest.core.domain.ProgressService
 import com.devquest.core.domain.model.ProgressResult
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -11,6 +12,9 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -26,10 +30,18 @@ class ProgressControllerTest {
 
     @BeforeEach
     fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("user-1", null, emptyList())
         mockMvc = MockMvcBuilders
             .standaloneSetup(ProgressController(progressService))
             .setControllerAdvice(ApiControllerAdvice())
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
             .build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
     }
 
     @Test
@@ -44,7 +56,7 @@ class ProgressControllerTest {
             )
         )
 
-        mockMvc.get("/api/v1/progress/user-1")
+        mockMvc.get("/api/v1/progress")
             .andExpect {
                 status { isOk() }
                 jsonPath("$.result") { value("SUCCESS") }
@@ -56,9 +68,9 @@ class ProgressControllerTest {
 
     @Test
     fun `getProgress - 진행 내역 없는 유저도 200과 빈 결과 반환`() {
-        whenever(progressService.getProgress("unknown")).thenReturn(
+        whenever(progressService.getProgress("user-1")).thenReturn(
             ProgressResult(
-                userId = "unknown",
+                userId = "user-1",
                 totalXp = 0,
                 level = 1,
                 completedQuests = emptyList(),
@@ -66,7 +78,7 @@ class ProgressControllerTest {
             )
         )
 
-        mockMvc.get("/api/v1/progress/unknown")
+        mockMvc.get("/api/v1/progress")
             .andExpect {
                 status { isOk() }
                 jsonPath("$.result") { value("SUCCESS") }
@@ -79,22 +91,12 @@ class ProgressControllerTest {
     fun `completeQuest - 정상 요청이면 200과 SUCCESS 반환`() {
         mockMvc.post("/api/v1/progress/complete") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user-1","questId":"1-1","actId":1,"earnedXp":100}"""
+            content = """{"questId":"1-1","actId":1,"earnedXp":100}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.result") { value("SUCCESS") }
         }
 
         verify(progressService).completeQuest("user-1", "1-1", 1, 100)
-    }
-
-    @Test
-    fun `completeQuest - userId 누락이면 400 반환`() {
-        mockMvc.post("/api/v1/progress/complete") {
-            contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"","questId":"1-1","actId":1,"earnedXp":100}"""
-        }.andExpect {
-            status { isBadRequest() }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Request DTO 16개에서 `userId` 필드 제거
- Controller 3개에서 `@AuthenticationPrincipal userId: String`으로 교체
- AiCheckController try-catch 11개 제거 (ApiControllerAdvice가 처리)
- InterviewCoachController try-catch 3개 제거
- ProgressController PathVariable/RequestParam userId → @AuthenticationPrincipal

## Test plan
- [ ] BE CI 통과
- [ ] 인증 없이 요청 시 401 반환
- [ ] JWT 포함 요청 시 정상 동작