### PR TITLE
fix(fe): fix timezone parsing and mobile grid layout in growth dashboard

### DIFF
--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -205,7 +205,7 @@ export function GrowthDashboard() {
           </section>
 
           {/* 등급 분포 + 연속 스트릭 */}
-          <section style={{ marginBottom: 28, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+          <section style={{ marginBottom: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16 }}>
             <div>
               <div
                 style={{

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -18,11 +18,11 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
   const hourCounts = new Array<number>(24).fill(0)
   for (const h of history) {
     const hour = getCreatedAtHour(h.createdAt)
-    if (hour !== null) hourCounts[hour]++
+    if (hour !== null) hourCounts[hour] = (hourCounts[hour] ?? 0) + 1
   }
   const counts = Array.from({ length: 24 }, (_, hour) => ({
     hour: `${String(hour).padStart(2, '0')}시`,
-    count: hourCounts[hour],
+    count: hourCounts[hour] ?? 0,
   }))
 
   const maxCount = Math.max(...counts.map((c) => c.count), 1)

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -5,10 +5,19 @@ interface HourlyActivityProps {
   history: QuestHistoryItem[]
 }
 
+function getCreatedAtHour(createdAt: string): number | null {
+  const match = createdAt.match(/^\d{4}-\d{2}-\d{2}T(\d{2}):\d{2}(?::\d{2}(?:\.\d+)?)?$/)
+  if (!match) {
+    return null
+  }
+  const hour = Number(match[1])
+  return Number.isInteger(hour) && hour >= 0 && hour <= 23 ? hour : null
+}
+
 export function HourlyActivity({ history }: HourlyActivityProps) {
   const counts = Array.from({ length: 24 }, (_, hour) => ({
     hour: `${String(hour).padStart(2, '0')}시`,
-    count: history.filter((h) => new Date(h.createdAt).getHours() === hour).length,
+    count: history.filter((h) => getCreatedAtHour(h.createdAt) === hour).length,
   }))
 
   const maxCount = Math.max(...counts.map((c) => c.count), 1)

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -15,9 +15,14 @@ function getCreatedAtHour(createdAt: string): number | null {
 }
 
 export function HourlyActivity({ history }: HourlyActivityProps) {
+  const hourCounts = new Array<number>(24).fill(0)
+  for (const h of history) {
+    const hour = getCreatedAtHour(h.createdAt)
+    if (hour !== null) hourCounts[hour]++
+  }
   const counts = Array.from({ length: 24 }, (_, hour) => ({
     hour: `${String(hour).padStart(2, '0')}시`,
-    count: history.filter((h) => getCreatedAtHour(h.createdAt) === hour).length,
+    count: hourCounts[hour],
   }))
 
   const maxCount = Math.max(...counts.map((c) => c.count), 1)

--- a/fe/src/features/growth/components/StreakBadge.tsx
+++ b/fe/src/features/growth/components/StreakBadge.tsx
@@ -21,7 +21,8 @@ function toHistoryDateStr(createdAt: string): string {
 }
 
 function subtractDays(dateStr: string, days: number): string {
-  const [year, month, day] = dateStr.split('-').map(Number)
+  const parts = dateStr.split('-').map(Number)
+  const [year, month, day] = parts as [number, number, number]
   const date = new Date(Date.UTC(year, month - 1, day))
   date.setUTCDate(date.getUTCDate() - days)
   return toUtcDateStr(date)

--- a/fe/src/features/growth/components/StreakBadge.tsx
+++ b/fe/src/features/growth/components/StreakBadge.tsx
@@ -4,17 +4,37 @@ interface StreakBadgeProps {
   history: QuestHistoryItem[]
 }
 
-function toDateStr(date: Date): string {
+function toLocalDateStr(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
+function toUtcDateStr(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`
+}
+
+function toHistoryDateStr(createdAt: string): string {
+  const datePart = createdAt.match(/^\d{4}-\d{2}-\d{2}/)?.[0]
+  if (datePart) {
+    return datePart
+  }
+  return toLocalDateStr(new Date(createdAt))
+}
+
+function subtractDays(dateStr: string, days: number): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  date.setUTCDate(date.getUTCDate() - days)
+  return toUtcDateStr(date)
+}
+
 function calcStreak(history: QuestHistoryItem[]): number {
-  const activeDates = new Set(history.map((h) => toDateStr(new Date(h.createdAt))))
+  const activeDates = new Set(history.map((h) => toHistoryDateStr(h.createdAt)))
   let streak = 0
-  const cursor = new Date()
-  while (activeDates.has(toDateStr(cursor))) {
+  let cursor = toLocalDateStr(new Date())
+
+  while (activeDates.has(cursor)) {
     streak++
-    cursor.setDate(cursor.getDate() - 1)
+    cursor = subtractDays(cursor, 1)
   }
   return streak
 }


### PR DESCRIPTION
## Summary
- `StreakBadge`: `new Date()` 타임존 의존 제거 — ISO 문자열에서 날짜 직접 파싱 (Closes #55)
- `HourlyActivity`: `new Date().getHours()` 대신 정규식으로 시간 추출 (Closes #54)
- `GrowthDashboard`: 등급분포+스트릭 섹션 `1fr 1fr` 고정 → `repeat(auto-fit, minmax(220px, 1fr))` 반응형 (Closes #58)

## Why
- `createdAt`이 타임존 없는 LocalDateTime 문자열이라 클라이언트 타임존에 따라 날짜/시간 경계가 달라짐
- 모바일(480px 이하)에서 고정 2열이 카드를 과도하게 좁게 만들어 가독성 저하

## Test plan
- [ ] FE CI 통과 확인
- [ ] GrowthDashboard 모바일 레이아웃 확인