### PR TITLE
fix(be): include aiEvaluationJson in progress response

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -8,15 +8,15 @@
 | 항목 | 내용 |
 |------|------|
 | 브랜치 | `main` (최신) |
-| 열린 PR | 없음 |
+| 열린 PR | #87 브라우저 재로드 후 aiResults 복원 (머지 대기), #88 agent 프롬프트 TDD 추가 (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
 | PR | 내용 | 날짜 |
 |----|------|------|
+| #88 | agent 프롬프트 TDD 워크플로우 추가 — be-feature-builder TDD 규칙, qa-reviewer 테스트 커버리지 섹션, fe-feature-builder JSON.parse 타입 가드 | 2026-04-21 |
+| #87 | 브라우저 재로드 후 aiResults 복원 — ProgressResult.QuestDetail aiEvaluationJson 추가, App.tsx fetchProgress 응답에서 setAiResults 복원, ProgressServiceTest 케이스 추가 | 2026-04-21 |
 | #85 | 1-BOSS 개발자 클래스 판별 AI 평가 — /ai-check/developer-class 신규, 1-1/1-2 aiEvaluationJson 저장, DeveloperClassResultCard FE 렌더링 | 2026-04-21 |
-| #84 | ACT1 UX 개선 — TechStackInput 키보드 네비게이션+자유입력, list placeholder 첫 항목만, FE 유효성 검증, aiResults 히스토리 유지 | 2026-04-20 |
-| #83 | OracleLoadingModal — RPG 테마 풀스크린 로딩 모달, 45개 신탁 멘트, 파티클 애니메이션, 4개 컴포넌트 인라인 로딩 박스 교체 | 2026-04-20 |
 
 ## 알아둬야 할 비자명적 결정
 
@@ -43,8 +43,9 @@ Copilot 리뷰가 달렸는데 gate가 pending이면 수동 트리거 필요:
 
 ## 다음 작업
 
+- [ ] PR #87, #88 머지
 - [ ] 앱 직접 사용 후 불편한 점 / 빠진 기능 파악 → 다음 기능 기획
-- [ ] Issue #86: DeveloperClassEvaluator 단위 테스트 추가 (tech-debt)
+- [ ] Issue #86: DeveloperClassEvaluator 단위 테스트 추가 (tech-debt, TDD 방식으로 진행)
 
 ## 참조 문서
 

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ProgressService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ProgressService.kt
@@ -56,7 +56,8 @@ class ProgressService(
                 it.questId to ProgressResult.QuestDetail(
                     status = it.status,
                     score = it.aiScore,
-                    xp = it.earnedXp
+                    xp = it.earnedXp,
+                    aiEvaluationJson = it.aiEvaluationJson
                 )
             },
             lastCompletedAt = lastCompletedAt

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/model/ProgressResult.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/model/ProgressResult.kt
@@ -13,6 +13,7 @@ data class ProgressResult(
     data class QuestDetail(
         val status: QuestStatus,
         val score: Int,
-        val xp: Int
+        val xp: Int,
+        val aiEvaluationJson: String? = null
     )
 }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ProgressServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ProgressServiceTest.kt
@@ -114,17 +114,42 @@ class ProgressServiceTest {
         verify(progressPort, never()).save(any())
     }
 
+    @Test
+    fun `aiEvaluationJson이 있으면 questDetails에 그대로 포함된다`() {
+        val json = "{\"score\":85}"
+        whenever(progressPort.findAllByUserId("user-1")).thenReturn(listOf(
+            progress("1-2", QuestStatus.COMPLETED, aiEvaluationJson = json),
+        ))
+
+        val result = service.getProgress("user-1")
+
+        assertThat(result.questDetails["1-2"]!!.aiEvaluationJson).isEqualTo(json)
+    }
+
+    @Test
+    fun `aiEvaluationJson이 null이면 questDetails에서도 null이다`() {
+        whenever(progressPort.findAllByUserId("user-1")).thenReturn(listOf(
+            progress("1-2", QuestStatus.COMPLETED, aiEvaluationJson = null),
+        ))
+
+        val result = service.getProgress("user-1")
+
+        assertThat(result.questDetails["1-2"]!!.aiEvaluationJson).isNull()
+    }
+
     private fun progress(
         questId: String,
         status: QuestStatus,
         aiScore: Int = 0,
-        earnedXp: Int = 0
+        earnedXp: Int = 0,
+        aiEvaluationJson: String? = null
     ) = QuestProgress(
         userId = "user-1",
         questId = questId,
         actId = 1,
         status = status,
         aiScore = aiScore,
-        earnedXp = earnedXp
+        earnedXp = earnedXp,
+        aiEvaluationJson = aiEvaluationJson
     )
 }

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -41,14 +41,24 @@ export function App() {
       .then((progress) => {
         const completedMap: Record<string, boolean> = {}
         const scoresMap: Record<string, number> = {}
+        const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult> = {}
         progress.completedQuests.forEach((id) => {
           completedMap[id] = true
         })
         Object.entries(progress.questDetails).forEach(([id, detail]) => {
           if (detail.score > 0) scoresMap[id] = detail.score
         })
+        Object.entries(progress.questDetails).forEach(([id, detail]) => {
+          if (detail.aiEvaluationJson) {
+            try {
+              const parsed = JSON.parse(detail.aiEvaluationJson)
+              aiResultsMap[id] = parsed
+            } catch { /* 파싱 실패 무시 */ }
+          }
+        })
         setCompleted(completedMap)
         setAiScores(scoresMap)
+        setAiResults(aiResultsMap)
         if (progress.lastCompletedAt) setLastCompletedAt(progress.lastCompletedAt)
       })
       .catch(() => {

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -9,6 +9,7 @@ export interface QuestDetail {
   status: string
   score: number
   xp: number
+  aiEvaluationJson?: string
 }
 
 export interface ProgressResult {


### PR DESCRIPTION
## Summary

- `ProgressResult.QuestDetail`에 `aiEvaluationJson: String? = null` 필드 추가
- `ProgressService.getProgress()`에서 `QuestProgress.aiEvaluationJson`을 `QuestDetail`에 포함하도록 수정
- DB에 이미 저장된 값을 API 응답에 노출하는 것이므로 스키마 변경 없음

## Motivation

페이지 재로드 시 FE의 `aiResults` 상태가 소실되는 버그 수정을 위한 BE 변경.
`getProgress()` 응답에 AI 평가 JSON이 포함되면 FE가 상태를 복원할 수 있다.

## Test plan

- [x] `:core:core-api:build` 통과 (빌드 성공)
- [x] `:core:core-api:test` 통과 (기존 테스트 전부 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)