### PR TITLE
refactor(be): PassCriteriaPolicy + GradePolicy 추출

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -5,11 +5,12 @@ import com.devquest.core.domain.model.QuestHistory
 import com.devquest.core.domain.model.QuestProgress
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.port.*
+import com.devquest.core.domain.GradePolicy
+import com.devquest.core.domain.PassCriteriaPolicy
 import com.devquest.core.domain.QuestXpPolicy
 import com.devquest.core.enums.QuestStatus
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -33,9 +34,6 @@ class AiCheckService(
     private val journeyReportPort: JourneyReportPort,
     private val publisher: ApplicationEventPublisher,
 ) {
-    @Value("\${devquest.ai.pass-score:70}")
-    private val passScore: Int = 70
-
     @Transactional
     fun checkSkillAssessment(userId: String, skills: List<String>, targetRole: String): SkillAssessmentResult {
         val result = skillAssessmentPort.evaluate(skills, targetRole)
@@ -89,7 +87,7 @@ class AiCheckService(
     @Transactional
     fun checkResume(userId: String, targetCompany: String, targetJd: String, resumeContent: String): ResumeCheckResult {
         val result = resumeEvaluator.evaluate(targetCompany, targetJd, resumeContent)
-        val passed = result.overallScore >= passScore
+        val passed = PassCriteriaPolicy.evaluate(result.overallScore)
         saveProgress(userId, "4-1", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-1", passed))
         return result
     }
@@ -98,7 +96,7 @@ class AiCheckService(
     fun analyzeCompanyFit(userId: String, preferences: Map<String, String>, companies: List<CompanyInfo>): List<CompanyFitResult> {
         val result = companyFitEvaluator.analyze(preferences, companies)
         val maxScore = result.maxOfOrNull { it.fitScore } ?: 0
-        val passed = result.isNotEmpty() && maxScore >= passScore
+        val passed = PassCriteriaPolicy.evaluateMax(result.map { it.fitScore })
         saveProgress(userId, "1-BOSS", 1, maxScore, passed, QuestXpPolicy.calculate("1-BOSS", passed))
         return result
     }
@@ -113,7 +111,7 @@ class AiCheckService(
     @Transactional
     fun checkBossPackage(userId: String, resumeContent: String, githubUrl: String, blogUrl: String, targetPosition: String): BossPackageResult {
         val result = bossPackageEvaluator.evaluate(resumeContent, githubUrl, blogUrl, targetPosition)
-        val passed = result.overallScore >= passScore
+        val passed = PassCriteriaPolicy.evaluate(result.overallScore)
         saveProgress(userId, "4-BOSS", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-BOSS", passed))
         return result
     }
@@ -153,13 +151,7 @@ class AiCheckService(
     }
 
     private fun saveHistory(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
-        val grade = when {
-            score >= 90 -> "S"
-            score >= 80 -> "A"
-            score >= 70 -> "B"
-            score >= 60 -> "C"
-            else -> "D"
-        }
+        val grade = GradePolicy.from(score)
         val history = QuestHistory(
             userId = userId,
             questId = questId,

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/GradePolicy.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/GradePolicy.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain
+
+object GradePolicy {
+
+    fun from(score: Int): String = when {
+        score >= 90 -> "S"
+        score >= 80 -> "A"
+        score >= 70 -> "B"
+        score >= 60 -> "C"
+        else -> "D"
+    }
+}

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/PassCriteriaPolicy.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/PassCriteriaPolicy.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain
+
+object PassCriteriaPolicy {
+
+    private const val DEFAULT_PASS_SCORE = 70
+
+    fun evaluate(score: Int, passScore: Int = DEFAULT_PASS_SCORE): Boolean =
+        score >= passScore
+
+    fun evaluateMax(scores: List<Int>, passScore: Int = DEFAULT_PASS_SCORE): Boolean =
+        scores.isNotEmpty() && scores.max() >= passScore
+}

--- a/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/GradePolicyTest.kt
+++ b/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/GradePolicyTest.kt
@@ -1,0 +1,28 @@
+package com.devquest.core.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GradePolicyTest {
+
+    @Test
+    fun `일반 점수 등급 변환`() {
+        assertThat(GradePolicy.from(90)).isEqualTo("S")
+        assertThat(GradePolicy.from(85)).isEqualTo("A")
+        assertThat(GradePolicy.from(75)).isEqualTo("B")
+        assertThat(GradePolicy.from(65)).isEqualTo("C")
+        assertThat(GradePolicy.from(50)).isEqualTo("D")
+    }
+
+    @Test
+    fun `경계값 등급 변환`() {
+        assertThat(GradePolicy.from(90)).isEqualTo("S")
+        assertThat(GradePolicy.from(89)).isEqualTo("A")
+        assertThat(GradePolicy.from(80)).isEqualTo("A")
+        assertThat(GradePolicy.from(79)).isEqualTo("B")
+        assertThat(GradePolicy.from(70)).isEqualTo("B")
+        assertThat(GradePolicy.from(69)).isEqualTo("C")
+        assertThat(GradePolicy.from(60)).isEqualTo("C")
+        assertThat(GradePolicy.from(59)).isEqualTo("D")
+    }
+}

--- a/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/PassCriteriaPolicyTest.kt
+++ b/be/core/core-domain/src/test/kotlin/com/devquest/core/domain/PassCriteriaPolicyTest.kt
@@ -1,0 +1,42 @@
+package com.devquest.core.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PassCriteriaPolicyTest {
+
+    @Test
+    fun `evaluate - score 70 이상이면 true`() {
+        assertThat(PassCriteriaPolicy.evaluate(70)).isTrue()
+        assertThat(PassCriteriaPolicy.evaluate(85)).isTrue()
+        assertThat(PassCriteriaPolicy.evaluate(100)).isTrue()
+    }
+
+    @Test
+    fun `evaluate - score 70 미만이면 false`() {
+        assertThat(PassCriteriaPolicy.evaluate(69)).isFalse()
+        assertThat(PassCriteriaPolicy.evaluate(0)).isFalse()
+    }
+
+    @Test
+    fun `evaluate - 커스텀 passScore 적용`() {
+        assertThat(PassCriteriaPolicy.evaluate(80, passScore = 80)).isTrue()
+        assertThat(PassCriteriaPolicy.evaluate(79, passScore = 80)).isFalse()
+    }
+
+    @Test
+    fun `evaluateMax - 빈 리스트는 false`() {
+        assertThat(PassCriteriaPolicy.evaluateMax(emptyList())).isFalse()
+    }
+
+    @Test
+    fun `evaluateMax - 최대값이 70 이상이면 true`() {
+        assertThat(PassCriteriaPolicy.evaluateMax(listOf(50, 70, 60))).isTrue()
+        assertThat(PassCriteriaPolicy.evaluateMax(listOf(90))).isTrue()
+    }
+
+    @Test
+    fun `evaluateMax - 최대값이 70 미만이면 false`() {
+        assertThat(PassCriteriaPolicy.evaluateMax(listOf(50, 60, 65))).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- `PassCriteriaPolicy` object 신규: passScore 기준 합격 판단 중앙화
- `GradePolicy` object 신규: score → 등급(S/A/B/C/D) 변환 중앙화
- `AiCheckService`: 인라인 passScore 비교 3곳 → policy 위임, grade 계산 → policy 위임
- `@Value passScore` 필드 제거

## Test plan
- [ ] BE CI 통과
- [ ] PassCriteriaPolicyTest 전체 통과
- [ ] GradePolicyTest 전체 통과