### PR TITLE
fix(be): use YAML multi-document to disable Flyway only on non-prod

### DIFF
--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -12,9 +12,6 @@ spring:
       - classpath:logging.yml
       - classpath:monitoring.yml
 
-  flyway:
-    enabled: false
-
   h2:
     console:
       enabled: false
@@ -42,3 +39,11 @@ devquest:
     github-client-secret: ${GITHUB_CLIENT_SECRET}
     jwt-secret: ${JWT_SECRET}
     jwt-expiration-ms: ${JWT_EXPIRATION_MS:2592000000}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: "!prod"
+  flyway:
+    enabled: false


### PR DESCRIPTION
## 문제

PR #65에서 `application.yml`에 `spring.flyway.enabled: false`를 추가했지만 Flyway가 여전히 prod에서 실행되지 않음.

Spring Boot 4.x에서 `spring.config.import`로 가져온 파일(db-core.yml)의 설정이 profile-specific 파일(`application-prod.yml`)보다 높은 우선순위를 가질 수 있어, `flyway.enabled: true`가 제대로 적용되지 않는 것으로 추정됨. 증상: Flyway 관련 로그가 전혀 없음 (실행 자체가 안 됨).

## 해결 방법

YAML multi-document 형식을 사용하여 `flyway.enabled: false`를 **명시적으로 `!prod` 프로파일에서만 활성화** 되도록 변경:

```yaml
---
spring:
  config:
    activate:
      on-profile: "!prod"
  flyway:
    enabled: false
```

`prod` 프로파일에서는 이 문서 자체가 로드되지 않으므로, `application-prod.yml`의 `flyway.enabled: true`가 확실히 적용됨.

## 검증 포인트

- [ ] Fly.io 배포 후 Flyway 로그 확인 (`Flyway Community Edition`, `Successfully applied 1 migration` 등)
- [ ] `quest_history`, `quest_progress` 테이블 생성 확인
- [ ] 앱 정상 시작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)