### PR TITLE
chore(be): migrate database from H2 to PostgreSQL with Flyway

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -25,7 +25,7 @@ storage:
   datasource:
     core:
       driver-class-name: org.postgresql.Driver
-      jdbc-url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+      jdbc-url: jdbc:postgresql://${DB_HOST}/${DB_NAME}?sslmode=require
       username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
       maximum-pool-size: 10

--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -6,8 +6,26 @@ spring:
   h2:
     console:
       enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 server:
   error:
     include-stacktrace: never
     include-message: never
+
+storage:
+  datasource:
+    core:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+      username: ${DB_USERNAME}
+      password: ${DB_PASSWORD}
+      maximum-pool-size: 10

--- a/be/storage/db-core/build.gradle.kts
+++ b/be/storage/db-core/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":core:core-enum"))
 
     api("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("org.postgresql:postgresql")
 }

--- a/be/storage/db-core/src/main/resources/db-core.yml
+++ b/be/storage/db-core/src/main/resources/db-core.yml
@@ -8,6 +8,8 @@ storage:
       maximum-pool-size: 5
 
 spring:
+  flyway:
+    enabled: false
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/be/storage/db-core/src/main/resources/db/migration/V1__init.sql
+++ b/be/storage/db-core/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,34 @@
+CREATE TABLE quest_progress
+(
+    id                  BIGSERIAL PRIMARY KEY,
+    user_id             VARCHAR(255) NOT NULL,
+    quest_id            VARCHAR(255) NOT NULL,
+    act_id              INTEGER      NOT NULL,
+    status              VARCHAR(50)  NOT NULL DEFAULT 'NOT_STARTED',
+    ai_score            INTEGER      NOT NULL DEFAULT 0,
+    earned_xp           INTEGER      NOT NULL DEFAULT 0,
+    ai_evaluation_json  TEXT,
+    completed_at        TIMESTAMP,
+    created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_quest_progress_user_quest ON quest_progress (user_id, quest_id);
+CREATE INDEX idx_quest_progress_user_id ON quest_progress (user_id);
+
+CREATE TABLE quest_history
+(
+    id         BIGSERIAL PRIMARY KEY,
+    user_id    VARCHAR(255) NOT NULL,
+    quest_id   VARCHAR(255) NOT NULL,
+    act_id     INTEGER      NOT NULL,
+    score      INTEGER      NOT NULL DEFAULT 0,
+    grade      VARCHAR(10)  NOT NULL DEFAULT 'D',
+    passed     BOOLEAN      NOT NULL DEFAULT FALSE,
+    earned_xp  INTEGER      NOT NULL DEFAULT 0,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_quest_history_user_id ON quest_history (user_id);
+CREATE INDEX idx_quest_history_user_quest ON quest_history (user_id, quest_id);


### PR DESCRIPTION
## Summary

- Flyway 의존성 추가 (`flyway-core`, `flyway-database-postgresql`)
- 기본값 `spring.flyway.enabled=false` (H2/로컬 보호) — prod 프로파일에서 `true`로 override
- `application-prod.yml`: PostgreSQL 데이터소스 (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`) + `ddl-auto: validate`
- `V1__init.sql`: `quest_progress` / `quest_history` 초기 스키마 + 인덱스

## 환경변수 (Fly.io secrets 등록 필요)

| 변수 | 설명 |
|------|------|
| `DB_HOST` | PostgreSQL 호스트 |
| `DB_PORT` | 포트 (기본값 5432) |
| `DB_NAME` | 데이터베이스 이름 |
| `DB_USERNAME` | DB 사용자 |
| `DB_PASSWORD` | DB 비밀번호 |

## Test plan

- [x] `db-core` 빌드 성공 확인
- [x] `core-api` 빌드 성공 확인
- [x] `db-core`, `core-api` 테스트 통과
- [ ] Fly.io에 PostgreSQL 추가 후 prod 배포 검증

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)