### PR TITLE
fix(be): upgrade sentry to 8.38.0 for Spring Boot 4 compatibility

### DIFF
--- a/be/core/core-api/build.gradle.kts
+++ b/be/core/core-api/build.gradle.kts
@@ -7,7 +7,7 @@ tasks.named<Jar>("jar").configure {
 }
 
 dependencies {
-    implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.0.0")
+    implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.38.0")
 
     implementation(project(":core:core-enum"))
     implementation(project(":core:core-domain"))


### PR DESCRIPTION
## Summary
- Sentry `8.0.0` → `8.38.0` 업그레이드
- Spring Boot 4.0에서 제거된 `RestClientAutoConfiguration` 참조 문제 해결
- Sentry Spring Boot 4 GA 지원은 8.27.0부터

## 원인
```
ClassNotFoundException: org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration
```
Sentry 8.0.0이 Spring Boot 3.x 기준으로 작성되어 Spring Boot 4.0에서 앱 시작 실패 → 502

## Test plan
- [ ] PR 머지 후 Fly.io 자동 재배포 확인
- [ ] `flyctl logs --app devquest-api`에서 정상 기동 확인
- [ ] Sentry 대시보드 연결 확인

🤖 Generated with [Claude Code](https://claude.ai/code)