### PR TITLE
fix(ci): re-evaluate Copilot gate on review comment reply

### DIFF
--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -12,9 +12,17 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: copilot-gate-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   check-copilot-review:
     runs-on: ubuntu-latest
+    # pull_request_review_comment 트리거 시 reply 코멘트(in_reply_to_id 있음)일 때만 실행
+    if: >
+      github.event_name != 'pull_request_review_comment' ||
+      github.event.comment.in_reply_to_id != null
     permissions:
       pull-requests: read
       statuses: write

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: copilot-gate-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-copilot-review:

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -3,6 +3,8 @@ name: Copilot Review Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## 문제

Copilot 리뷰 코멘트에 답글을 달아도 gate가 자동으로 재실행되지 않았습니다.

트리거가 `pull_request: [opened, synchronize, reopened]`와 `workflow_dispatch`뿐이라, 사람이 직접 답글을 달면 gate가 재실행되지 않아 수동 `workflow_dispatch`가 필요했습니다.

## 변경

`pull_request_review_comment: [created]` 트리거 추가.

답글이 달리는 즉시 gate가 재실행되어 commit status를 success로 업데이트합니다.

## 동작 흐름 (변경 후)

```
Copilot 리뷰 → gate: failure
  ↓
답글 달기 (사람 or 봇)
  ↓
pull_request_review_comment 이벤트 → gate 자동 재실행 → success
```

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)