### PR TITLE
chore(ci): Copilot 수용 제안 Issue 기록 + 배치 Fix 워크플로우

### DIFF
--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       pull-requests: write
       statuses: write
+      issues: write
 
     steps:
       - name: Claude가 Copilot 리뷰 코멘트에 자동 답글
@@ -132,12 +133,70 @@ jobs:
                   const data = await res.json();
                   const reply = data.content[0].text.trim();
 
+                  const isAccepted = reply.includes('수정하는 걸 권장');
+
+                  let replyBody = `🤖 **Claude 자동 평가**\n\n${reply}`;
+
+                  if (isAccepted) {
+                    const lineRef = comment.line ?? comment.original_line ?? '?';
+                    const issueTitle = `[Copilot] ${comment.path}:${lineRef}`;
+                    const issueBody = [
+                      `## Copilot 제안`,
+                      ``,
+                      `- **PR:** #${prNumber} — ${pr.title}`,
+                      `- **파일:** \`${comment.path}\`:${lineRef}`,
+                      `- **브랜치:** \`${pr.head.ref}\``,
+                      ``,
+                      `### Claude 평가`,
+                      reply,
+                      ``,
+                      `### Copilot 코멘트`,
+                      comment.body,
+                      ``,
+                      `### 코드 컨텍스트`,
+                      '```diff',
+                      comment.diff_hunk,
+                      '```',
+                    ].join('\n');
+
+                    try {
+                      // copilot-suggestion 라벨 보장 (없으면 생성)
+                      try {
+                        await github.rest.issues.getLabel({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          name: 'copilot-suggestion',
+                        });
+                      } catch {
+                        await github.rest.issues.createLabel({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          name: 'copilot-suggestion',
+                          color: '0075ca',
+                          description: 'Copilot 리뷰에서 수용된 제안',
+                        });
+                      }
+
+                      const { data: issue } = await github.rest.issues.create({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        title: issueTitle,
+                        body: issueBody,
+                        labels: ['copilot-suggestion'],
+                      });
+                      replyBody += `\n\n→ 수정 이슈 등록: #${issue.number}`;
+                      core.notice(`이슈 생성: #${issue.number} (${comment.path}:${lineRef})`);
+                    } catch (e) {
+                      core.warning(`이슈 생성 실패: ${e.message}`);
+                    }
+                  }
+
                   await github.rest.pulls.createReplyForReviewComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: prNumber,
                     comment_id: comment.id,
-                    body: `🤖 **Claude 자동 평가**\n\n${reply}`,
+                    body: replyBody,
                   });
 
                   core.notice(`답글 완료: comment ${comment.id}`);

--- a/.github/workflows/copilot-batch-fix.yml
+++ b/.github/workflows/copilot-batch-fix.yml
@@ -1,0 +1,131 @@
+name: Copilot Batch Fix
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1'  # 매주 월요일 오전 9시 UTC
+
+jobs:
+  batch-fix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Collect open copilot-suggestion issues
+        id: collect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: 'copilot-suggestion',
+                state: 'open',
+              }
+            );
+
+            if (issues.length === 0) {
+              core.notice('처리할 copilot-suggestion 이슈가 없습니다.');
+              core.setOutput('has_issues', 'false');
+              return;
+            }
+
+            core.setOutput('has_issues', 'true');
+            core.setOutput('issue_count', issues.length.toString());
+            core.setOutput('issue_numbers', issues.map(i => i.number).join(','));
+
+            const fs = require('fs');
+            fs.writeFileSync('/tmp/issues.json', JSON.stringify(issues, null, 2));
+            core.notice(`${issues.length}개 이슈 수집`);
+
+      - name: Setup git and create branch
+        if: steps.collect.outputs.has_issues == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="fix/copilot-batch-$(date +%Y%m%d)"
+          git checkout -b $BRANCH
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Install Claude CLI
+        if: steps.collect.outputs.has_issues == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Generate prompt and run Claude
+        if: steps.collect.outputs.has_issues == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          node << 'SCRIPT'
+          const issues = require('/tmp/issues.json');
+          const items = issues.map(issue =>
+            `### 이슈 #${issue.number}: ${issue.title}\n\n${issue.body}`
+          ).join('\n\n---\n\n');
+
+          const prompt = `당신은 Spring Boot(Kotlin) + React(TypeScript) 풀스택 프로젝트의 코드 개선 담당자입니다.
+
+다음은 GitHub Copilot 코드 리뷰에서 수용된 제안들입니다.
+각 제안에 대해 해당 파일을 읽고 제안된 개선 사항을 적용해주세요.
+
+## 규칙
+- be/ 경로 파일: Kotlin/Spring Boot 컨벤션 (be/CLAUDE.md 참고)
+- fe/ 경로 파일: React/TypeScript 컨벤션 (fe/CLAUDE.md 참고)
+- 수정 범위는 제안된 부분만, 불필요한 리팩토링 금지
+- 각 이슈 처리 후 git commit (메시지 형식: "fix: apply copilot suggestion (#이슈번호)")
+
+## 수용된 제안 목록
+
+${items}`;
+
+          require('fs').writeFileSync('/tmp/prompt.txt', prompt);
+          SCRIPT
+
+          claude -p "$(cat /tmp/prompt.txt)" \
+            --allowedTools "Read,Edit,Bash" \
+            --model claude-sonnet-4-6
+
+      - name: Check for changes and push
+        if: steps.collect.outputs.has_issues == 'true'
+        id: push
+        run: |
+          if git diff --quiet HEAD; then
+            echo "변경사항 없음 — 수정할 코드가 없습니다."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git push origin $BRANCH
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR
+        if: steps.collect.outputs.has_issues == 'true' && steps.push.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ env.BRANCH }}
+          ISSUE_NUMBERS: ${{ steps.collect.outputs.issue_numbers }}
+          ISSUE_COUNT: ${{ steps.collect.outputs.issue_count }}
+        with:
+          script: |
+            const issueNumbers = process.env.ISSUE_NUMBERS.split(',');
+            const closes = issueNumbers.map(n => `closes #${n}`).join('\n');
+            const count = process.env.ISSUE_COUNT;
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `fix: Copilot 제안 배치 적용 (${count}건)`,
+              body: `## Copilot 제안 배치 수정\n\n${closes}\n\n🤖 자동 생성된 PR — copilot-batch-fix 워크플로우`,
+              head: process.env.BRANCH,
+              base: 'main',
+            });
+
+            core.notice(`PR 생성: #${pr.number} — ${pr.html_url}`);


### PR DESCRIPTION
## Summary

- `claude-review-responder`: 수용 판단(`수정하는 걸 권장`) 시 `copilot-suggestion` 라벨 GitHub Issue 자동 생성, 답글에 이슈 링크 포함
- `copilot-batch-fix`: 매주 월요일 or `workflow_dispatch`로 open 이슈 수집 → Claude CLI headless 실행 → 수정 커밋 → PR 자동 생성

## Flow

\`\`\`
PR Open
  → Copilot review
  → Claude 타당성 검토 + 댓글
  → 수용 시: Issue #N 생성 (컨텍스트 보존)
  → PR merge (빠름)

매주 월요일 or 수동 트리거
  → copilot-suggestion 이슈 수집
  → Claude CLI 배치 수정
  → fix/copilot-batch-YYYYMMDD 브랜치 PR 생성
  → 이슈 자동 close
\`\`\`

## Test plan

- [ ] PR에 Copilot 인라인 코멘트 수용 → Issue 생성 확인
- [ ] `workflow_dispatch`로 copilot-batch-fix 수동 실행 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)