### PR TITLE
fix(fe): correct auth callback response field check

### DIFF
--- a/fe/src/features/auth/components/AuthCallback.tsx
+++ b/fe/src/features/auth/components/AuthCallback.tsx
@@ -13,7 +13,7 @@ export function AuthCallback() {
     })
       .then((res) => res.json())
       .then((json) => {
-        if (json.success && json.data?.token) {
+        if (json.result === 'SUCCESS' && json.data?.token) {
           setToken(json.data.token)
           window.location.href = '/'
         }


### PR DESCRIPTION
## Summary
- BE 응답은 `result: "SUCCESS"` 형식인데 FE가 `json.success`를 체크하고 있어 로그인 후 항상 리다이렉트 실패
- `json.success` → `json.result === 'SUCCESS'` 로 수정

## Test plan
- [ ] GitHub OAuth 로그인 시도 → 인증 후 홈 화면으로 정상 이동 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)