### PR TITLE
refactor(be): extract QuestProgressRecorder from AiCheckService

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -1,20 +1,12 @@
 package com.devquest.core.domain
 
-import com.devquest.core.domain.event.QuestEvaluatedEvent
-import com.devquest.core.domain.model.QuestHistory
-import com.devquest.core.domain.model.QuestProgress
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.port.*
-import com.devquest.core.domain.GradePolicy
 import com.devquest.core.domain.PassCriteriaPolicy
 import com.devquest.core.domain.QuestXpPolicy
 import com.devquest.core.enums.QuestStatus
-import com.devquest.core.support.error.CoreException
-import com.devquest.core.support.error.ErrorType
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 class AiCheckService(
@@ -29,15 +21,14 @@ class AiCheckService(
     private val skillAssessmentPort: SkillAssessmentPort,
     private val actClearReportPort: ActClearReportPort,
     private val progressPort: QuestProgressPort,
-    private val historyPort: QuestHistoryPort,
     private val bossPackageEvaluator: BossPackageEvaluatorPort,
     private val journeyReportPort: JourneyReportPort,
-    private val publisher: ApplicationEventPublisher,
+    private val questProgressRecorder: QuestProgressRecorder,
 ) {
     @Transactional
     fun checkSkillAssessment(userId: String, skills: List<String>, targetRole: String): SkillAssessmentResult {
         val result = skillAssessmentPort.evaluate(skills, targetRole)
-        saveProgress(userId, "1-1", 1, result.score, true, QuestXpPolicy.calculate("1-1", true))
+        questProgressRecorder.record(userId, "1-1", 1, result.score, true, QuestXpPolicy.calculate("1-1", true))
         return result
     }
 
@@ -46,14 +37,14 @@ class AiCheckService(
         userId: String, dissatisfactions: List<String>, goals: List<String>, fiveYearVision: String
     ): EssayCheckResult {
         val result = essayEvaluator.evaluate(dissatisfactions, goals, fiveYearVision)
-        saveProgress(userId, "1-2", 1, result.score, result.passed, QuestXpPolicy.calculate("1-2", result.passed, score = result.score))
+        questProgressRecorder.record(userId, "1-2", 1, result.score, result.passed, QuestXpPolicy.calculate("1-2", result.passed, score = result.score))
         return result
     }
 
     @Transactional
     fun checkTechBlog(userId: String, questId: String, techTopic: String, title: String, content: String): AiEvaluationResult {
         val result = blogEvaluator.evaluate(techTopic, title, content)
-        saveProgress(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed, xpMultiplier = result.xpMultiplier))
+        questProgressRecorder.record(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed, xpMultiplier = result.xpMultiplier))
         return result
     }
 
@@ -62,14 +53,14 @@ class AiCheckService(
         userId: String, questId: String, problemStatement: String, architectureDescription: String, considerations: List<String>
     ): AiEvaluationResult {
         val result = systemDesignEvaluator.evaluate(problemStatement, architectureDescription, considerations)
-        saveProgress(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed, xpMultiplier = result.xpMultiplier))
+        questProgressRecorder.record(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed, xpMultiplier = result.xpMultiplier))
         return result
     }
 
     @Transactional
     fun checkMockInterview(userId: String, questId: String, category: String, question: String, answer: String, questionId: String): InterviewEvaluationResult {
         val result = interviewEvaluator.evaluate(category, question, answer, questionId)
-        saveProgress(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed))
+        questProgressRecorder.record(userId, questId, 2, result.score, result.passed, QuestXpPolicy.calculate(questId, result.passed))
         return result
     }
 
@@ -80,7 +71,7 @@ class AiCheckService(
     @Transactional
     fun analyzeJd(userId: String, companyName: String, jobDescription: String, userSkills: List<String>, userExperiences: List<String>): JdAnalysisResult {
         val result = jdAnalysisEvaluator.analyze(companyName, jobDescription, userSkills, userExperiences)
-        saveProgress(userId, "3-2", 3, result.overallMatchScore, true, QuestXpPolicy.calculate("3-2", true))
+        questProgressRecorder.record(userId, "3-2", 3, result.overallMatchScore, true, QuestXpPolicy.calculate("3-2", true))
         return result
     }
 
@@ -88,7 +79,7 @@ class AiCheckService(
     fun checkResume(userId: String, targetCompany: String, targetJd: String, resumeContent: String): ResumeCheckResult {
         val result = resumeEvaluator.evaluate(targetCompany, targetJd, resumeContent)
         val passed = PassCriteriaPolicy.evaluate(result.overallScore)
-        saveProgress(userId, "4-1", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-1", passed))
+        questProgressRecorder.record(userId, "4-1", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-1", passed))
         return result
     }
 
@@ -97,14 +88,14 @@ class AiCheckService(
         val result = companyFitEvaluator.analyze(preferences, companies)
         val maxScore = result.maxOfOrNull { it.fitScore } ?: 0
         val passed = PassCriteriaPolicy.evaluateMax(result.map { it.fitScore })
-        saveProgress(userId, "1-BOSS", 1, maxScore, passed, QuestXpPolicy.calculate("1-BOSS", passed))
+        questProgressRecorder.record(userId, "1-BOSS", 1, maxScore, passed, QuestXpPolicy.calculate("1-BOSS", passed))
         return result
     }
 
     @Transactional
     fun checkPersonalityInterview(userId: String, question: String, answer: String): AiEvaluationResult {
         val result = personalityEvaluator.evaluate(question, answer)
-        saveProgress(userId, "5-1", 5, result.score, result.passed, QuestXpPolicy.calculate("5-1", result.passed, xpMultiplier = result.xpMultiplier))
+        questProgressRecorder.record(userId, "5-1", 5, result.score, result.passed, QuestXpPolicy.calculate("5-1", result.passed, xpMultiplier = result.xpMultiplier))
         return result
     }
 
@@ -112,7 +103,7 @@ class AiCheckService(
     fun checkBossPackage(userId: String, resumeContent: String, githubUrl: String, blogUrl: String, targetPosition: String): BossPackageResult {
         val result = bossPackageEvaluator.evaluate(resumeContent, githubUrl, blogUrl, targetPosition)
         val passed = PassCriteriaPolicy.evaluate(result.overallScore)
-        saveProgress(userId, "4-BOSS", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-BOSS", passed))
+        questProgressRecorder.record(userId, "4-BOSS", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-BOSS", passed))
         return result
     }
 
@@ -131,47 +122,5 @@ class AiCheckService(
             .filter { it.actId == actId && it.aiScore > 0 }
             .associate { it.questId to it.aiScore }
         return actClearReportPort.generate(actId, actTitle, questScores)
-    }
-
-    private fun saveProgress(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
-        val existing = progressPort.findByUserIdAndQuestId(userId, questId)
-        val progress = QuestProgress(
-            id = existing?.id,
-            userId = userId,
-            questId = questId,
-            actId = actId,
-            status = if (passed) QuestStatus.COMPLETED else QuestStatus.AI_FAILED,
-            aiScore = score,
-            earnedXp = xp,
-            completedAt = if (passed) LocalDateTime.now() else null,
-            updatedAt = LocalDateTime.now()
-        )
-        progressPort.save(progress)
-        saveHistory(userId, questId, actId, score, passed, xp)
-    }
-
-    private fun saveHistory(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
-        val grade = GradePolicy.from(score)
-        val history = QuestHistory(
-            userId = userId,
-            questId = questId,
-            actId = actId,
-            score = score,
-            grade = grade,
-            passed = passed,
-            earnedXp = xp
-        )
-        historyPort.save(history)
-        publisher.publishEvent(
-            QuestEvaluatedEvent(
-                userId = userId,
-                questId = questId,
-                actId = actId,
-                score = score,
-                grade = grade,
-                passed = passed,
-                earnedXp = xp,
-            )
-        )
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestProgressRecorder.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/QuestProgressRecorder.kt
@@ -1,0 +1,59 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.event.QuestEvaluatedEvent
+import com.devquest.core.domain.model.QuestHistory
+import com.devquest.core.domain.model.QuestProgress
+import com.devquest.core.domain.port.QuestHistoryPort
+import com.devquest.core.domain.port.QuestProgressPort
+import com.devquest.core.enums.QuestStatus
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Component
+class QuestProgressRecorder(
+    private val progressPort: QuestProgressPort,
+    private val historyPort: QuestHistoryPort,
+    private val publisher: ApplicationEventPublisher,
+) {
+    @Transactional
+    fun record(userId: String, questId: String, actId: Int, score: Int, passed: Boolean, xp: Int) {
+        val existing = progressPort.findByUserIdAndQuestId(userId, questId)
+        val progress = QuestProgress(
+            id = existing?.id,
+            userId = userId,
+            questId = questId,
+            actId = actId,
+            status = if (passed) QuestStatus.COMPLETED else QuestStatus.AI_FAILED,
+            aiScore = score,
+            earnedXp = xp,
+            completedAt = if (passed) LocalDateTime.now() else null,
+            updatedAt = LocalDateTime.now()
+        )
+        progressPort.save(progress)
+
+        val grade = GradePolicy.from(score)
+        val history = QuestHistory(
+            userId = userId,
+            questId = questId,
+            actId = actId,
+            score = score,
+            grade = grade,
+            passed = passed,
+            earnedXp = xp
+        )
+        historyPort.save(history)
+        publisher.publishEvent(
+            QuestEvaluatedEvent(
+                userId = userId,
+                questId = questId,
+                actId = actId,
+                score = score,
+                grade = grade,
+                passed = passed,
+                earnedXp = xp,
+            )
+        )
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -1,11 +1,8 @@
 package com.devquest.core.domain
 
-import com.devquest.core.domain.model.QuestHistory
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.port.*
-import com.devquest.core.enums.QuestStatus
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -13,9 +10,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.context.ApplicationEventPublisher
 
 @ExtendWith(MockitoExtension::class)
 class AiCheckServiceTest {
@@ -31,19 +28,12 @@ class AiCheckServiceTest {
     @Mock lateinit var skillAssessmentPort: SkillAssessmentPort
     @Mock lateinit var actClearReportPort: ActClearReportPort
     @Mock lateinit var progressPort: QuestProgressPort
-    @Mock lateinit var historyPort: QuestHistoryPort
     @Mock lateinit var bossPackageEvaluator: BossPackageEvaluatorPort
     @Mock lateinit var journeyReportPort: JourneyReportPort
-    @Mock lateinit var publisher: ApplicationEventPublisher
+    @Mock lateinit var questProgressRecorder: QuestProgressRecorder
 
     @InjectMocks
     private lateinit var service: AiCheckService
-
-    @BeforeEach
-    fun setUp() {
-        whenever(progressPort.save(any())).thenAnswer { it.arguments[0] }
-        whenever(historyPort.save(any())).thenAnswer { it.arguments[0] }
-    }
 
     // ===== analyzeCompanyFit 테스트 =====
 
@@ -53,11 +43,7 @@ class AiCheckServiceTest {
 
         service.analyzeCompanyFit("user1", emptyMap(), emptyList())
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
-        assertThat(captor.firstValue.aiScore).isEqualTo(0)
+        verify(questProgressRecorder).record(eq("user1"), eq("1-BOSS"), eq(1), eq(0), eq(false), eq(0))
     }
 
     @Test
@@ -70,11 +56,7 @@ class AiCheckServiceTest {
 
         service.analyzeCompanyFit("user1", emptyMap(), emptyList())
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
-        assertThat(captor.firstValue.aiScore).isEqualTo(69)
+        verify(questProgressRecorder).record(eq("user1"), eq("1-BOSS"), eq(1), eq(69), eq(false), eq(0))
     }
 
     @Test
@@ -87,12 +69,7 @@ class AiCheckServiceTest {
 
         service.analyzeCompanyFit("user1", emptyMap(), emptyList())
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(500)
-        assertThat(captor.firstValue.aiScore).isEqualTo(70)
-        verify(publisher).publishEvent(any<com.devquest.core.domain.event.QuestEvaluatedEvent>())
+        verify(questProgressRecorder).record(eq("user1"), eq("1-BOSS"), eq(1), eq(70), eq(true), eq(500))
     }
 
     @Test
@@ -105,11 +82,19 @@ class AiCheckServiceTest {
 
         service.analyzeCompanyFit("user1", emptyMap(), emptyList())
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.aiScore).isEqualTo(95)
-        assertThat(captor.firstValue.questId).isEqualTo("1-BOSS")
+        val userIdCaptor = argumentCaptor<String>()
+        val questIdCaptor = argumentCaptor<String>()
+        val actIdCaptor = argumentCaptor<Int>()
+        val scoreCaptor = argumentCaptor<Int>()
+        val passedCaptor = argumentCaptor<Boolean>()
+        val xpCaptor = argumentCaptor<Int>()
+        verify(questProgressRecorder).record(
+            userIdCaptor.capture(), questIdCaptor.capture(), actIdCaptor.capture(),
+            scoreCaptor.capture(), passedCaptor.capture(), xpCaptor.capture()
+        )
+        assertThat(questIdCaptor.firstValue).isEqualTo("1-BOSS")
+        assertThat(scoreCaptor.firstValue).isEqualTo(95)
+        assertThat(passedCaptor.firstValue).isTrue()
     }
 
     // ===== checkResume 테스트 =====
@@ -121,13 +106,7 @@ class AiCheckServiceTest {
 
         service.checkResume("user1", "카카오", "JD", "이력서 내용")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(500)
-        assertThat(captor.firstValue.aiScore).isEqualTo(85)
-        assertThat(captor.firstValue.questId).isEqualTo("4-1")
-        verify(publisher).publishEvent(any<com.devquest.core.domain.event.QuestEvaluatedEvent>())
+        verify(questProgressRecorder).record(eq("user1"), eq("4-1"), eq(4), eq(85), eq(true), eq(500))
     }
 
     @Test
@@ -137,11 +116,7 @@ class AiCheckServiceTest {
 
         service.checkResume("user1", "카카오", "JD", "이력서 내용")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
-        assertThat(captor.firstValue.aiScore).isEqualTo(69)
+        verify(questProgressRecorder).record(eq("user1"), eq("4-1"), eq(4), eq(69), eq(false), eq(0))
     }
 
     // ===== checkCareerEssay 테스트 =====
@@ -153,11 +128,7 @@ class AiCheckServiceTest {
 
         service.checkCareerEssay("user1", listOf("불만"), listOf("목표"), "비전")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(160) // 200 * 80 / 100
-        assertThat(captor.firstValue.questId).isEqualTo("1-2")
+        verify(questProgressRecorder).record(eq("user1"), eq("1-2"), eq(1), eq(80), eq(true), eq(160))
     }
 
     @Test
@@ -167,10 +138,7 @@ class AiCheckServiceTest {
 
         service.checkCareerEssay("user1", listOf("불만"), listOf("목표"), "비전")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
+        verify(questProgressRecorder).record(eq("user1"), eq("1-2"), eq(1), eq(50), eq(false), eq(0))
     }
 
     // ===== checkTechBlog 테스트 =====
@@ -182,11 +150,7 @@ class AiCheckServiceTest {
 
         service.checkTechBlog("user1", "2-1", "Kotlin", "제목", "내용")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(900) // (600 * 1.5).toInt()
-        assertThat(captor.firstValue.questId).isEqualTo("2-1")
+        verify(questProgressRecorder).record(eq("user1"), eq("2-1"), eq(2), eq(85), eq(true), eq(900))
     }
 
     @Test
@@ -196,10 +160,7 @@ class AiCheckServiceTest {
 
         service.checkTechBlog("user1", "2-1", "Kotlin", "제목", "내용")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
+        verify(questProgressRecorder).record(eq("user1"), eq("2-1"), eq(2), eq(40), eq(false), eq(0))
     }
 
     // ===== checkMockInterview 테스트 =====
@@ -211,10 +172,7 @@ class AiCheckServiceTest {
 
         service.checkMockInterview("user1", "2-2", "backend", "질문", "답변", "q-1")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(800)
+        verify(questProgressRecorder).record(eq("user1"), eq("2-2"), eq(2), eq(90), eq(true), eq(800))
     }
 
     @Test
@@ -224,10 +182,7 @@ class AiCheckServiceTest {
 
         service.checkMockInterview("user1", "2-2", "backend", "질문", "답변", "q-1")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.AI_FAILED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(0)
+        verify(questProgressRecorder).record(eq("user1"), eq("2-2"), eq(2), eq(30), eq(false), eq(0))
     }
 
     // ===== analyzeJd 테스트 =====
@@ -239,11 +194,7 @@ class AiCheckServiceTest {
 
         service.analyzeJd("user1", "카카오", "JD 내용", listOf("Kotlin"), listOf("3년 경력"))
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(350)
-        assertThat(captor.firstValue.questId).isEqualTo("3-2")
+        verify(questProgressRecorder).record(eq("user1"), eq("3-2"), eq(3), eq(60), eq(true), eq(350))
     }
 
     // ===== checkBossPackage 테스트 =====
@@ -265,12 +216,7 @@ class AiCheckServiceTest {
 
         service.checkBossPackage("user-1", "이력서 내용", "https://github.com/user", "", "시니어 백엔드")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(700)
-        assertThat(captor.firstValue.aiScore).isEqualTo(80)
-        assertThat(captor.firstValue.questId).isEqualTo("4-BOSS")
+        verify(questProgressRecorder).record(eq("user-1"), eq("4-BOSS"), eq(4), eq(80), eq(true), eq(700))
     }
 
     // ===== checkPersonalityInterview 테스트 =====
@@ -282,10 +228,6 @@ class AiCheckServiceTest {
 
         service.checkPersonalityInterview("user1", "장단점은?", "저는...")
 
-        val captor = argumentCaptor<com.devquest.core.domain.model.QuestProgress>()
-        verify(progressPort).save(captor.capture())
-        assertThat(captor.firstValue.status).isEqualTo(QuestStatus.COMPLETED)
-        assertThat(captor.firstValue.earnedXp).isEqualTo(480) // (400 * 1.2).toInt()
-        assertThat(captor.firstValue.questId).isEqualTo("5-1")
+        verify(questProgressRecorder).record(eq("user1"), eq("5-1"), eq(5), eq(88), eq(true), eq(480))
     }
 }


### PR DESCRIPTION
## Summary
- AiCheckService에서 saveProgress/saveHistory 로직을 QuestProgressRecorder @Component로 추출
- AiCheckService 생성자 파라미터 15→14개, private 메서드 2개 제거
- 퀘스트 진행도 기록 책임 분리

## Test plan
- [ ] BE 빌드 성공 확인
- [ ] AiCheckController → AiCheckService → QuestProgressRecorder 흐름 추적

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)