### PR TITLE
fix(fe): ACT1 UX improvements — keyboard nav, free text input, validation, result history

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -31,6 +31,7 @@ export function App() {
   const [lastCompletedAt, setLastCompletedAt] = useState<string | null>(null)
   const [aiScores, setAiScores] = useState<Record<string, number>>({})
   const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | null>(null)
+  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult>>({})
   const [showForm, setShowForm] = useState(false)
   const [showIntro, setShowIntro] = useState(true)
 
@@ -81,14 +82,14 @@ export function App() {
   const handleSelectAct = (act: Act) => {
     if (act.quests.length > 0) {
       const quest = act.quests.find((q) => !completed[q.id]) ?? act.quests[act.quests.length - 1]!
-      setAiResult(null)
+      setAiResult(aiResults[quest.id] ?? null)
       setShowForm(false)
       setView({ kind: 'briefing', act, quest })
     }
   }
 
   const handleSelectQuest = (act: Act, quest: Quest) => {
-    setAiResult(null)
+    setAiResult(aiResults[quest.id] ?? null)
     setShowForm(false)
     setView({ kind: 'briefing', act, quest })
   }
@@ -118,6 +119,7 @@ export function App() {
     setShowForm(false)
     if (view.kind === 'detail') {
       const { quest, act } = view
+      setAiResults((prev) => ({ ...prev, [quest.id]: result }))
       const isBoss = quest.id === '4-BOSS'
       const score = isBoss
         ? (result as BossPackageResult).overallScore
@@ -135,7 +137,7 @@ export function App() {
     for (const act of ACTS) {
       const quest = act.quests.find((q) => q.id === questId)
       if (quest) {
-        setAiResult(null)
+        setAiResult(aiResults[quest.id] ?? null)
         setShowForm(false)
         setView({ kind: 'detail', act, quest })
         return

--- a/fe/src/features/ai-check/components/FormField.tsx
+++ b/fe/src/features/ai-check/components/FormField.tsx
@@ -96,7 +96,7 @@ export function FormField({ field: f, value, activeHint, onActiveHintChange, onC
               <input
                 value={((value as string[] | undefined) ?? [])[i] ?? ''}
                 onChange={(e) => onListItemChange(i, e.target.value)}
-                placeholder={f.placeholder}
+                placeholder={i === 0 ? f.placeholder : ''}
                 style={{ ...inputStyle, flex: 1 }}
               />
             </div>

--- a/fe/src/features/ai-check/components/TechStackInput.tsx
+++ b/fe/src/features/ai-check/components/TechStackInput.tsx
@@ -32,6 +32,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
   const isMaxReached = value.length >= 10
 
   const addedNames = value.map((v) => v.split(':')[0])
+  const addedNamesLower = addedNames.map((n) => (n ?? '').toLowerCase())
 
   const filtered = query.trim().length === 0
     ? []
@@ -39,10 +40,11 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
         s.toLowerCase().includes(query.toLowerCase())
       ).slice(0, 8)
 
+  const queryNorm = query.trim().toLowerCase()
   const showFreeText =
     query.trim().length > 0 &&
-    !TECH_STACKS.some((s) => s.toLowerCase() === query.toLowerCase().trim()) &&
-    !addedNames.includes(query.trim())
+    !TECH_STACKS.some((s) => s.toLowerCase() === queryNorm) &&
+    !addedNamesLower.includes(queryNorm)
 
   const totalDropdownItems = filtered.length + (showFreeText ? 1 : 0)
 
@@ -75,7 +77,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
   }
 
   const handleStackSelect = (stack: string) => {
-    if (addedNames.includes(stack)) return
+    if (addedNamesLower.includes(stack.toLowerCase())) return
     setPendingStack(stack)
     setShowDropdown(false)
     setFocusedIndex(-1)
@@ -242,18 +244,28 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
           onBlur={handleBlur}
           placeholder={isMaxReached ? '최대 10개 선택됨' : (placeholder ?? '기술 검색...')}
           disabled={isMaxReached}
+          role="combobox"
+          aria-expanded={showDropdown && totalDropdownItems > 0}
+          aria-haspopup="listbox"
+          aria-activedescendant={focusedIndex >= 0 ? `tech-option-${focusedIndex}` : undefined}
           style={inputStyle}
         />
 
         {showDropdown && totalDropdownItems > 0 && !isMaxReached && (
-          <div style={{ ...dropdownStyle, position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10 }}>
+          <div
+            role="listbox"
+            style={{ ...dropdownStyle, position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10 }}
+          >
             {filtered.map((stack, i) => {
-              const alreadyAdded = addedNames.includes(stack)
+              const alreadyAdded = addedNamesLower.includes(stack.toLowerCase())
               const isFocused = focusedIndex === i
               return (
                 <button
                   key={stack}
+                  id={`tech-option-${i}`}
                   type="button"
+                  role="option"
+                  aria-selected={isFocused}
                   onMouseDown={() => handleStackSelect(stack)}
                   disabled={alreadyAdded}
                   style={{
@@ -272,7 +284,10 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
             })}
             {showFreeText && (
               <button
+                id={`tech-option-${filtered.length}`}
                 type="button"
+                role="option"
+                aria-selected={focusedIndex === filtered.length}
                 onMouseDown={() => handleStackSelect(query.trim())}
                 style={{
                   ...dropdownItemBase,

--- a/fe/src/features/ai-check/components/TechStackInput.tsx
+++ b/fe/src/features/ai-check/components/TechStackInput.tsx
@@ -27,6 +27,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
   const [query, setQuery] = useState('')
   const [pendingStack, setPendingStack] = useState<string | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
+  const [focusedIndex, setFocusedIndex] = useState(-1)
 
   const isMaxReached = value.length >= 10
 
@@ -38,16 +39,46 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
         s.toLowerCase().includes(query.toLowerCase())
       ).slice(0, 8)
 
+  const showFreeText =
+    query.trim().length > 0 &&
+    !TECH_STACKS.some((s) => s.toLowerCase() === query.toLowerCase().trim()) &&
+    !addedNames.includes(query.trim())
+
+  const totalDropdownItems = filtered.length + (showFreeText ? 1 : 0)
+
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value)
     setPendingStack(null)
     setShowDropdown(true)
+    setFocusedIndex(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showDropdown || totalDropdownItems === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setFocusedIndex((i) => Math.min(i + 1, totalDropdownItems - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setFocusedIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (focusedIndex >= 0 && focusedIndex < filtered.length) {
+        handleStackSelect(filtered[focusedIndex]!)
+      } else if (focusedIndex === filtered.length && showFreeText) {
+        handleStackSelect(query.trim())
+      }
+    } else if (e.key === 'Escape') {
+      setShowDropdown(false)
+      setFocusedIndex(-1)
+    }
   }
 
   const handleStackSelect = (stack: string) => {
     if (addedNames.includes(stack)) return
     setPendingStack(stack)
     setShowDropdown(false)
+    setFocusedIndex(-1)
     setQuery('')
   }
 
@@ -64,6 +95,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
   const handleBlur = () => {
     setTimeout(() => {
       setShowDropdown(false)
+      setFocusedIndex(-1)
     }, 150)
   }
 
@@ -205,6 +237,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
         <input
           value={query}
           onChange={handleQueryChange}
+          onKeyDown={handleKeyDown}
           onFocus={() => query.trim().length > 0 && setShowDropdown(true)}
           onBlur={handleBlur}
           placeholder={isMaxReached ? '최대 10개 선택됨' : (placeholder ?? '기술 검색...')}
@@ -212,10 +245,11 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
           style={inputStyle}
         />
 
-        {showDropdown && filtered.length > 0 && !isMaxReached && (
+        {showDropdown && totalDropdownItems > 0 && !isMaxReached && (
           <div style={{ ...dropdownStyle, position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10 }}>
-            {filtered.map((stack) => {
+            {filtered.map((stack, i) => {
               const alreadyAdded = addedNames.includes(stack)
+              const isFocused = focusedIndex === i
               return (
                 <button
                   key={stack}
@@ -226,6 +260,7 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
                     ...dropdownItemBase,
                     color: alreadyAdded ? '#334155' : '#F1F5F9',
                     cursor: alreadyAdded ? 'default' : 'pointer',
+                    background: isFocused ? 'rgba(78,205,196,0.1)' : 'transparent',
                   }}
                 >
                   {stack}
@@ -235,6 +270,22 @@ export function TechStackInput({ value, onChange, placeholder }: TechStackInputP
                 </button>
               )
             })}
+            {showFreeText && (
+              <button
+                type="button"
+                onMouseDown={() => handleStackSelect(query.trim())}
+                style={{
+                  ...dropdownItemBase,
+                  color: '#A78BFA',
+                  cursor: 'pointer',
+                  background: focusedIndex === filtered.length ? 'rgba(167,139,250,0.1)' : 'transparent',
+                  borderTop: filtered.length > 0 ? '1px solid rgba(255,255,255,0.06)' : 'none',
+                }}
+              >
+                <span style={{ color: '#475569', marginRight: 4 }}>직접 입력:</span>
+                {query.trim()}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/fe/src/features/ai-check/hooks/useAiCheckForm.ts
+++ b/fe/src/features/ai-check/hooks/useAiCheckForm.ts
@@ -29,7 +29,34 @@ export function useAiCheckForm({ questId, cfg, onResult, onSubmit, initialValues
 
   const handleActiveHintChange = (key: string | null) => setActiveHint(key)
 
+  const validate = (): string | null => {
+    for (const field of cfg.fields) {
+      const val = values[field.key]
+      if (field.type === 'text' || field.type === 'textarea') {
+        if (!val || !(val as string).trim()) {
+          return `'${field.label}' 항목을 입력해주세요`
+        }
+      } else if (field.type === 'list') {
+        const arr = (val as string[] | undefined) ?? []
+        if (arr.filter((s) => s.trim().length > 0).length === 0) {
+          return `'${field.label}' 항목을 최소 1개 이상 입력해주세요`
+        }
+      } else if (field.type === 'tag-search') {
+        const arr = (val as string[] | undefined) ?? []
+        if (arr.length === 0) {
+          return `'${field.label}' 항목을 최소 1개 이상 선택해주세요`
+        }
+      }
+    }
+    return null
+  }
+
   const handleSubmit = async () => {
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
     setLoading(true)
     setError('')
     try {

--- a/fe/src/features/ai-check/hooks/useAiCheckForm.ts
+++ b/fe/src/features/ai-check/hooks/useAiCheckForm.ts
@@ -38,7 +38,8 @@ export function useAiCheckForm({ questId, cfg, onResult, onSubmit, initialValues
         }
       } else if (field.type === 'list') {
         const arr = (val as string[] | undefined) ?? []
-        if (arr.filter((s) => s.trim().length > 0).length === 0) {
+        const hasNonEmptyItem = arr.some((s) => (typeof s === 'string' ? s : '').trim().length > 0)
+        if (!hasNonEmptyItem) {
           return `'${field.label}' 항목을 최소 1개 이상 입력해주세요`
         }
       } else if (field.type === 'tag-search') {


### PR DESCRIPTION
## Summary

- **TechStackInput 키보드 지원**: 드롭다운에서 `ArrowUp/Down`으로 항목 이동, `Enter`로 선택, `Escape`로 닫기
- **TechStackInput 자유 입력**: 검색어가 TECH_STACKS 목록에 없을 때 `'직접 입력: [query]'` 옵션 표시 → 선택 시 경력 선택 후 추가됨
- **FormField list placeholder**: list 타입 필드에서 첫 번째 항목에만 placeholder 표시 (이하 항목은 빈 상태)
- **useAiCheckForm 클라이언트 유효성 검증**: 제출 전 필드별 입력 확인 (`text/textarea` 비어있음, `list` 최소 1개, `tag-search` 최소 1개 선택); 빈 폼으로 API 호출 차단
- **App.tsx AI 결과 히스토리 유지**: `aiResults: Record<string, result>` 맵으로 퀘스트별 마지막 결과 보존; 맵으로 이동 후 다시 돌아왔을 때 이전 분석 결과 복원됨

## Test plan

- [ ] TechStackInput에서 검색 후 ArrowDown/Up으로 항목 하이라이트, Enter로 선택 확인
- [ ] TECH_STACKS에 없는 키워드 입력 시 '직접 입력' 옵션 표시 확인
- [ ] `1-2` 퀘스트에서 list 필드(불만족 3가지, 목표 3가지) — 1번 항목에만 placeholder 있는지 확인
- [ ] 아무 값도 입력하지 않고 제출 버튼 클릭 → 유효성 에러 메시지 표시 확인
- [ ] AI 결과 받은 후 맵으로 이동 → 같은 퀘스트 재진입 시 이전 결과 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)