### PR TITLE
feat(fe): OracleLoadingModal — RPG 신탁 로딩 모달

### DIFF
--- a/fe/src/components/ui/OracleLoadingModal.tsx
+++ b/fe/src/components/ui/OracleLoadingModal.tsx
@@ -58,38 +58,59 @@ export function OracleLoadingModal({ isOpen }: OracleLoadingModalProps) {
 
   useEffect(() => {
     if (!isOpen) return
-    const interval = setInterval(() => {
-      setVisible(false)
-      setTimeout(() => {
-        setMsgIdx((i) => (i + 1) % ORACLE_MESSAGES.length)
-        setVisible(true)
-      }, 300)
-    }, 3000)
-    return () => clearInterval(interval)
+
+    let cycleTimeout: ReturnType<typeof setTimeout> | undefined
+    let transitionTimeout: ReturnType<typeof setTimeout> | undefined
+
+    const scheduleNext = () => {
+      cycleTimeout = setTimeout(() => {
+        setVisible(false)
+        transitionTimeout = setTimeout(() => {
+          setMsgIdx((i) => (i + 1) % ORACLE_MESSAGES.length)
+          setVisible(true)
+          scheduleNext()
+        }, 300)
+      }, 3000)
+    }
+
+    scheduleNext()
+
+    return () => {
+      if (cycleTimeout) clearTimeout(cycleTimeout)
+      if (transitionTimeout) clearTimeout(transitionTimeout)
+    }
   }, [isOpen])
 
   if (!isOpen) return null
 
   return (
-    <div style={{
-      position: 'fixed',
-      inset: 0,
-      background: 'rgba(6, 6, 16, 0.85)',
-      backdropFilter: 'blur(4px)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 1000,
-    }}>
-      <div style={{
-        background: '#0F172A',
-        border: '1px solid rgba(78, 205, 196, 0.3)',
-        borderRadius: 20,
-        padding: '40px 48px',
-        textAlign: 'center',
-        width: 320,
-        animation: 'oracleGlow 3s ease-in-out infinite',
-      }}>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="AI 분석 중"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(6, 6, 16, 0.85)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        aria-busy="true"
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(78, 205, 196, 0.3)',
+          borderRadius: 20,
+          padding: '40px 48px',
+          textAlign: 'center',
+          width: 320,
+          animation: 'oracleGlow 3s ease-in-out infinite',
+        }}
+      >
         {/* 파티클 레이어 */}
         <div style={{ position: 'relative', width: 80, height: 80, margin: '0 auto 24px' }}>
           {/* 파티클 1 */}
@@ -142,7 +163,7 @@ export function OracleLoadingModal({ isOpen }: OracleLoadingModalProps) {
         </div>
 
         {/* 멘트 */}
-        <div style={{
+        <div aria-live="polite" style={{
           fontSize: 14,
           color: '#F1F5F9',
           marginBottom: 20,

--- a/fe/src/components/ui/OracleLoadingModal.tsx
+++ b/fe/src/components/ui/OracleLoadingModal.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react'
+
+const ORACLE_MESSAGES = [
+  '신탁이 운명의 서를 펼치는 중...',
+  '예언자가 커피를 보충하는 중...',
+  '현자가 Git 커밋 기록을 훔쳐보는 중...',
+  '길드 마스터가 이력서를 정독하는 중...',
+  '운명의 룬이 기술 스택을 정렬하는 중...',
+  '드래곤이 코드 냄새를 맡는 중...',
+  '신탁의 마법진이 과부하 직전인 중...',
+  '예언자가 5년 후 비전을 스캔하는 중...',
+  '고대의 알고리즘이 잠에서 깨어나는 중...',
+  '마법사가 Spring Boot를 구동하는 중...',
+  '현자가 기술 부채 총량을 계산하는 중...',
+  '신탁이 LinkedIn을 몰래 열어보는 중...',
+  '운명의 주사위가 굴러가는 중...',
+  '길드 서버가 열심히 일하는 척하는 중...',
+  '예언자가 스택오버플로우를 순례하는 중...',
+  '마법진이 Docker 컨테이너를 소환하는 중...',
+  '현자가 README를 몰래 수정하는 중...',
+  '신탁의 GPU가 열을 식히는 중...',
+  '길드 현인이 연봉 협상 시나리오를 짜는 중...',
+  '운명의 저울이 기술 역량을 측정하는 중...',
+  '예언자가 JD를 열두 번째 정독하는 중...',
+  '마법사가 캐시를 비우고 다시 시도하는 중...',
+  '현자가 커밋 메시지를 퇴고하는 중...',
+  '신탁이 N+1 쿼리를 잡아내는 중...',
+  '드래곤이 레거시 코드를 소각하는 중...',
+  '길드 마법진이 PR 리뷰를 기다리는 중...',
+  '예언자가 인프라 비용을 계산하는 중...',
+  '운명의 서버가 재시작하는 중...',
+  '마법사가 의존성 버전을 맞추는 중...',
+  '현자가 면접 예상 질문을 뽑는 중...',
+  '신탁이 당신의 포텐셜을 측정하는 중...',
+  '길드 원로들이 회의실에서 논쟁하는 중...',
+  '예언자가 기술 면접 채점표를 작성하는 중...',
+  '마법진이 CI 파이프라인을 통과하는 중...',
+  '현자가 5년치 성장 곡선을 그리는 중...',
+  '드래곤이 이력서 클리셰를 불태우는 중...',
+  '신탁이 당신의 운명을 컴파일하는 중...',
+  '길드 서기가 판정문을 작성하는 중...',
+  '예언자가 업계 연봉 데이터를 수집하는 중...',
+  '마법사가 배포 직전 긴장하는 중...',
+  '현자가 기술 부채를 묵묵히 감내하는 중...',
+  '신탁의 신성한 LLM이 기도를 드리는 중...',
+  '운명의 룬이 당신의 커리어를 각인하는 중...',
+  '길드 마스터가 최종 인장을 찍으려는 중...',
+  '예언자가 오라클 DB와 혼동되는 중...',
+]
+
+interface OracleLoadingModalProps {
+  isOpen: boolean
+}
+
+export function OracleLoadingModal({ isOpen }: OracleLoadingModalProps) {
+  const [msgIdx, setMsgIdx] = useState(() => Math.floor(Math.random() * ORACLE_MESSAGES.length))
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const interval = setInterval(() => {
+      setVisible(false)
+      setTimeout(() => {
+        setMsgIdx((i) => (i + 1) % ORACLE_MESSAGES.length)
+        setVisible(true)
+      }, 300)
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return (
+    <div style={{
+      position: 'fixed',
+      inset: 0,
+      background: 'rgba(6, 6, 16, 0.85)',
+      backdropFilter: 'blur(4px)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        background: '#0F172A',
+        border: '1px solid rgba(78, 205, 196, 0.3)',
+        borderRadius: 20,
+        padding: '40px 48px',
+        textAlign: 'center',
+        width: 320,
+        animation: 'oracleGlow 3s ease-in-out infinite',
+      }}>
+        {/* 파티클 레이어 */}
+        <div style={{ position: 'relative', width: 80, height: 80, margin: '0 auto 24px' }}>
+          {/* 파티클 1 */}
+          <div style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            marginTop: -4,
+            marginLeft: -4,
+            animation: 'oracleOrbit1 4s linear infinite',
+            fontSize: 8,
+            color: '#4ECDC4',
+            opacity: 0.7,
+          }}>✦</div>
+          {/* 파티클 2 */}
+          <div style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            marginTop: -3,
+            marginLeft: -3,
+            animation: 'oracleOrbit2 6s linear infinite',
+            fontSize: 6,
+            color: '#A78BFA',
+            opacity: 0.6,
+          }}>✦</div>
+          {/* 파티클 3 */}
+          <div style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            marginTop: -5,
+            marginLeft: -5,
+            animation: 'oracleOrbit3 8s linear infinite',
+            fontSize: 10,
+            color: '#4ECDC4',
+            opacity: 0.4,
+          }}>✦</div>
+          {/* 메인 아이콘 */}
+          <div style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            fontSize: 40,
+            color: '#4ECDC4',
+            animation: 'oracleBreathe 2s ease-in-out infinite',
+            lineHeight: 1,
+          }}>✦</div>
+        </div>
+
+        {/* 멘트 */}
+        <div style={{
+          fontSize: 14,
+          color: '#F1F5F9',
+          marginBottom: 20,
+          minHeight: 22,
+          letterSpacing: 0.3,
+          animation: visible ? 'oracleSlideDown 0.4s ease' : 'none',
+          opacity: visible ? 1 : 0,
+          transition: 'opacity 0.3s ease',
+        }}>
+          {ORACLE_MESSAGES[msgIdx]}
+        </div>
+
+        {/* Magic Energy Bar */}
+        <div style={{
+          position: 'relative',
+          height: 3,
+          background: 'rgba(78, 205, 196, 0.1)',
+          borderRadius: 2,
+          overflow: 'hidden',
+          marginBottom: 16,
+        }}>
+          <div style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '50%',
+            height: '100%',
+            background: 'linear-gradient(90deg, transparent, #4ECDC4, #A78BFA, transparent)',
+            animation: 'oracleShimmer 1.8s linear infinite',
+          }} />
+        </div>
+
+        {/* 보조 문구 */}
+        <div style={{ fontSize: 11, color: '#475569' }}>
+          약 30초 소요됩니다
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -1,4 +1,5 @@
 import type { AiEvaluationResult, BossPackageResult } from '@/types/api.types'
+import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { AI_FORMS } from '../constants/formConfig'
 import { useAiCheckForm } from '../hooks/useAiCheckForm'
 import { FormField } from './FormField'
@@ -34,23 +35,7 @@ export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCh
           onListItemChange={(index, val) => setListItem(f.key, index, val)}
         />
       ))}
-      {loading && (
-        <div style={{
-          background: 'rgba(78,205,196,0.06)',
-          border: '1px solid rgba(78,205,196,0.2)',
-          borderRadius: 10,
-          padding: '14px 16px',
-          marginBottom: 12,
-          textAlign: 'center',
-        }}>
-          <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
-            ⟳ AI 분석 중
-          </div>
-          <div style={{ fontSize: 11, color: '#94A3B8' }}>
-            약 30초 소요됩니다. 잠시만 기다려주세요.
-          </div>
-        </div>
-      )}
+      <OracleLoadingModal isOpen={loading} />
       {error && (
         <div
           style={{

--- a/fe/src/features/ai-check/components/MockInterviewPanel.tsx
+++ b/fe/src/features/ai-check/components/MockInterviewPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import type { InterviewEvaluationResult } from '@/types/api.types'
+import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { FALLBACK_QUESTIONS } from '../constants/fallbackQuestions'
 import { submitMockInterview } from '../api/aiCheckApi'
@@ -141,23 +142,7 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
         <p style={{ fontSize: 14, color: '#F1F5F9', margin: 0, lineHeight: 1.7 }}>{q.question}</p>
       </div>
 
-      {loading && (
-        <div style={{
-          background: 'rgba(78,205,196,0.06)',
-          border: '1px solid rgba(78,205,196,0.2)',
-          borderRadius: 10,
-          padding: '14px 16px',
-          marginBottom: 12,
-          textAlign: 'center',
-        }}>
-          <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
-            ⟳ AI 채점 중
-          </div>
-          <div style={{ fontSize: 11, color: '#94A3B8' }}>
-            약 30초 소요됩니다. 잠시만 기다려주세요.
-          </div>
-        </div>
-      )}
+      <OracleLoadingModal isOpen={loading} />
       {error && (
         <div
           style={{

--- a/fe/src/features/interview-coach/components/CoachOnboarding.tsx
+++ b/fe/src/features/interview-coach/components/CoachOnboarding.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { CoachBubble } from './CoachBubble'
 
 interface CoachOnboardingProps {
@@ -69,22 +70,7 @@ export function CoachOnboarding({ onStart, loading }: CoachOnboardingProps) {
           />
         </div>
 
-        {loading && (
-          <div style={{
-            background: 'rgba(78,205,196,0.06)',
-            border: '1px solid rgba(78,205,196,0.2)',
-            borderRadius: 10,
-            padding: '14px 16px',
-            textAlign: 'center',
-          }}>
-            <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
-              ⟳ JD 분석 중
-            </div>
-            <div style={{ fontSize: 11, color: '#94A3B8' }}>
-              약 30초 소요됩니다. 잠시만 기다려주세요.
-            </div>
-          </div>
-        )}
+        <OracleLoadingModal isOpen={loading} />
         <button
           onClick={() => onStart(targetRole.trim(), jdText.trim())}
           disabled={!canSubmit}

--- a/fe/src/features/interview-coach/components/CoachQASession.tsx
+++ b/fe/src/features/interview-coach/components/CoachQASession.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import type { CoachQuestion, CoachAnswerResult, CoachAnswerHistory } from '../types/coach.types'
 import { CoachBubble } from './CoachBubble'
 
@@ -87,23 +88,7 @@ export function CoachQASession({ questions, onSubmitAnswer, onComplete }: CoachQ
 
       {!feedback && (
         <div style={{ marginTop: 8 }}>
-          {loading && (
-            <div style={{
-              background: 'rgba(78,205,196,0.06)',
-              border: '1px solid rgba(78,205,196,0.2)',
-              borderRadius: 10,
-              padding: '14px 16px',
-              marginBottom: 12,
-              textAlign: 'center',
-            }}>
-              <div style={{ fontSize: 12, color: '#4ECDC4', letterSpacing: 2, marginBottom: 6 }}>
-                ⟳ 답변 검토 중
-              </div>
-              <div style={{ fontSize: 11, color: '#94A3B8' }}>
-                약 30초 소요됩니다. 잠시만 기다려주세요.
-              </div>
-            </div>
-          )}
+          <OracleLoadingModal isOpen={loading} />
           {error && (
             <div style={{
               background: 'rgba(239,68,68,0.1)',

--- a/fe/src/styles/global.css
+++ b/fe/src/styles/global.css
@@ -35,6 +35,46 @@ body {
   50% { transform: scale(1.05); text-shadow: 0 0 16px rgba(239, 68, 68, 0.6); }
 }
 
+@keyframes oracleRotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes oracleBreathe {
+  0%, 100% { transform: rotate(0deg) scale(1); }
+  50% { transform: rotate(180deg) scale(1.15); }
+}
+
+@keyframes oracleGlow {
+  0%, 100% { box-shadow: 0 0 24px rgba(78, 205, 196, 0.3), 0 0 48px rgba(78, 205, 196, 0.1); }
+  50% { box-shadow: 0 0 24px rgba(167, 139, 250, 0.4), 0 0 48px rgba(167, 139, 250, 0.15); }
+}
+
+@keyframes oracleOrbit1 {
+  from { transform: rotate(0deg) translateX(38px) rotate(0deg); }
+  to { transform: rotate(360deg) translateX(38px) rotate(-360deg); }
+}
+
+@keyframes oracleOrbit2 {
+  from { transform: rotate(120deg) translateX(28px) rotate(-120deg); }
+  to { transform: rotate(480deg) translateX(28px) rotate(-480deg); }
+}
+
+@keyframes oracleOrbit3 {
+  from { transform: rotate(240deg) translateX(48px) rotate(-240deg); }
+  to { transform: rotate(600deg) translateX(48px) rotate(-600deg); }
+}
+
+@keyframes oracleShimmer {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(200%); }
+}
+
+@keyframes oracleSlideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .hov-act {
   transition: transform 0.2s, box-shadow 0.2s;
   cursor: pointer;

--- a/fe/src/styles/global.css
+++ b/fe/src/styles/global.css
@@ -35,11 +35,6 @@ body {
   50% { transform: scale(1.05); text-shadow: 0 0 16px rgba(239, 68, 68, 0.6); }
 }
 
-@keyframes oracleRotate {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
 @keyframes oracleBreathe {
   0%, 100% { transform: rotate(0deg) scale(1); }
   50% { transform: rotate(180deg) scale(1.15); }


### PR DESCRIPTION
## Summary

- AI 제출 시 인라인 로딩 박스를 RPG 테마 풀스크린 모달로 교체
- #81 이슈(LoadingBox 공용화) 함께 해결

## 구현 내용

**OracleLoadingModal 컴포넌트**
- ✦ 아이콘: rotate 360 + breathing scale 복합 애니메이션
- 카드 테두리: teal ↔ purple glow pulse (3s)
- 파티클 3개: 각자 다른 반지름(28/38/48px)·속도(4/6/8s)로 공전
- Magic Energy Bar: shimmer 그라디언트 좌→우 흐름
- 45개 신탁 멘트: 랜덤 시작 인덱스 후 3초마다 슬라이드 다운 교체

**적용 컴포넌트**
- `AiCheckForm` / `MockInterviewPanel` / `CoachOnboarding` / `CoachQASession`

## Test plan

- [ ] AI 제출 버튼 클릭 → 모달 표시 확인
- [ ] 3초마다 멘트 교체 + 슬라이드 애니메이션 확인
- [ ] ✦ 회전 및 파티클 공전 확인
- [ ] shimmer energy bar 흐름 확인
- [ ] 응답 수신/에러 시 모달 닫힘 확인
- [ ] 4개 컴포넌트 모두 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)