### PR TITLE
chore(be): Sentry + Logtail observability 추가

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -1,0 +1,35 @@
+# 미완료 작업 (사용자 직접 실행 필요)
+
+## [Observability] Sentry + Logtail 설정 완료 (PR #48 머지 후)
+
+### 1. Sentry 설정
+
+1. [sentry.io](https://sentry.io) 가입 → New Project → **Java Spring**
+2. DSN 복사 (형식: `https://xxx@o000.ingest.sentry.io/000`)
+3. Fly.io secret 등록:
+   ```bash
+   flyctl secrets set SENTRY_DSN=<복사한 DSN> --app devquest-api
+   ```
+
+### 2. Logtail (Better Stack) 설정
+
+1. [betterstack.com](https://betterstack.com) 가입 → Logs → **New Source**
+   - Platform: **HTTP** 선택
+   - Source 이름: `devquest-api`
+2. Source token 복사
+3. Fly.io log drain 등록:
+   ```bash
+   flyctl logs drain create https://in.logs.betterstack.com \
+     --app devquest-api \
+     -H "Authorization: Bearer <복사한 토큰>"
+   ```
+4. drain 확인:
+   ```bash
+   flyctl logs drain list --app devquest-api
+   ```
+
+### 완료 후 검증
+
+- Fly.io에서 앱 재시작: `flyctl machine restart --app devquest-api`
+- 로그인 시도 → Sentry에서 에러 캡처 확인
+- Logtail 대시보드에서 실시간 로그 확인

--- a/be/core/core-api/build.gradle.kts
+++ b/be/core/core-api/build.gradle.kts
@@ -7,6 +7,8 @@ tasks.named<Jar>("jar").configure {
 }
 
 dependencies {
+    implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.0.0")
+
     implementation(project(":core:core-enum"))
     implementation(project(":core:core-domain"))
     implementation(project(":support:logging"))

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -30,7 +30,7 @@ logging:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SPRING_PROFILES_ACTIVE:local}
-  traces-sample-rate: 1.0
+  traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:0.1}
   logging:
     minimum-event-level: error
     minimum-breadcrumb-level: info

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -27,6 +27,14 @@ logging:
   level:
     com.devquest: DEBUG
 
+sentry:
+  dsn: ${SENTRY_DSN:}
+  environment: ${SPRING_PROFILES_ACTIVE:local}
+  traces-sample-rate: 1.0
+  logging:
+    minimum-event-level: error
+    minimum-breadcrumb-level: info
+
 devquest:
   ai:
     pass-score: 70


### PR DESCRIPTION
## Summary

- **Sentry 8.0.0** SDK 추가 — 예외 자동 캡처, 스택 트레이스 영구 보관
- **application.yml** sentry 설정 — DSN 미설정 시 자동 비활성 (`${SENTRY_DSN:}`)
- **Logtail** — 코드 변경 없음, flyctl log drain으로 설정 (가이드: `.claude/TASKS.md`)

## 해결하는 문제

Fly.io 로그 버퍼가 작아서 Spring 예외 발생 시 첫 줄(예외 메시지)이 잘려나가는 문제.
```
ERROR ApiControllerAdvice: Unexpected error: ???  ← 버퍼 오버플로로 소실
java.lang.IllegalStateException: ???             ← 소실
    at AuthController.githubAuth(AuthController.kt:39)  ← 소실
    at JwtAuthFilter...  ← 여기서부터만 보임
```

## 머지 후 사용자 직접 설정 필요

`.claude/TASKS.md` 참고:
1. sentry.io → 프로젝트 생성 → `flyctl secrets set SENTRY_DSN=...`
2. betterstack.com → 소스 생성 → `flyctl logs drain create ...`

## Test plan

- [ ] PR 머지 후 TASKS.md 따라 Sentry DSN 등록
- [ ] 로그인 시도 → Sentry 대시보드에서 에러 캡처 확인
- [ ] Logtail 대시보드에서 실시간 로그 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)