### PR TITLE
fix(be): fix Flyway not running in prod due to config.import priority

### DIFF
--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -12,6 +12,9 @@ spring:
       - classpath:logging.yml
       - classpath:monitoring.yml
 
+  flyway:
+    enabled: false
+
   h2:
     console:
       enabled: false

--- a/be/storage/db-core/src/main/resources/db-core.yml
+++ b/be/storage/db-core/src/main/resources/db-core.yml
@@ -8,8 +8,6 @@ storage:
       maximum-pool-size: 5
 
 spring:
-  flyway:
-    enabled: false
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## 원인

`db-core.yml`은 `application.yml`에서 `spring.config.import`로 로드됩니다.
Spring Boot에서 import된 파일은 importing 파일보다 **높은 우선순위**를 가지므로,
`db-core.yml`의 `spring.flyway.enabled: false`가 `application-prod.yml`의
`spring.flyway.enabled: true`를 override하고 있었습니다.

결과: prod 배포 시 Flyway bean 자체가 생성되지 않아 마이그레이션 미실행 → `quest_history` 테이블 없음 → 앱 기동 실패

## 수정

- `db-core.yml`에서 `spring.flyway.enabled: false` 제거
- `application.yml`에 `spring.flyway.enabled: false` 추가 (profile-specific이 아닌 기본값)

Profile-specific(`application-prod.yml`)은 non-profile(`application.yml`)보다 항상 높은 우선순위이므로 prod에서 `true`가 정상 적용됩니다.

## 우선순위 구조 (수정 후)

```
application-prod.yml  flyway.enabled: true   ← 최고 우선순위 (profile-specific)
application.yml       flyway.enabled: false  ← 기본값
db-core.yml           (flyway 설정 없음)
```

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)