### PR TITLE
fix(be): add length=50 to status column to match migration schema

### DIFF
--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/QuestHistoryEntity.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/QuestHistoryEntity.kt
@@ -17,7 +17,7 @@ class QuestHistoryEntity(
     @Column(nullable = false)
     val score: Int = 0,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     val grade: String = "D",
 
     @Column(nullable = false)

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/QuestProgressEntity.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/QuestProgressEntity.kt
@@ -17,7 +17,7 @@ class QuestProgressEntity(
     val actId: Int = 0,
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     var status: QuestStatus = QuestStatus.NOT_STARTED,
 
     var aiScore: Int = 0,


### PR DESCRIPTION
## Summary
- `QuestProgressEntity.status`에 `@Column(length = 50)` 추가

## Why
`V1__init.sql`에서 status를 `VARCHAR(50)`으로 생성하지만 엔티티에 length 미지정 시 Hibernate가 `VARCHAR(255)`로 검증 → `ddl-auto: validate` 환경에서 기동 실패 가능.

Closes #61

## Test plan
- [ ] BE CI 통과 확인