### PR TITLE
refactor(fe): extract ResultHeader and ResultSection from AiResultCard

### DIFF
--- a/fe/src/features/ai-check/components/AiResultCard.tsx
+++ b/fe/src/features/ai-check/components/AiResultCard.tsx
@@ -1,7 +1,7 @@
 import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
-import { ScoreRing } from '@/components/ui/ScoreRing'
-import { GradeTag } from '@/components/ui/GradeTag'
 import { getGrade, PASS_THRESHOLD } from '../../../utils/gradeUtils'
+import { ResultHeader } from './ResultHeader'
+import { ResultSection } from './ResultSection'
 
 interface AiResultCardProps {
   result: AiEvaluationResult
@@ -23,63 +23,32 @@ export function AiResultCard({ result }: AiResultCardProps) {
         animation: 'slideIn 0.5s ease',
       }}
     >
-      <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 18 }}>
-        <ScoreRing score={score} />
-        <div style={{ flex: 1 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
-            <GradeTag grade={grade} />
-            <span
-              style={{ fontSize: 13, color: passed ? '#10B981' : '#EF4444', fontWeight: 'bold' }}
-            >
-              {passed ? '✓ 통과 — 퀘스트 완료!' : '✗ 미통과 — 재시도 가능'}
-            </span>
-          </div>
-          {result.summary && (
-            <p style={{ color: '#94A3B8', fontSize: 13, margin: 0, lineHeight: 1.6 }}>
-              {result.summary}
-            </p>
-          )}
-          {result.developerType && (
-            <div style={{ marginTop: 6, fontSize: 12, color: '#A78BFA' }}>
-              🧠 {result.developerType}
-            </div>
-          )}
-        </div>
-      </div>
+      <ResultHeader
+        score={score}
+        passed={passed}
+        grade={grade}
+        summary={result.summary}
+        developerType={result.developerType}
+      />
 
       {result.strengths && result.strengths.length > 0 && (
-        <div style={{ marginBottom: 14 }}>
-          <div style={{ fontSize: 10, color: '#10B981', letterSpacing: 3, marginBottom: 8 }}>
-            ✓ STRENGTHS
-          </div>
-          {result.strengths.map((s, i) => (
-            <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
-              <span style={{ color: '#10B981' }}>▸ </span>
-              {s}
-            </div>
-          ))}
-        </div>
+        <ResultSection label="✓ STRENGTHS" color="#10B981" items={result.strengths} />
       )}
 
-      {result.improvements && (
-        <div style={{ marginBottom: 14 }}>
-          <div style={{ fontSize: 10, color: '#F59E0B', letterSpacing: 3, marginBottom: 8 }}>
-            ↑ IMPROVEMENTS
-          </div>
-          {(Array.isArray(result.improvements) ? result.improvements : [result.improvements]).map(
-            (imp, i) => (
-              <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
-                <span style={{ color: '#F59E0B' }}>▸ </span>
-                {typeof imp === 'string'
-                  ? imp
-                  : (imp as { suggestion?: string; issue?: string }).suggestion ??
-                    (imp as { suggestion?: string; issue?: string }).issue ??
-                    JSON.stringify(imp)}
-              </div>
-            ),
-          )}
-        </div>
-      )}
+      {result.improvements && (() => {
+        const improvementItems = (
+          Array.isArray(result.improvements) ? result.improvements : [result.improvements]
+        ).map((imp) =>
+          typeof imp === 'string'
+            ? imp
+            : (imp as { suggestion?: string; issue?: string }).suggestion ??
+              (imp as { suggestion?: string; issue?: string }).issue ??
+              JSON.stringify(imp),
+        )
+        return improvementItems.length > 0 ? (
+          <ResultSection label="↑ IMPROVEMENTS" color="#F59E0B" items={improvementItems} />
+        ) : null
+      })()}
 
       {(result.detailedFeedback ?? result.feedback) && (
         <div
@@ -178,19 +147,13 @@ export function BossPackageResultCard({ result }: BossPackageResultCardProps) {
         animation: 'slideIn 0.5s ease',
       }}
     >
-      <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 18 }}>
-        <ScoreRing score={result.overallScore} />
-        <div style={{ flex: 1 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
-            <GradeTag grade={grade} />
-            <span
-              style={{ fontSize: 13, color: passed ? '#10B981' : '#EF4444', fontWeight: 'bold' }}
-            >
-              {passed ? '✓ 통과 — 지원 패키지 완성!' : '✗ 미통과 — 패키지 보완 필요'}
-            </span>
-          </div>
-        </div>
-      </div>
+      <ResultHeader
+        score={result.overallScore}
+        passed={passed}
+        grade={grade}
+        passLabel="✓ 통과 — 지원 패키지 완성!"
+        failLabel="✗ 미통과 — 패키지 보완 필요"
+      />
 
       <div style={{ marginBottom: 18 }}>
         <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 10 }}>
@@ -229,33 +192,9 @@ export function BossPackageResultCard({ result }: BossPackageResultCardProps) {
         </div>
       </div>
 
-      {result.strengths.length > 0 && (
-        <div style={{ marginBottom: 14 }}>
-          <div style={{ fontSize: 10, color: '#10B981', letterSpacing: 3, marginBottom: 8 }}>
-            ✓ STRENGTHS
-          </div>
-          {result.strengths.map((s, i) => (
-            <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
-              <span style={{ color: '#10B981' }}>▸ </span>
-              {s}
-            </div>
-          ))}
-        </div>
-      )}
+      <ResultSection label="✓ STRENGTHS" color="#10B981" items={result.strengths} />
 
-      {result.improvements.length > 0 && (
-        <div style={{ marginBottom: 14 }}>
-          <div style={{ fontSize: 10, color: '#F59E0B', letterSpacing: 3, marginBottom: 8 }}>
-            ↑ IMPROVEMENTS
-          </div>
-          {result.improvements.map((imp, i) => (
-            <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
-              <span style={{ color: '#F59E0B' }}>▸ </span>
-              {imp}
-            </div>
-          ))}
-        </div>
-      )}
+      <ResultSection label="↑ IMPROVEMENTS" color="#F59E0B" items={result.improvements} />
 
       <div
         style={{

--- a/fe/src/features/ai-check/components/ResultHeader.tsx
+++ b/fe/src/features/ai-check/components/ResultHeader.tsx
@@ -1,0 +1,48 @@
+import { ScoreRing } from '@/components/ui/ScoreRing'
+import { GradeTag } from '@/components/ui/GradeTag'
+
+interface ResultHeaderProps {
+  score: number
+  passed: boolean
+  grade: string
+  summary?: string
+  developerType?: string
+  passLabel?: string
+  failLabel?: string
+}
+
+export function ResultHeader({
+  score,
+  passed,
+  grade,
+  summary,
+  developerType,
+  passLabel = '✓ 통과 — 퀘스트 완료!',
+  failLabel = '✗ 미통과 — 재시도 가능',
+}: ResultHeaderProps) {
+  return (
+    <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 18 }}>
+      <ScoreRing score={score} />
+      <div style={{ flex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <GradeTag grade={grade} />
+          <span
+            style={{ fontSize: 13, color: passed ? '#10B981' : '#EF4444', fontWeight: 'bold' }}
+          >
+            {passed ? passLabel : failLabel}
+          </span>
+        </div>
+        {summary && (
+          <p style={{ color: '#94A3B8', fontSize: 13, margin: 0, lineHeight: 1.6 }}>
+            {summary}
+          </p>
+        )}
+        {developerType && (
+          <div style={{ marginTop: 6, fontSize: 12, color: '#A78BFA' }}>
+            🧠 {developerType}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/ai-check/components/ResultSection.tsx
+++ b/fe/src/features/ai-check/components/ResultSection.tsx
@@ -1,0 +1,23 @@
+interface ResultSectionProps {
+  label: string
+  color: string
+  items: string[]
+}
+
+export function ResultSection({ label, color, items }: ResultSectionProps) {
+  if (items.length === 0) return null
+
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={{ fontSize: 10, color, letterSpacing: 3, marginBottom: 8 }}>
+        {label}
+      </div>
+      {items.map((item, i) => (
+        <div key={i} style={{ fontSize: 13, color: '#64748B', marginBottom: 4 }}>
+          <span style={{ color }}>▸ </span>
+          {item}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- ResultHeader 컴포넌트: ScoreRing + GradeTag + 통과/미통과 상태를 하나의 재사용 단위로 추출
- ResultSection 컴포넌트: 레이블 + 색상 + 항목 목록 (STRENGTHS/IMPROVEMENTS 공통 구조)
- AiResultCard, BossPackageResultCard 모두 서브컴포넌트 사용으로 단순화

## Test plan
- [ ] TypeScript 타입 오류 없음
- [ ] AiResultCard, BossPackageResultCard 렌더링 구조 동일

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)