### PR TITLE
fix(ci): fix Copilot review responder always skipping

### DIFF
--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   respond-to-copilot:
-    if: github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+    if: contains(github.event.review.user.login, 'copilot-pull-request-reviewer')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/claude-review-responder.yml
+++ b/.github/workflows/claude-review-responder.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   respond-to-copilot:
-    if: contains(github.event.review.user.login, 'copilot-pull-request-reviewer')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -20,6 +19,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Copilot 리뷰가 아닌 경우 스킵 (job-level if 대신 early return으로 action_required 방지)
+            const reviewerLogin = context.payload.review?.user?.login ?? '';
+            if (!reviewerLogin.includes('copilot-pull-request-reviewer')) {
+              core.notice(`리뷰어 ${reviewerLogin} — Copilot 아님, 건너뜀`);
+              core.setOutput('has_work', 'false');
+              return;
+            }
+
             const prNumber = context.payload.pull_request.number;
             const pr = context.payload.pull_request;
             const sha = pr.head.sha;

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -19,10 +19,6 @@ concurrency:
 jobs:
   check-copilot-review:
     runs-on: ubuntu-latest
-    # pull_request_review_comment 트리거 시 reply 코멘트(in_reply_to_id 있음)일 때만 실행
-    if: >
-      github.event_name != 'pull_request_review_comment' ||
-      github.event.comment.in_reply_to_id != null
     permissions:
       pull-requests: read
       statuses: write
@@ -32,6 +28,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // pull_request_review_comment 이벤트에서 reply 아닌 경우 스킵 (action_required 방지)
+            if (context.eventName === 'pull_request_review_comment' && !context.payload.comment?.in_reply_to_id) {
+              core.notice('Copilot 초기 코멘트 — 평가 스킵');
+              return;
+            }
+
             const prNumber = context.payload.inputs?.pr_number
               ?? context.payload.pull_request?.number;
 

--- a/.github/workflows/review-comment-to-issue.yml
+++ b/.github/workflows/review-comment-to-issue.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   create-issue:
-    # /issue 키워드로 시작하는 리뷰 코멘트만 처리
-    if: startsWith(github.event.comment.body, '/issue')
     runs-on: ubuntu-latest
     permissions:
       issues: write
 
     steps:
       - name: Create issue from review comment
+        # /issue 키워드로 시작하는 리뷰 코멘트만 처리 (job 레벨 skip → action_required 방지)
+        if: startsWith(github.event.comment.body, '/issue')
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## 문제

`claude-review-responder.yml`이 Copilot 리뷰 제출 시 항상 `skipped`로 끝나 인라인 코멘트를 처리하지 못했다.

## 원인

### 1. `claude-review-responder.yml` — bot login 비교 실패
```yaml
# Before (항상 false)
if: github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'

# After
if: contains(github.event.review.user.login, 'copilot-pull-request-reviewer')
```
GitHub event payload의 `review.user.login` 값이 REST API(`copilot-pull-request-reviewer[bot]`)와 다를 수 있음. `contains()`로 교체해 `[bot]` suffix 유무에 무관하게 매칭.

### 2. `review-comment-to-issue.yml` — job-level skip → `action_required`
```yaml
# Before: job이 skip되면 workflow conclusion = action_required
jobs:
  create-issue:
    if: startsWith(...)   ← job level

# After: job은 항상 실행, step만 skip → conclusion = success
    steps:
      - if: startsWith(...)   ← step level
```
Copilot 코멘트가 `/issue`로 시작하지 않으면 job 전체가 skip되어 GitHub Actions가 `action_required`를 반환했음.

## 결과

- Copilot 리뷰 제출 시 `respond-to-copilot` job이 실행됨
- suggestion 블록 → 자동 코드 적용 + 답글
- 아키텍처 제안 → issue 생성 + 답글 → Copilot Gate 자동 success

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)