### PR TITLE
fix(chore): add python3 fallback for jq in assert-not-main.sh

### DIFF
--- a/.claude/scripts/assert-not-main.sh
+++ b/.claude/scripts/assert-not-main.sh
@@ -5,7 +5,11 @@
 # stdin에서 tool input JSON 읽기 (Claude Code 훅 프로토콜)
 INPUT=$(cat)
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || echo "")
+if command -v jq &>/dev/null; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || echo "")
+else
+  FILE_PATH=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path') or d.get('tool_input',{}).get('path') or '')" 2>/dev/null || echo "")
+fi
 
 # git 레포 외부 경로 (메모리, 홈 디렉토리 등)는 브랜치와 무관 → 허용
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- WSL 환경에 `jq`가 없어 `FILE_PATH` 파싱이 실패, `/home/` 경로도 main 브랜치에서 차단되는 버그 수정
- `jq` 없을 때 `python3`로 fallback 처리

## Root cause
`jq` 미설치 → `FILE_PATH=""` → repo-external 체크 스킵 → branch 체크로 낙하 → `/home/dhbang/.claude/` 등 외부 경로 차단

## Test
- `/home/dhbang/...` 경로: exit 0 (허용) ✅
- repo 내부 파일 (main 브랜치): exit 2 (차단) ✅

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)