### PR TITLE
chore(be): upgrade boss model to claude-sonnet-4-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ cd be
 | 키 | 기본값 | 용도 |
 |-----|--------|------|
 | `spring.ai.anthropic.chat.options.model` | claude-haiku-4-5-20251001 | 일반 퀘스트 |
-| `devquest.ai.boss-model` | claude-sonnet-4-5 | BOSS 퀘스트 |
+| `devquest.ai.boss-model` | claude-sonnet-4-6 | BOSS 퀘스트 |
 | `spring.ai.anthropic.chat.options.max-tokens` | 2000 | 일반 최대 토큰 |
 | `devquest.ai.boss-max-tokens` | 4000 | BOSS 최대 토큰 |
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ cd be
 |-----|--------|------|
 | `spring.ai.anthropic.chat.options.model` | claude-haiku-4-5-20251001 | 일반 퀘스트 |
 | `devquest.ai.boss-model` | claude-sonnet-4-6 | BOSS 퀘스트 |
-| `spring.ai.anthropic.chat.options.max-tokens` | 2000 | 일반 최대 토큰 |
+| `spring.ai.anthropic.chat.options.max-tokens` | 4000 | 일반 최대 토큰 |
 | `devquest.ai.boss-max-tokens` | 4000 | BOSS 최대 토큰 |
 
 ### 환경변수

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
@@ -22,7 +22,7 @@ class AiClientConfig {
 
     @Bean("bossChatClient")
     fun bossChatClient(
-        @Value("\${devquest.ai.boss-model:claude-sonnet-4-5}") bossModel: String,
+        @Value("\${devquest.ai.boss-model:claude-sonnet-4-6}") bossModel: String,
         @Value("\${devquest.ai.boss-max-tokens:4000}") bossMaxTokens: Int,
         @Value("\${spring.ai.anthropic.api-key}") apiKey: String,
     ): ChatClient {

--- a/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
+++ b/be/clients/client-ai/src/main/resources/client-ai-anthropic.yml
@@ -10,5 +10,5 @@ spring:
 
 devquest:
   ai:
-    boss-model: claude-sonnet-4-5
+    boss-model: claude-sonnet-4-6
     boss-max-tokens: 4000


### PR DESCRIPTION
## Summary
- BOSS 퀘스트 평가에 사용하는 AI 모델을 `claude-sonnet-4-5` → `claude-sonnet-4-6`으로 업그레이드
- README AI 모델 설정 표도 함께 업데이트

## Test plan
- [ ] BOSS 퀘스트 AI 평가 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)