### PR TITLE
fix(chore): fix YAML parse error in claude-review-responder

### DIFF
--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -2,8 +2,8 @@ name: Claude Review Responder
 
 on:
   schedule:
-    - cron: '*/15 * * * *'  # 15분마다 실행 — github-actions[bot] (신뢰된 액터)
-  workflow_dispatch:          # 수동 실행용
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
 
 jobs:
   respond-to-copilot:
@@ -19,7 +19,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           script: |
-            // 오픈 PR 전체 조회
             const openPRs = await github.paginate(
               github.rest.pulls.list,
               { owner: context.repo.owner, repo: context.repo.repo, state: 'open' }
@@ -30,7 +29,6 @@ jobs:
             for (const pr of openPRs) {
               const prNumber = pr.number;
 
-              // Copilot 리뷰 존재 여부 확인
               const reviews = await github.paginate(
                 github.rest.pulls.listReviews,
                 { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
@@ -42,7 +40,6 @@ jobs:
 
               if (copilotReviews.length === 0) continue;
 
-              // 전체 인라인 코멘트 수집
               const allComments = await github.paginate(
                 github.rest.pulls.listReviewComments,
                 { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
@@ -50,12 +47,10 @@ jobs:
 
               const copilotReviewIds = new Set(copilotReviews.map(r => r.id));
 
-              // Copilot 최상위 코멘트 (답글 아닌 것)
               const copilotTopComments = allComments.filter(c =>
                 copilotReviewIds.has(c.pull_request_review_id) && !c.in_reply_to_id
               );
 
-              // 이미 답글 달린 코멘트 제외
               const repliedIds = new Set(
                 allComments.filter(c => c.in_reply_to_id).map(c => c.in_reply_to_id)
               );
@@ -69,31 +64,33 @@ jobs:
               let repliedCount = 0;
 
               for (const comment of unreplied) {
-                const prompt = `당신은 Spring Boot(Kotlin) + React(TypeScript) 풀스택 프로젝트의 코드 리뷰 보조자입니다.
-
-GitHub Copilot이 PR에 인라인 리뷰 코멘트를 달았습니다.
-이 코멘트의 타당성을 판단하고 수용 또는 거부를 결정해 주세요.
-
-**PR 제목:** ${pr.title}
-**파일:** ${comment.path}
-**코드 컨텍스트 (diff):**
-\`\`\`diff
-${comment.diff_hunk}
-\`\`\`
-
-**Copilot 코멘트:**
-${comment.body}
-
----
-다음 형식으로 한국어로 답변해 주세요. 격식 없이 자연스럽게 말하듯 작성해 주세요.
-
-수용인 경우:
-"이건 (이유)로 타당합니다. 수정하는 걸 권장드립니다."
-
-거부인 경우:
-"이건 (이유)로 타당하지 않습니다. 수정하지 않아도 됩니다."
-
-이유는 1~2문장으로 간결하게. 앞뒤 장식 없이 위 문장 형식만 출력해.`;
+                const prompt = [
+                  '당신은 Spring Boot(Kotlin) + React(TypeScript) 풀스택 프로젝트의 코드 리뷰 보조자입니다.',
+                  '',
+                  'GitHub Copilot이 PR에 인라인 리뷰 코멘트를 달았습니다.',
+                  '이 코멘트의 타당성을 판단하고 수용 또는 거부를 결정해 주세요.',
+                  '',
+                  `**PR 제목:** ${pr.title}`,
+                  `**파일:** ${comment.path}`,
+                  '**코드 컨텍스트 (diff):**',
+                  '```diff',
+                  comment.diff_hunk,
+                  '```',
+                  '',
+                  '**Copilot 코멘트:**',
+                  comment.body,
+                  '',
+                  '---',
+                  '다음 형식으로 한국어로 답변해 주세요. 격식 없이 자연스럽게 말하듯 작성해 주세요.',
+                  '',
+                  '수용인 경우:',
+                  '"이건 (이유)로 타당합니다. 수정하는 걸 권장드립니다."',
+                  '',
+                  '거부인 경우:',
+                  '"이건 (이유)로 타당하지 않습니다. 수정하지 않아도 됩니다."',
+                  '',
+                  '이유는 1~2문장으로 간결하게. 앞뒤 장식 없이 위 문장 형식만 출력해.',
+                ].join('\n');
 
                 try {
                   const res = await fetch('https://api.anthropic.com/v1/messages', {
@@ -134,7 +131,6 @@ ${comment.body}
                 }
               }
 
-              // 답글을 달았으면 Gate 재실행 (workflow_dispatch — 신뢰된 액터)
               if (repliedCount > 0) {
                 try {
                   await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
## 문제

`claude-review-responder.yml`이 항상 `event: push, jobs: 0, conclusion: failure` 로 실패하고 있었음.

**원인**: YAML `script: |` 블록 스칼라 안에서 JavaScript 템플릿 리터럴을 여러 줄로 작성했는데, 프롬프트 텍스트 라인들이 들여쓰기 없이 시작되어 YAML 파서가 블록 스칼라를 잘못 종료함.

```yaml
script: |
  const prompt = `한국어 텍스트
  
GitHub Copilot이 ...   ← 들여쓰기 없음 → YAML 파서가 여기서 중단
```

## 수정

템플릿 리터럴 대신 `array.join('\n')` 패턴으로 교체 → 모든 내용이 YAML 들여쓰기 내에 유지됨.

## 영향

- `workflow_dispatch` 트리거가 정상 인식됨
- `schedule` 트리거가 정상 실행됨
- PR #34 Copilot 코멘트 자동 답글 → Gate PASS 흐름 정상 작동

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)