### PR TITLE
refactor(fe): extract useAiCheckForm hook and FormField component

### DIFF
--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react'
 import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
 import { AI_FORMS } from '../constants/formConfig'
-import { submitAiCheck, submitBossPackage } from '../api/aiCheckApi'
-import { TechStackInput } from './TechStackInput'
-import { inputStyle } from '../../../constants/styles'
+import { useAiCheckForm } from '../hooks/useAiCheckForm'
+import { FormField } from './FormField'
 
 interface AiCheckFormProps {
   questId: string
@@ -14,40 +12,11 @@ interface AiCheckFormProps {
 
 export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCheckFormProps) {
   const cfg = AI_FORMS[questId]
-  const [values, setValues] = useState<Record<string, unknown>>(initialValues ?? {})
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-  const [activeHint, setActiveHint] = useState<string | null>(null)
+
+  const { values, loading, error, activeHint, set, setListItem, setActiveHint, handleSubmit } =
+    useAiCheckForm({ questId, cfg: cfg!, onResult, onSubmit, initialValues })
 
   if (!cfg) return null
-
-  const set = (key: string, value: unknown) =>
-    setValues((prev) => ({ ...prev, [key]: value }))
-
-  const setListItem = (key: string, index: number, value: string) =>
-    setValues((prev) => {
-      const arr = [...((prev[key] as string[] | undefined) ?? [])]
-      arr[index] = value
-      return { ...prev, [key]: arr }
-    })
-
-  const handleSubmit = async () => {
-    setLoading(true)
-    setError('')
-    try {
-      onSubmit?.(values)
-      const body = cfg.transform(values)
-      const result =
-        questId === '4-BOSS'
-          ? await submitBossPackage(body)
-          : await submitAiCheck(cfg.endpoint, body)
-      onResult(result)
-    } catch (e) {
-      setError('서버 연결 오류: ' + (e instanceof Error ? e.message : String(e)))
-    } finally {
-      setLoading(false)
-    }
-  }
 
   return (
     <div style={{ marginTop: 18, animation: 'slideIn 0.3s ease' }}>
@@ -55,102 +24,15 @@ export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCh
         🤖 AI SUBMISSION FORM
       </div>
       {cfg.fields.map((f) => (
-        <div key={f.key} style={{ marginBottom: 14 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-            <label style={{ fontSize: 12, color: '#64748B' }}>{f.label}</label>
-            {(f.tips || f.example) && (
-              <button
-                type="button"
-                onClick={() => setActiveHint(activeHint === f.key ? null : f.key)}
-                style={{
-                  background: activeHint === f.key ? 'rgba(78,205,196,0.15)' : 'rgba(255,255,255,0.05)',
-                  border: `1px solid ${activeHint === f.key ? 'rgba(78,205,196,0.4)' : 'rgba(255,255,255,0.1)'}`,
-                  borderRadius: '50%',
-                  width: 18,
-                  height: 18,
-                  fontSize: 10,
-                  color: activeHint === f.key ? '#4ECDC4' : '#475569',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontFamily: "'Courier New', monospace",
-                  padding: 0,
-                  flexShrink: 0,
-                }}
-              >
-                ?
-              </button>
-            )}
-          </div>
-          {activeHint === f.key && (f.tips || f.example) && (
-            <div style={{
-              background: 'rgba(78,205,196,0.04)',
-              border: '1px solid rgba(78,205,196,0.2)',
-              borderRadius: 8,
-              padding: '10px 12px',
-              marginBottom: 8,
-              animation: 'slideIn 0.2s ease',
-            }}>
-              {f.tips && f.tips.length > 0 && (
-                <div style={{ marginBottom: f.example ? 8 : 0 }}>
-                  <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>💡 작성 팁</div>
-                  {f.tips.map((tip, ti) => (
-                    <div key={ti} style={{ fontSize: 12, color: '#64748B', marginBottom: 3, display: 'flex', gap: 6 }}>
-                      <span style={{ color: '#4ECDC4', flexShrink: 0 }}>·</span>
-                      <span>{tip}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {f.example && (
-                <div>
-                  <div style={{ fontSize: 10, color: '#A78BFA', letterSpacing: 2, marginBottom: 6 }}>✏️ 예시 답변</div>
-                  <div style={{ fontSize: 12, color: '#475569', lineHeight: 1.6, fontStyle: 'italic' }}>{f.example}</div>
-                </div>
-              )}
-            </div>
-          )}
-          {f.type === 'text' && (
-            <input
-              value={(values[f.key] as string) ?? ''}
-              onChange={(e) => set(f.key, e.target.value)}
-              placeholder={f.placeholder}
-              style={inputStyle}
-            />
-          )}
-          {f.type === 'textarea' && (
-            <textarea
-              value={(values[f.key] as string) ?? ''}
-              onChange={(e) => set(f.key, e.target.value)}
-              placeholder={f.placeholder}
-              rows={f.rows ?? 5}
-              style={{ ...inputStyle, resize: 'vertical' }}
-            />
-          )}
-          {f.type === 'list' && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              {Array.from({ length: f.count ?? 0 }).map((_, i) => (
-                <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <span style={{ fontSize: 12, color: '#334155', minWidth: 16 }}>{i + 1}.</span>
-                  <input
-                    value={((values[f.key] as string[] | undefined) ?? [])[i] ?? ''}
-                    onChange={(e) => setListItem(f.key, i, e.target.value)}
-                    placeholder={f.placeholder}
-                    style={{ ...inputStyle, flex: 1 }}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-          {f.type === 'tag-search' && (
-            <TechStackInput
-              value={(values[f.key] as string[] | undefined) ?? []}
-              onChange={(val) => set(f.key, val)}
-              placeholder={f.placeholder}
-            />
-          )}
-        </div>
+        <FormField
+          key={f.key}
+          field={f}
+          value={values[f.key]}
+          activeHint={activeHint}
+          onActiveHintChange={setActiveHint}
+          onChange={(val) => set(f.key, val)}
+          onListItemChange={(index, val) => setListItem(f.key, index, val)}
+        />
       ))}
       {error && (
         <div

--- a/fe/src/features/ai-check/components/FormField.tsx
+++ b/fe/src/features/ai-check/components/FormField.tsx
@@ -1,0 +1,115 @@
+import type { FormFieldConfig } from '../types/aiCheck.types'
+import { TechStackInput } from './TechStackInput'
+import { inputStyle } from '../../../constants/styles'
+
+interface FormFieldProps {
+  field: FormFieldConfig
+  value: unknown
+  activeHint: string | null
+  onActiveHintChange: (key: string | null) => void
+  onChange: (value: unknown) => void
+  onListItemChange: (index: number, value: string) => void
+}
+
+export function FormField({ field: f, value, activeHint, onActiveHintChange, onChange, onListItemChange }: FormFieldProps) {
+  const isHintActive = activeHint === f.key
+
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <label style={{ fontSize: 12, color: '#64748B' }}>{f.label}</label>
+        {(f.tips || f.example) && (
+          <button
+            type="button"
+            onClick={() => onActiveHintChange(isHintActive ? null : f.key)}
+            style={{
+              background: isHintActive ? 'rgba(78,205,196,0.15)' : 'rgba(255,255,255,0.05)',
+              border: `1px solid ${isHintActive ? 'rgba(78,205,196,0.4)' : 'rgba(255,255,255,0.1)'}`,
+              borderRadius: '50%',
+              width: 18,
+              height: 18,
+              fontSize: 10,
+              color: isHintActive ? '#4ECDC4' : '#475569',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontFamily: "'Courier New', monospace",
+              padding: 0,
+              flexShrink: 0,
+            }}
+          >
+            ?
+          </button>
+        )}
+      </div>
+      {isHintActive && (f.tips || f.example) && (
+        <div style={{
+          background: 'rgba(78,205,196,0.04)',
+          border: '1px solid rgba(78,205,196,0.2)',
+          borderRadius: 8,
+          padding: '10px 12px',
+          marginBottom: 8,
+          animation: 'slideIn 0.2s ease',
+        }}>
+          {f.tips && f.tips.length > 0 && (
+            <div style={{ marginBottom: f.example ? 8 : 0 }}>
+              <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>💡 작성 팁</div>
+              {f.tips.map((tip, ti) => (
+                <div key={ti} style={{ fontSize: 12, color: '#64748B', marginBottom: 3, display: 'flex', gap: 6 }}>
+                  <span style={{ color: '#4ECDC4', flexShrink: 0 }}>·</span>
+                  <span>{tip}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {f.example && (
+            <div>
+              <div style={{ fontSize: 10, color: '#A78BFA', letterSpacing: 2, marginBottom: 6 }}>✏️ 예시 답변</div>
+              <div style={{ fontSize: 12, color: '#475569', lineHeight: 1.6, fontStyle: 'italic' }}>{f.example}</div>
+            </div>
+          )}
+        </div>
+      )}
+      {f.type === 'text' && (
+        <input
+          value={(value as string) ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={f.placeholder}
+          style={inputStyle}
+        />
+      )}
+      {f.type === 'textarea' && (
+        <textarea
+          value={(value as string) ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={f.placeholder}
+          rows={f.rows ?? 5}
+          style={{ ...inputStyle, resize: 'vertical' }}
+        />
+      )}
+      {f.type === 'list' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {Array.from({ length: f.count ?? 0 }).map((_, i) => (
+            <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <span style={{ fontSize: 12, color: '#334155', minWidth: 16 }}>{i + 1}.</span>
+              <input
+                value={((value as string[] | undefined) ?? [])[i] ?? ''}
+                onChange={(e) => onListItemChange(i, e.target.value)}
+                placeholder={f.placeholder}
+                style={{ ...inputStyle, flex: 1 }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+      {f.type === 'tag-search' && (
+        <TechStackInput
+          value={(value as string[] | undefined) ?? []}
+          onChange={(val: string[]) => onChange(val)}
+          placeholder={f.placeholder}
+        />
+      )}
+    </div>
+  )
+}

--- a/fe/src/features/ai-check/hooks/useAiCheckForm.ts
+++ b/fe/src/features/ai-check/hooks/useAiCheckForm.ts
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
+import type { AiFormConfig } from '../types/aiCheck.types'
+import { submitAiCheck, submitBossPackage } from '../api/aiCheckApi'
+
+interface UseAiCheckFormParams {
+  questId: string
+  cfg: AiFormConfig
+  onResult: (result: AiEvaluationResult | BossPackageResult) => void
+  onSubmit?: (values: Record<string, unknown>) => void
+  initialValues?: Record<string, unknown>
+}
+
+export function useAiCheckForm({ questId, cfg, onResult, onSubmit, initialValues }: UseAiCheckFormParams) {
+  const [values, setValues] = useState<Record<string, unknown>>(initialValues ?? {})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [activeHint, setActiveHint] = useState<string | null>(null)
+
+  const set = (key: string, value: unknown) =>
+    setValues((prev) => ({ ...prev, [key]: value }))
+
+  const setListItem = (key: string, index: number, value: string) =>
+    setValues((prev) => {
+      const arr = [...((prev[key] as string[] | undefined) ?? [])]
+      arr[index] = value
+      return { ...prev, [key]: arr }
+    })
+
+  const handleActiveHintChange = (key: string | null) => setActiveHint(key)
+
+  const handleSubmit = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      onSubmit?.(values)
+      const body = cfg.transform(values)
+      const result =
+        questId === '4-BOSS'
+          ? await submitBossPackage(body)
+          : await submitAiCheck(cfg.endpoint, body)
+      onResult(result)
+    } catch (e) {
+      setError('서버 연결 오류: ' + (e instanceof Error ? e.message : String(e)))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    values,
+    loading,
+    error,
+    activeHint,
+    set,
+    setListItem,
+    setActiveHint: handleActiveHintChange,
+    handleSubmit,
+  }
+}


### PR DESCRIPTION
## Summary
- useAiCheckForm 훅: values/loading/error/activeHint 상태 + set/setListItem/handleSubmit 로직 분리
- FormField 컴포넌트: 필드 타입별 렌더링 (text/textarea/list/tag-search) + hint UI 캡슐화
- AiCheckForm은 훅과 컴포넌트 조합만 담당하는 얇은 컴포넌트로 축소

## Test plan
- [ ] TypeScript 타입 오류 없음
- [ ] AI 폼 제출 동작 정상

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)