### PR TITLE
fix(chore): replace check run with commit status in copilot gate

### DIFF
--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      actions: write
+      statuses: write
 
     steps:
       - name: Claude가 Copilot 리뷰 코멘트에 자동 답글
@@ -26,8 +26,20 @@ jobs:
 
             core.notice(`오픈 PR ${openPRs.length}건 조회`);
 
+            const setStatus = async (sha, state, description) => {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state,
+                context: 'check-copilot-review',
+                description,
+              });
+            };
+
             for (const pr of openPRs) {
               const prNumber = pr.number;
+              const sha = pr.head.sha;
 
               const reviews = await github.paginate(
                 github.rest.pulls.listReviews,
@@ -57,7 +69,11 @@ jobs:
 
               const unreplied = copilotTopComments.filter(c => !repliedIds.has(c.id));
 
-              if (unreplied.length === 0) continue;
+              if (unreplied.length === 0) {
+                // 모든 코멘트 처리됨 → success 갱신
+                await setStatus(sha, 'success', `Copilot 리뷰 ${copilotTopComments.length}건 — 모두 처리됨`);
+                continue;
+              }
 
               core.notice(`PR #${prNumber}: 미답변 Copilot 코멘트 ${unreplied.length}건 처리 시작`);
 
@@ -131,18 +147,15 @@ jobs:
                 }
               }
 
+              // 답글 완료 후 남은 미처리 수 재계산해서 Commit Status 업데이트
               if (repliedCount > 0) {
-                try {
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'copilot-review-evaluator.yml',
-                    ref: pr.head.ref,
-                    inputs: { pr_number: String(prNumber) },
-                  });
-                  core.notice(`PR #${prNumber}: Gate 재실행 dispatch 완료`);
-                } catch (e) {
-                  core.warning(`PR #${prNumber}: Gate dispatch 실패: ${e.message}`);
+                const remaining = unreplied.length - repliedCount;
+                if (remaining === 0) {
+                  await setStatus(sha, 'success', `Copilot 리뷰 ${copilotTopComments.length}건 — 모두 처리됨`);
+                  core.notice(`PR #${prNumber}: Commit Status → success`);
+                } else {
+                  await setStatus(sha, 'failure', `미처리 ${remaining}건 남음`);
+                  core.notice(`PR #${prNumber}: Commit Status → failure (${remaining}건 남음)`);
                 }
               }
             }

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -3,14 +3,10 @@ name: Copilot Review Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, dismissed]
-  pull_request_review_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to evaluate (from Claude Review Responder)'
+        description: 'PR number to evaluate'
         required: false
         type: string
 
@@ -26,12 +22,34 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.inputs?.pr_number  // workflow_dispatch
-              ?? context.payload.pull_request?.number
-              ?? context.payload.review?.pull_request_url?.split('/').pop()
-              ?? context.payload.comment?.pull_request_url?.split('/').pop();
+            const prNumber = context.payload.inputs?.pr_number
+              ?? context.payload.pull_request?.number;
 
-            // 1. Copilot이 리뷰를 달았는지 확인
+            if (!prNumber) {
+              core.warning('PR number을 확인할 수 없습니다.');
+              return;
+            }
+
+            // PR HEAD SHA 조회
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(prNumber),
+            });
+            const sha = pr.head.sha;
+
+            const setStatus = async (state, description) => {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state,
+                context: 'check-copilot-review',
+                description,
+              });
+            };
+
+            // 1. Copilot 리뷰 여부 확인
             const reviews = await github.paginate(
               github.rest.pulls.listReviews,
               { owner: context.repo.owner, repo: context.repo.repo, pull_number: Number(prNumber) }
@@ -42,11 +60,11 @@ jobs:
             );
 
             if (copilotReviews.length === 0) {
-              core.setFailed('Copilot 리뷰 대기 중 — 리뷰가 달리면 자동으로 재평가됩니다.');
+              await setStatus('pending', 'Copilot 리뷰 대기 중');
               return;
             }
 
-            // 2. 미해결 인라인 코멘트 수집
+            // 2. 미처리 인라인 코멘트 수집
             const allComments = await github.paginate(
               github.rest.pulls.listReviewComments,
               { owner: context.repo.owner, repo: context.repo.repo, pull_number: Number(prNumber) }
@@ -54,12 +72,10 @@ jobs:
 
             const copilotReviewIds = new Set(copilotReviews.map(r => r.id));
 
-            // Copilot 최상위 코멘트 (답글 아닌 것)
             const copilotTopComments = allComments.filter(c =>
               copilotReviewIds.has(c.pull_request_review_id) && !c.in_reply_to_id
             );
 
-            // 답글이 달린 코멘트 ID 수집 (수용/거부 무관하게 답글 존재 = 처리됨)
             const repliedIds = new Set(
               allComments
                 .filter(c => c.in_reply_to_id)
@@ -70,14 +86,12 @@ jobs:
 
             // 3. 판정
             if (unresolvedComments.length === 0) {
-              core.notice(`Copilot 리뷰 ${copilotTopComments.length}건 — 모두 처리됨 (수용/거부 무관). 통과`);
+              await setStatus('success', `Copilot 리뷰 ${copilotTopComments.length}건 — 모두 처리됨`);
               return;
             }
 
             const summary = unresolvedComments
-              .map(c => `- \`${c.path}:${c.line ?? c.original_line ?? '?'}\` — ${c.body.slice(0, 100)}`)
-              .join('\n');
+              .map(c => `${c.path}:${c.line ?? c.original_line ?? '?'}`)
+              .join(', ');
 
-            core.setFailed(
-              `Copilot 리뷰 미처리 코멘트 ${unresolvedComments.length}건\n\n${summary}\n\n수용/거부 무관하게 답글을 달면 통과됩니다.`
-            );
+            await setStatus('failure', `미처리 ${unresolvedComments.length}건: ${summary}`.slice(0, 140));


### PR DESCRIPTION
## 문제

\`workflow_dispatch\`로 생성된 check run은 PR의 check_suite에 귀속되지 않아 \`mergeStateStatus\`가 BLOCKED 상태로 남았다. 이 때문에 매번 \`--admin\` 머지가 필요했다.

## 근본 원인

```
workflow_dispatch → 독립 check_suite 생성 → PR check_suite와 무관
→ statusCheckRollup이 원래 FAILURE check run을 참조 → BLOCKED
```

## 변경 내용

**copilot-review-evaluator.yml**
- \`core.setFailed()\` / \`core.notice()\` → \`createCommitStatus(pending/failure/success)\`
- PR number로 HEAD SHA 직접 조회 후 Commit Status 기록
- check run annotation 제거 → Commit Status는 SHA에 직접 붙어 actor 무관하게 반영

**claude-review-responder.yml**
- 답글 완료 후 \`createWorkflowDispatch()\` → \`createCommitStatus()\` 직접 호출
- dispatch → check_suite 귀속 문제 완전 제거

## 결과

- \`--admin\` 머지 불필요
- 봇/사람 모두 트리거 가능, 결과가 \`mergeStateStatus\`에 즉시 반영

## 브랜치 보호 설정 변경 필요

PR 머지 후 \`check-copilot-review\` required check의 \`app_id\`를 null로 변경해야 함:
```bash
gh api repos/bangddong/switch-job-quest/branches/main/protection/required_status_checks \
  -X PATCH --input - << 'JSON'
{"strict": false, "checks": [
  {"context": "FE CI / build", "app_id": -1},
  {"context": "BE CI / test", "app_id": -1},
  {"context": "check-copilot-review", "app_id": -1}
]}
JSON
```

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)