### PR TITLE
fix(be): remove sentry until Spring Boot 4.x support is stable

### DIFF
--- a/be/core/core-api/build.gradle.kts
+++ b/be/core/core-api/build.gradle.kts
@@ -7,8 +7,6 @@ tasks.named<Jar>("jar").configure {
 }
 
 dependencies {
-    implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.38.0")
-
     implementation(project(":core:core-enum"))
     implementation(project(":core:core-domain"))
     implementation(project(":support:logging"))

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -27,14 +27,6 @@ logging:
   level:
     com.devquest: DEBUG
 
-sentry:
-  dsn: ${SENTRY_DSN:}
-  environment: ${SPRING_PROFILES_ACTIVE:local}
-  traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:0.1}
-  logging:
-    minimum-event-level: error
-    minimum-breadcrumb-level: info
-
 devquest:
   ai:
     pass-score: 70


### PR DESCRIPTION
## Summary
- Sentry 의존성 및 `application.yml` Sentry 설정 제거
- Spring Boot 4.0.x에서 `RestClientAutoConfiguration` 클래스가 존재하지 않아 앱 기동 실패 → 502 발생
- Sentry가 Spring Boot 4.x를 공식 지원하면 재추가 예정

## 원인
Sentry의 `SentryAutoConfiguration`이 Spring Boot 3.x 기준 클래스인 `RestClientAutoConfiguration`을 참조 — Spring Boot 4.0.3에 해당 클래스 없음. 버전 업그레이드(8.0.0 → 8.38.0)로도 해결 불가.

## Test plan
- [ ] PR 머지 후 앱 정상 기동 확인
- [ ] `https://api.quest.dhbang.co.kr/api/v1/quests` 200 응답 확인

🤖 Generated with [Claude Code](https://claude.ai/code)