### PR TITLE
feat(fe): add 5 stats panels to GrowthDashboard

### DIFF
--- a/fe/src/features/growth/components/ActPassRate.tsx
+++ b/fe/src/features/growth/components/ActPassRate.tsx
@@ -1,0 +1,63 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import type { QuestHistoryItem } from '@/types/api.types'
+
+interface ActPassRateProps {
+  history: QuestHistoryItem[]
+}
+
+const ACT_COLORS = ['#4ECDC4', '#A78BFA', '#F59E0B', '#10B981', '#EF4444']
+
+export function ActPassRate({ history }: ActPassRateProps) {
+  const data = [1, 2, 3, 4, 5].map((actId) => {
+    const actHistory = history.filter((h) => h.actId === actId)
+    const total = actHistory.length
+    const passed = actHistory.filter((h) => h.passed).length
+    return {
+      name: `ACT ${actId}`,
+      rate: total === 0 ? 0 : Math.round((passed / total) * 100),
+      total,
+    }
+  })
+
+  return (
+    <div style={{ width: '100%', height: 180 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -24, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis
+            dataKey="name"
+            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 100]}
+            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              background: '#0F172A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+              fontSize: 12,
+              color: '#F8FAFC',
+            }}
+            formatter={(value, _name, props) => [
+              `${value}% (${(props.payload as { total: number } | undefined)?.total ?? 0}회 시도)`,
+              '합격률',
+            ]}
+            labelStyle={{ color: '#475569' }}
+          />
+          <Bar dataKey="rate" radius={[4, 4, 0, 0]}>
+            {data.map((_, i) => (
+              <Cell key={i} fill={ACT_COLORS[i]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/fe/src/features/growth/components/GradeDistribution.tsx
+++ b/fe/src/features/growth/components/GradeDistribution.tsx
@@ -1,0 +1,55 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import type { QuestHistoryItem } from '@/types/api.types'
+import { GRADE_COLORS } from '@/utils/gradeUtils'
+
+interface GradeDistributionProps {
+  history: QuestHistoryItem[]
+}
+
+const GRADES = ['S', 'A', 'B', 'C', 'D']
+
+export function GradeDistribution({ history }: GradeDistributionProps) {
+  const data = GRADES.map((grade) => ({
+    grade,
+    count: history.filter((h) => h.grade === grade).length,
+  }))
+
+  return (
+    <div style={{ width: '100%', height: 180 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -24, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis
+            dataKey="grade"
+            tick={{ fill: '#475569', fontSize: 13, fontFamily: "'Courier New', monospace", fontWeight: 'bold' }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <YAxis
+            allowDecimals={false}
+            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              background: '#0F172A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+              fontSize: 12,
+              color: '#F8FAFC',
+            }}
+            formatter={(value) => [`${value}회`, '횟수']}
+            labelStyle={{ color: '#475569' }}
+          />
+          <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+            {data.map((entry) => (
+              <Cell key={entry.grade} fill={GRADE_COLORS[entry.grade] ?? '#475569'} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -4,6 +4,11 @@ import type { QuestHistoryItem } from '@/types/api.types'
 import { fetchHistory } from '@/lib/apiClient'
 import { ScoreTimeline } from './ScoreTimeline'
 import { QuestHistoryList } from './QuestHistoryList'
+import { ActPassRate } from './ActPassRate'
+import { GradeDistribution } from './GradeDistribution'
+import { StreakBadge } from './StreakBadge'
+import { HourlyActivity } from './HourlyActivity'
+import { QuestAttemptCount } from './QuestAttemptCount'
 
 interface BestScoreEntry {
   questId: string
@@ -171,6 +176,135 @@ export function GrowthDashboard() {
                   </ResponsiveContainer>
                 </div>
               )}
+            </div>
+          </section>
+
+          {/* ACT별 합격률 */}
+          <section style={{ marginBottom: 28 }}>
+            <div
+              style={{
+                fontSize: 12,
+                color: '#475569',
+                marginBottom: 10,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              ACT별 합격률
+            </div>
+            <div
+              style={{
+                background: '#0F172A',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 10,
+                padding: '16px 8px 8px',
+              }}
+            >
+              <ActPassRate history={history} />
+            </div>
+          </section>
+
+          {/* 등급 분포 + 연속 스트릭 */}
+          <section style={{ marginBottom: 28, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+            <div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: '#475569',
+                  marginBottom: 10,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}
+              >
+                등급 분포
+              </div>
+              <div
+                style={{
+                  background: '#0F172A',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 10,
+                  padding: '16px 8px 8px',
+                  height: '100%',
+                }}
+              >
+                <GradeDistribution history={history} />
+              </div>
+            </div>
+            <div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: '#475569',
+                  marginBottom: 10,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}
+              >
+                연속 학습 스트릭
+              </div>
+              <div
+                style={{
+                  background: '#0F172A',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 10,
+                  padding: '8px',
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                <StreakBadge history={history} />
+              </div>
+            </div>
+          </section>
+
+          {/* 시간대별 활동 */}
+          <section style={{ marginBottom: 28 }}>
+            <div
+              style={{
+                fontSize: 12,
+                color: '#475569',
+                marginBottom: 10,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              시간대별 활동
+            </div>
+            <div
+              style={{
+                background: '#0F172A',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 10,
+                padding: '16px 8px 8px',
+              }}
+            >
+              <HourlyActivity history={history} />
+            </div>
+          </section>
+
+          {/* 퀘스트별 시도 횟수 */}
+          <section style={{ marginBottom: 28 }}>
+            <div
+              style={{
+                fontSize: 12,
+                color: '#475569',
+                marginBottom: 10,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              퀘스트별 시도 횟수 (많은 순)
+            </div>
+            <div
+              style={{
+                background: '#0F172A',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 10,
+                padding: '16px 8px 8px',
+              }}
+            >
+              <QuestAttemptCount history={history} />
             </div>
           </section>
 

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -1,0 +1,52 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import type { QuestHistoryItem } from '@/types/api.types'
+
+interface HourlyActivityProps {
+  history: QuestHistoryItem[]
+}
+
+export function HourlyActivity({ history }: HourlyActivityProps) {
+  const counts = Array.from({ length: 24 }, (_, hour) => ({
+    hour: `${String(hour).padStart(2, '0')}시`,
+    count: history.filter((h) => new Date(h.createdAt).getHours() === hour).length,
+  }))
+
+  const maxCount = Math.max(...counts.map((c) => c.count), 1)
+
+  return (
+    <div style={{ width: '100%', height: 180 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={counts} margin={{ top: 8, right: 8, left: -24, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis
+            dataKey="hour"
+            tick={{ fill: '#475569', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+            interval={2}
+          />
+          <YAxis
+            allowDecimals={false}
+            domain={[0, maxCount]}
+            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              background: '#0F172A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+              fontSize: 12,
+              color: '#F8FAFC',
+            }}
+            formatter={(value) => [`${value}회`, '시도']}
+            labelStyle={{ color: '#475569' }}
+          />
+          <Bar dataKey="count" fill="#60A5FA" radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/fe/src/features/growth/components/QuestAttemptCount.tsx
+++ b/fe/src/features/growth/components/QuestAttemptCount.tsx
@@ -1,0 +1,73 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import type { QuestHistoryItem } from '@/types/api.types'
+
+interface QuestAttemptCountProps {
+  history: QuestHistoryItem[]
+}
+
+export function QuestAttemptCount({ history }: QuestAttemptCountProps) {
+  const countMap = new Map<string, number>()
+  for (const item of history) {
+    countMap.set(item.questId, (countMap.get(item.questId) ?? 0) + 1)
+  }
+
+  const data = Array.from(countMap.entries())
+    .map(([questId, count]) => ({ questId, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10)
+
+  if (data.length === 0) {
+    return (
+      <div
+        style={{
+          padding: '32px 0',
+          textAlign: 'center',
+          color: '#475569',
+          fontSize: 13,
+          fontFamily: "'Courier New', monospace",
+        }}
+      >
+        아직 기록이 없습니다
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ width: '100%', height: 200 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -24, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis
+            dataKey="questId"
+            tick={{ fill: '#475569', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+            interval={0}
+            angle={-30}
+            textAnchor="end"
+            height={40}
+          />
+          <YAxis
+            allowDecimals={false}
+            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              background: '#0F172A',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+              fontSize: 12,
+              color: '#F8FAFC',
+            }}
+            formatter={(value) => [`${value}회`, '시도 횟수']}
+            labelStyle={{ color: '#475569' }}
+          />
+          <Bar dataKey="count" fill="#F59E0B" radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/fe/src/features/growth/components/StreakBadge.tsx
+++ b/fe/src/features/growth/components/StreakBadge.tsx
@@ -1,0 +1,45 @@
+import type { QuestHistoryItem } from '@/types/api.types'
+
+interface StreakBadgeProps {
+  history: QuestHistoryItem[]
+}
+
+function toDateStr(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function calcStreak(history: QuestHistoryItem[]): number {
+  const activeDates = new Set(history.map((h) => toDateStr(new Date(h.createdAt))))
+  let streak = 0
+  const cursor = new Date()
+  while (activeDates.has(toDateStr(cursor))) {
+    streak++
+    cursor.setDate(cursor.getDate() - 1)
+  }
+  return streak
+}
+
+export function StreakBadge({ history }: StreakBadgeProps) {
+  const streak = calcStreak(history)
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 16,
+        padding: '24px 0',
+        fontFamily: "'Courier New', monospace",
+      }}
+    >
+      <div style={{ textAlign: 'center' }}>
+        <div style={{ fontSize: 48, fontWeight: 'bold', color: streak > 0 ? '#F59E0B' : '#334155', lineHeight: 1 }}>
+          {streak}
+        </div>
+        <div style={{ fontSize: 12, color: '#475569', marginTop: 6 }}>연속 학습일</div>
+      </div>
+      <div style={{ fontSize: 36 }}>{streak >= 7 ? '🔥' : streak >= 3 ? '⚡' : streak > 0 ? '✨' : '💤'}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **ACT별 합격률**: ACT 1~5 각각 합격/전체 비율 바 차트
- **등급 분포**: S/A/B/C/D 획득 횟수 바 차트
- **연속 학습 스트릭**: 오늘 포함 연속 도전일수 + 이모지 (💤/✨/⚡/🔥)
- **시간대별 활동**: 0~23시 시도 분포 바 차트
- **퀘스트별 시도 횟수**: 가장 많이 시도한 퀘스트 TOP 10

BE 추가 없이 기존 `/api/v1/progress/history` 데이터만 활용.

## Test plan

- [ ] 히스토리 데이터가 있을 때 5개 차트 정상 렌더링 확인
- [ ] 히스토리 데이터가 없을 때 빈 상태 처리 확인 (ActPassRate 0%, StreakBadge 0일)
- [ ] 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)