### PR TITLE
fix: AI 평가 응답 오류 수정, max-tokens 증가, 로딩 스피너 추가

### DIFF
--- a/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
+++ b/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
@@ -5,7 +5,7 @@ spring:
       chat:
         options:
           model: claude-haiku-4-5-20251001
-          max-tokens: 2000
+          max-tokens: 4000
           temperature: 0.3
 
 devquest:

--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -34,6 +34,23 @@ export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCh
           onListItemChange={(index, val) => setListItem(f.key, index, val)}
         />
       ))}
+      {loading && (
+        <div style={{
+          background: 'rgba(78,205,196,0.06)',
+          border: '1px solid rgba(78,205,196,0.2)',
+          borderRadius: 10,
+          padding: '14px 16px',
+          marginBottom: 12,
+          textAlign: 'center',
+        }}>
+          <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
+            ⟳ AI 분석 중
+          </div>
+          <div style={{ fontSize: 11, color: '#94A3B8' }}>
+            약 30초 소요됩니다. 잠시만 기다려주세요.
+          </div>
+        </div>
+      )}
       {error && (
         <div
           style={{

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -107,7 +107,7 @@ export async function callAiCheck<T>(
 
   const json: ApiResponse<T> = await res.json()
 
-  if (!json.success || json.data == null) {
+  if (json.result !== 'SUCCESS' || json.data == null) {
     throw new Error(json.message ?? 'AI 평가 오류')
   }
 


### PR DESCRIPTION
## Summary
- `apiClient.ts`: `json.success` → `json.result !== 'SUCCESS'` 체크로 수정 (200 응답을 오류로 처리하던 버그)
- `client-ai-anthropic.yml`: `max-tokens` 2000 → 4000 (feedback 잘림 현상 해결)
- `AiCheckForm.tsx`: AI 분석 중 로딩 스피너 UI 추가

## Test plan
- [ ] AI 평가 제출 후 결과 카드 정상 표시 확인
- [ ] feedback 필드가 잘리지 않고 전체 출력 확인
- [ ] 분석 중 로딩 스피너 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)