### PR TITLE
fix(chore): Copilot gate 자동 트리거 수정

### DIFF
--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 concurrency:
-  group: copilot-gate-${{ github.event.pull_request.number || github.event.review.pull_request_url || github.event.inputs.pr_number }}
+  group: copilot-gate-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -3,6 +3,8 @@ name: Copilot Review Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created]
   workflow_dispatch:
@@ -13,7 +15,7 @@ on:
         type: string
 
 concurrency:
-  group: copilot-gate-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: copilot-gate-${{ github.event.pull_request.number || github.event.review.pull_request_url || github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -34,8 +36,16 @@ jobs:
               return;
             }
 
+            // pull_request_review 이벤트에서 Copilot bot이 아닌 경우 스킵
+            if (context.eventName === 'pull_request_review' &&
+                context.payload.review?.user?.login !== 'copilot-pull-request-reviewer[bot]') {
+              core.notice('Copilot 외 리뷰어 — 평가 스킵');
+              return;
+            }
+
             const prNumber = context.payload.inputs?.pr_number
-              ?? context.payload.pull_request?.number;
+              ?? context.payload.pull_request?.number
+              ?? context.payload.review?.pull_request_url?.match(/\/(\d+)$/)?.[1];
 
             if (!prNumber) {
               core.warning('PR number을 확인할 수 없습니다.');


### PR DESCRIPTION
## Summary

- Copilot 리뷰 제출 후 gate가 `pending` → `failure`로 자동 전환되지 않던 문제 수정
- `pull_request_review: submitted` 트리거 추가로 Copilot 리뷰 완료 시점에 즉시 평가 실행
- Copilot bot 외 리뷰어가 제출한 리뷰는 스킵 처리

## 원인

`pull_request_review_comment: created` 이벤트는 등록했으나, 초기 코멘트를 스킵하는 로직으로 인해 Copilot 리뷰 제출 시 아무 평가도 이뤄지지 않았음. 결과적으로 수동 트리거가 필요했음.

## Test plan

- [ ] 새 PR에서 Copilot 리뷰 제출 시 gate가 자동으로 `failure`로 전환되는지 확인
- [ ] Copilot 외 리뷰어(사람) 리뷰 제출 시 gate가 실행되지 않는지 확인
- [ ] 기존 동작(답글 달면 success, 새 커밋 push 시 재평가) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)