### PR TITLE
refactor(be): extract BaseAiEvaluator and QuestConstants

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.ActClearReportResult
 import com.devquest.core.domain.port.ActClearReportPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class ActClearReportEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : ActClearReportPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), ActClearReportPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/act-clear-report.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.BossPackageResult
 import com.devquest.core.domain.port.BossPackageEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -11,9 +12,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class BossPackageEvaluator(
-    @Qualifier("bossChatClient") private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : BossPackageEvaluatorPort {
+    @Qualifier("bossChatClient") chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), BossPackageEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/boss-package.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.EssayCheckResult
 import com.devquest.core.domain.port.EssayEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class CareerEssayEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : EssayEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), EssayEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/career-essay.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.CompanyFitResult
 import com.devquest.core.domain.port.CompanyFitEvaluatorPort
@@ -16,9 +17,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class CompanyFitEvaluator(
-    @Qualifier("bossChatClient") private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : CompanyFitEvaluatorPort {
+    @Qualifier("bossChatClient") chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), CompanyFitEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
 import com.devquest.core.domain.model.evaluation.CoachAnswerResult
 import com.devquest.core.domain.model.evaluation.CoachReportResult
@@ -13,9 +14,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class InterviewCoachEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : InterviewCoachPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), InterviewCoachPort {
 
     private val startTemplate = PromptTemplate(ClassPathResource("prompts/interview-coach-start.st"))
     private val evaluateTemplate = PromptTemplate(ClassPathResource("prompts/interview-coach-evaluate.st"))

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.JdAnalysisResult
 import com.devquest.core.domain.port.JdAnalysisEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class JdAnalysisEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : JdAnalysisEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), JdAnalysisEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/jd-analysis.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.JourneyReportResult
 import com.devquest.core.domain.port.JourneyReportPort
 import org.springframework.ai.chat.client.ChatClient
@@ -11,9 +12,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class JourneyReportGenerator(
-    @Qualifier("bossChatClient") private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : JourneyReportPort {
+    @Qualifier("bossChatClient") chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), JourneyReportPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/journey-report.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.InterviewEvaluationResult
 import com.devquest.core.domain.port.InterviewEvaluatorPort
@@ -15,9 +16,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class MockInterviewEvaluator(
-    @Qualifier("bossChatClient") private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : InterviewEvaluatorPort {
+    @Qualifier("bossChatClient") chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), InterviewEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.port.PersonalityEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class PersonalityInterviewEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : PersonalityEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), PersonalityEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/personality-interview.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.ResumeCheckResult
 import com.devquest.core.domain.port.ResumeEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class ResumeCheckEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : ResumeEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), ResumeEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/resume-check.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.SkillAssessmentResult
 import com.devquest.core.domain.port.SkillAssessmentPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class SkillAssessmentEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : SkillAssessmentPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), SkillAssessmentPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/skill-assessment.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.port.SystemDesignEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class SystemDesignEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : SystemDesignEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), SystemDesignEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/system-design.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
@@ -1,6 +1,7 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.BaseAiEvaluator
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.port.BlogEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class TechBlogEvaluator(
-    private val chatClient: ChatClient,
-    private val aiCallExecutor: AiCallExecutor
-) : BlogEvaluatorPort {
+    chatClient: ChatClient,
+    aiCallExecutor: AiCallExecutor
+) : BaseAiEvaluator(chatClient, aiCallExecutor), BlogEvaluatorPort {
 
     private val template = PromptTemplate(ClassPathResource("prompts/tech-blog.st"))
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
@@ -1,0 +1,8 @@
+package com.devquest.client.ai.support
+
+import org.springframework.ai.chat.client.ChatClient
+
+abstract class BaseAiEvaluator(
+    protected val chatClient: ChatClient,
+    protected val aiCallExecutor: AiCallExecutor
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -3,6 +3,7 @@ package com.devquest.core.domain
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.port.*
 import com.devquest.core.domain.PassCriteriaPolicy
+import com.devquest.core.domain.QuestConstants
 import com.devquest.core.domain.QuestXpPolicy
 import com.devquest.core.enums.QuestStatus
 import org.springframework.stereotype.Service
@@ -28,7 +29,7 @@ class AiCheckService(
     @Transactional
     fun checkSkillAssessment(userId: String, skills: List<String>, targetRole: String): SkillAssessmentResult {
         val result = skillAssessmentPort.evaluate(skills, targetRole)
-        questProgressRecorder.record(userId, "1-1", 1, result.score, true, QuestXpPolicy.calculate("1-1", true))
+        questProgressRecorder.record(userId, QuestConstants.SKILL_ASSESSMENT, 1, result.score, true, QuestXpPolicy.calculate(QuestConstants.SKILL_ASSESSMENT, true))
         return result
     }
 
@@ -37,7 +38,7 @@ class AiCheckService(
         userId: String, dissatisfactions: List<String>, goals: List<String>, fiveYearVision: String
     ): EssayCheckResult {
         val result = essayEvaluator.evaluate(dissatisfactions, goals, fiveYearVision)
-        questProgressRecorder.record(userId, "1-2", 1, result.score, result.passed, QuestXpPolicy.calculate("1-2", result.passed, score = result.score))
+        questProgressRecorder.record(userId, QuestConstants.CAREER_ESSAY, 1, result.score, result.passed, QuestXpPolicy.calculate(QuestConstants.CAREER_ESSAY, result.passed, score = result.score))
         return result
     }
 
@@ -71,7 +72,7 @@ class AiCheckService(
     @Transactional
     fun analyzeJd(userId: String, companyName: String, jobDescription: String, userSkills: List<String>, userExperiences: List<String>): JdAnalysisResult {
         val result = jdAnalysisEvaluator.analyze(companyName, jobDescription, userSkills, userExperiences)
-        questProgressRecorder.record(userId, "3-2", 3, result.overallMatchScore, true, QuestXpPolicy.calculate("3-2", true))
+        questProgressRecorder.record(userId, QuestConstants.JD_ANALYSIS, 3, result.overallMatchScore, true, QuestXpPolicy.calculate(QuestConstants.JD_ANALYSIS, true))
         return result
     }
 
@@ -79,7 +80,7 @@ class AiCheckService(
     fun checkResume(userId: String, targetCompany: String, targetJd: String, resumeContent: String): ResumeCheckResult {
         val result = resumeEvaluator.evaluate(targetCompany, targetJd, resumeContent)
         val passed = PassCriteriaPolicy.evaluate(result.overallScore)
-        questProgressRecorder.record(userId, "4-1", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-1", passed))
+        questProgressRecorder.record(userId, QuestConstants.RESUME_CHECK, 4, result.overallScore, passed, QuestXpPolicy.calculate(QuestConstants.RESUME_CHECK, passed))
         return result
     }
 
@@ -88,14 +89,14 @@ class AiCheckService(
         val result = companyFitEvaluator.analyze(preferences, companies)
         val maxScore = result.maxOfOrNull { it.fitScore } ?: 0
         val passed = PassCriteriaPolicy.evaluateMax(result.map { it.fitScore })
-        questProgressRecorder.record(userId, "1-BOSS", 1, maxScore, passed, QuestXpPolicy.calculate("1-BOSS", passed))
+        questProgressRecorder.record(userId, QuestConstants.COMPANY_FIT_BOSS, 1, maxScore, passed, QuestXpPolicy.calculate(QuestConstants.COMPANY_FIT_BOSS, passed))
         return result
     }
 
     @Transactional
     fun checkPersonalityInterview(userId: String, question: String, answer: String): AiEvaluationResult {
         val result = personalityEvaluator.evaluate(question, answer)
-        questProgressRecorder.record(userId, "5-1", 5, result.score, result.passed, QuestXpPolicy.calculate("5-1", result.passed, xpMultiplier = result.xpMultiplier))
+        questProgressRecorder.record(userId, QuestConstants.PERSONALITY_INTERVIEW, 5, result.score, result.passed, QuestXpPolicy.calculate(QuestConstants.PERSONALITY_INTERVIEW, result.passed, xpMultiplier = result.xpMultiplier))
         return result
     }
 
@@ -103,7 +104,7 @@ class AiCheckService(
     fun checkBossPackage(userId: String, resumeContent: String, githubUrl: String, blogUrl: String, targetPosition: String): BossPackageResult {
         val result = bossPackageEvaluator.evaluate(resumeContent, githubUrl, blogUrl, targetPosition)
         val passed = PassCriteriaPolicy.evaluate(result.overallScore)
-        questProgressRecorder.record(userId, "4-BOSS", 4, result.overallScore, passed, QuestXpPolicy.calculate("4-BOSS", passed))
+        questProgressRecorder.record(userId, QuestConstants.BOSS_PACKAGE, 4, result.overallScore, passed, QuestXpPolicy.calculate(QuestConstants.BOSS_PACKAGE, passed))
         return result
     }
 

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/QuestConstants.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/QuestConstants.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.domain
+
+object QuestConstants {
+    const val SKILL_ASSESSMENT = "1-1"
+    const val CAREER_ESSAY = "1-2"
+    const val COMPANY_FIT_BOSS = "1-BOSS"
+    const val JD_ANALYSIS = "3-2"
+    const val RESUME_CHECK = "4-1"
+    const val BOSS_PACKAGE = "4-BOSS"
+    const val PERSONALITY_INTERVIEW = "5-1"
+}


### PR DESCRIPTION
## Summary
- 13개 Evaluator가 공통으로 갖던 chatClient + aiCallExecutor를 BaseAiEvaluator 추상 클래스로 추출
- QuestConstants object로 AiCheckService의 quest ID 매직 스트링 제거
- 새 Evaluator 추가 시 보일러플레이트 감소

## Test plan
- [ ] client-ai 모듈 빌드 성공
- [ ] core-api 모듈 빌드 성공
- [ ] AiCheckService에 import QuestConstants 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)