### PR TITLE
fix(fe): AI 분석 로딩 박스 UI 통일

### DIFF
--- a/fe/src/features/ai-check/components/MockInterviewPanel.tsx
+++ b/fe/src/features/ai-check/components/MockInterviewPanel.tsx
@@ -141,6 +141,23 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
         <p style={{ fontSize: 14, color: '#F1F5F9', margin: 0, lineHeight: 1.7 }}>{q.question}</p>
       </div>
 
+      {loading && (
+        <div style={{
+          background: 'rgba(78,205,196,0.06)',
+          border: '1px solid rgba(78,205,196,0.2)',
+          borderRadius: 10,
+          padding: '14px 16px',
+          marginBottom: 12,
+          textAlign: 'center',
+        }}>
+          <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
+            ⟳ AI 채점 중
+          </div>
+          <div style={{ fontSize: 11, color: '#94A3B8' }}>
+            약 30초 소요됩니다. 잠시만 기다려주세요.
+          </div>
+        </div>
+      )}
       {error && (
         <div
           style={{

--- a/fe/src/features/interview-coach/components/CoachOnboarding.tsx
+++ b/fe/src/features/interview-coach/components/CoachOnboarding.tsx
@@ -69,6 +69,22 @@ export function CoachOnboarding({ onStart, loading }: CoachOnboardingProps) {
           />
         </div>
 
+        {loading && (
+          <div style={{
+            background: 'rgba(78,205,196,0.06)',
+            border: '1px solid rgba(78,205,196,0.2)',
+            borderRadius: 10,
+            padding: '14px 16px',
+            textAlign: 'center',
+          }}>
+            <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
+              ⟳ JD 분석 중
+            </div>
+            <div style={{ fontSize: 11, color: '#94A3B8' }}>
+              약 30초 소요됩니다. 잠시만 기다려주세요.
+            </div>
+          </div>
+        )}
         <button
           onClick={() => onStart(targetRole.trim(), jdText.trim())}
           disabled={!canSubmit}

--- a/fe/src/features/interview-coach/components/CoachQASession.tsx
+++ b/fe/src/features/interview-coach/components/CoachQASession.tsx
@@ -14,6 +14,7 @@ export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQ
   const [feedback, setFeedback] = useState<CoachAnswerResult | null>(null)
   const [history, setHistory] = useState<CoachAnswerHistory[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const current = questions[currentIndex]!
   const isLast = currentIndex === questions.length - 1
@@ -21,9 +22,12 @@ export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQ
   const handleSubmit = async () => {
     if (!answer.trim() || loading) return
     setLoading(true)
+    setError(null)
     try {
       const result = await onSubmitAnswer(current.question, answer.trim(), currentIndex, questions.length)
       setFeedback(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'AI 평가 중 오류가 발생했습니다. 다시 시도해주세요.')
     } finally {
       setLoading(false)
     }
@@ -100,9 +104,23 @@ export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQ
               </div>
             </div>
           )}
+          {error && (
+            <div style={{
+              background: 'rgba(239,68,68,0.1)',
+              border: '1px solid rgba(239,68,68,0.3)',
+              borderRadius: 8,
+              padding: '10px 14px',
+              marginBottom: 10,
+              fontSize: 13,
+              color: '#EF4444',
+            }}>
+              {error}
+            </div>
+          )}
           <textarea
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}
+            disabled={loading}
             placeholder="답변을 입력해주세요. 구체적인 경험과 수치를 포함하면 더 좋은 평가를 받을 수 있습니다."
             rows={6}
             style={{

--- a/fe/src/features/interview-coach/components/CoachQASession.tsx
+++ b/fe/src/features/interview-coach/components/CoachQASession.tsx
@@ -83,6 +83,23 @@ export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQ
 
       {!feedback && (
         <div style={{ marginTop: 8 }}>
+          {loading && (
+            <div style={{
+              background: 'rgba(78,205,196,0.06)',
+              border: '1px solid rgba(78,205,196,0.2)',
+              borderRadius: 10,
+              padding: '14px 16px',
+              marginBottom: 12,
+              textAlign: 'center',
+            }}>
+              <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
+                ⟳ 답변 검토 중
+              </div>
+              <div style={{ fontSize: 11, color: '#94A3B8' }}>
+                약 30초 소요됩니다. 잠시만 기다려주세요.
+              </div>
+            </div>
+          )}
           <textarea
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}


### PR DESCRIPTION
## Summary

- `MockInterviewPanel`, `CoachOnboarding`, `CoachQASession`에 로딩 박스 UI 추가
- 기존에는 버튼 텍스트만 변경되었으나, `AiCheckForm`과 동일한 패턴의 로딩 박스를 삽입하여 일관성 확보
- 로딩 박스: teal 테두리 + "⟳ [작업명]" + "약 30초 소요됩니다" 안내 문구

## Test plan

- [ ] MockInterviewPanel: 답변 제출 클릭 시 "⟳ AI 채점 중" 로딩 박스 노출 확인
- [ ] CoachOnboarding: 코칭 시작 클릭 시 "⟳ JD 분석 중" 로딩 박스 노출 확인
- [ ] CoachQASession: 답변 제출 클릭 시 "⟳ 답변 검토 중" 로딩 박스 노출 확인
- [ ] 응답 수신 후 로딩 박스 사라지고 결과 표시 확인
- [ ] 에러 발생 시 로딩 박스 사라지고 에러 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)