### PR TITLE
fix(chore): trigger copilot review gate only on review events

### DIFF
--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   respond-to-copilot:
-    if: github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+    if: contains(github.event.review.user.login, 'copilot-pull-request-reviewer')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -1,6 +1,8 @@
 name: Copilot Review Gate
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
   pull_request_review_comment:
@@ -8,9 +10,6 @@ on:
 
 jobs:
   check-copilot-review:
-    if: |
-      (github.event_name == 'pull_request_review' && contains(github.event.review.user.login, 'copilot-pull-request-reviewer')) ||
-      github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -36,7 +35,7 @@ jobs:
             );
 
             if (copilotReviews.length === 0) {
-              core.notice('Copilot 리뷰 없음 — 통과');
+              core.setFailed('Copilot 리뷰 대기 중 — 리뷰가 달리면 자동으로 재평가됩니다.');
               return;
             }
 

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -1,8 +1,6 @@
 name: Copilot Review Gate
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
 

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -3,9 +3,14 @@ name: Copilot Review Gate
 on:
   pull_request_review:
     types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   check-copilot-review:
+    if: |
+      (github.event_name == 'pull_request_review' && contains(github.event.review.user.login, 'copilot-pull-request-reviewer')) ||
+      github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -17,7 +22,8 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request?.number
-              ?? context.payload.review?.pull_request_url?.split('/').pop();
+              ?? context.payload.review?.pull_request_url?.split('/').pop()
+              ?? context.payload.comment?.pull_request_url?.split('/').pop();
 
             // 1. Copilot이 리뷰를 달았는지 확인
             const reviews = await github.paginate(


### PR DESCRIPTION
## Summary
- `pull_request` 트리거(`opened`, `synchronize`, `reopened`) 제거
- Copilot 리뷰가 달리기 전 PR 오픈/업데이트 시 무조건 pass되던 문제 수정
- 이제 `pull_request_review` 이벤트(`submitted`, `dismissed`)에서만 체크

## Test plan
- [ ] PR 오픈 시 체크가 실행되지 않음 확인
- [ ] Copilot 리뷰 제출 시 미처리 코멘트 있으면 fail 확인
- [ ] 모든 코멘트에 답글 달면 pass 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)