### PR TITLE
chore(agents): skills 주입 방식으로 전환

### DIFF
--- a/.claude/agents/be-feature-builder.md
+++ b/.claude/agents/be-feature-builder.md
@@ -8,6 +8,10 @@ tools:
   - Bash
   - Glob
   - Grep
+skills:
+  - be-port-adapter
+  - be-api-endpoint
+  - be-ai-evaluator
 description: Kotlin/Spring Boot 기능 구현 전담 에이전트. Port & Adapter 패턴을 준수하며 Domain Model → Port → AI/DB Adapter → Service → Controller 전체 플로우를 구현한다.
 hooks:
   PreToolUse:
@@ -56,77 +60,8 @@ be/
 
 ## 구현 순서
 
-### 1. Domain Model (`core-domain/model/`)
-```kotlin
-data class [Feature]Result(
-    val score: Int = 0,
-    val passed: Boolean = false,
-    val grade: String = "D",
-    // 모든 필드에 기본값 필수 (AI JSON 파싱 대비)
-)
-```
-
-### 2. Port 인터페이스 (`core-domain/port/`)
-```kotlin
-interface [Feature]Port {
-    fun evaluate(/* 도메인 파라미터 */): [Feature]Result
-}
-```
-- Spring 어노테이션 금지
-- 반환 타입은 Domain Model (Entity 아님)
-
-### 3. AI Adapter (`client-ai/evaluator/`)
-```kotlin
-@Component
-class [Feature]Evaluator(private val chatClient: ChatClient) : [Feature]Port {
-    override fun evaluate(/* */): [Feature]Result {
-        val prompt = """
-            [컨텍스트]
-            ## 입력 데이터
-            [사용자 입력]
-            ## 평가 기준 (총 100점)
-            - 항목A (N점): 설명
-            반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
-            { "score": 75, "passed": true, "grade": "B", ... }
-        """.trimIndent()
-        return chatClient.prompt().user(prompt).call()
-            .entity([Feature]Result::class.java)
-            ?: throw AiEvaluationException("파싱 실패")
-    }
-}
-```
-
-### 4. Service 메서드 (`core-api/domain/AiCheckService.kt`)
-```kotlin
-@Transactional
-fun check[Feature](userId: String, /* params */): [Feature]Result {
-    val result = [feature]Port.evaluate(/* */)
-    saveProgress(userId, "[questId]", actId, result.score, result.passed, xp)
-    return result
-}
-```
-- Port 인터페이스로 주입 (구체 클래스 X)
-
-### 5. Request DTO (`core-api/controller/v1/request/`)
-```kotlin
-data class [Feature]RequestDto(
-    @field:NotBlank val userId: String,
-    @field:NotBlank val fieldA: String,
-)
-```
-
-### 6. Controller 엔드포인트 (`core-api/controller/v1/AiCheckController.kt`에 추가)
-```kotlin
-@PostMapping("/[endpoint]")
-fun check[Feature](@Valid @RequestBody request: [Feature]RequestDto): ApiResponse<*> {
-    return try {
-        ApiResponse.success(aiCheckService.check[Feature](/* */))
-    } catch (e: Exception) {
-        log.error("[Feature] check failed", e)
-        throw CoreException(ErrorType.AI_EVALUATION_FAILED)
-    }
-}
-```
+주입된 skills(be-port-adapter, be-api-endpoint, be-ai-evaluator) 패턴을 따른다:
+`Domain Model → Port 인터페이스 → AI Adapter → Service 메서드 → Request DTO → Controller 엔드포인트`
 
 ## TDD 규칙 (필수)
 
@@ -152,17 +87,7 @@ Service 생성자에 새 의존성(Port, ObjectMapper 등) 추가 시:
 | AiCheckService | `be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt` |
 | ProgressService | `be/core/core-api/src/test/kotlin/com/devquest/core/domain/ProgressServiceTest.kt` |
 
-## Kotlin 스타일 규칙
-- `val` 선호, `var`는 Entity 변경 필드만
-- `!!` 사용 금지
-- 문자열 템플릿에서 한글 붙을 때: `${score}점` (파싱 오류 방지)
-- 로거: `LoggerFactory.getLogger(javaClass)`
-
-## TDD 규칙
-
-새 Evaluator 구현 시 단위 테스트를 함께 작성한다.
-
-### Evaluator 테스트 패턴
+## Evaluator 단위 테스트 패턴
 
 ChatClient fluent 체인은 `RETURNS_DEEP_STUBS`로 목킹, Evaluator는 직접 생성한다.
 `@Mock`/`@InjectMocks` 사용 금지 — 기존 패턴(CareerEssayEvaluatorTest 등) 참고.
@@ -170,7 +95,6 @@ ChatClient fluent 체인은 `RETURNS_DEEP_STUBS`로 목킹, Evaluator는 직접 
 ```kotlin
 @ExtendWith(MockitoExtension::class)
 class [Feature]EvaluatorTest {
-    // RETURNS_DEEP_STUBS로 fluent 체인 전체 목킹
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
     private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
     private val evaluator = [Feature]Evaluator(chatClient, aiCallExecutor)
@@ -199,7 +123,8 @@ class [Feature]EvaluatorTest {
 }
 ```
 
-### Controller 테스트 패턴
+## Controller 테스트 패턴
+
 `standaloneSetup` + `@AuthenticationPrincipal` 조합:
 ```kotlin
 @BeforeEach fun setup() {
@@ -212,13 +137,18 @@ class [Feature]EvaluatorTest {
 @AfterEach fun teardown() { SecurityContextHolder.clearContext() }
 ```
 
+## Kotlin 스타일 규칙
+- `val` 선호, `var`는 Entity 변경 필드만
+- `!!` 사용 금지
+- 문자열 템플릿에서 한글 붙을 때: `${score}점` (파싱 오류 방지)
+- 로거: `LoggerFactory.getLogger(javaClass)`
+
 ## 구현 후 체크리스트
 - [ ] Port에 Spring 어노테이션 없음
 - [ ] Domain Model 모든 필드 기본값 있음
 - [ ] AI 프롬프트 JSON 스키마가 Result 필드와 일치
 - [ ] Service에서 Port 인터페이스로 주입
 - [ ] `saveProgress` 올바른 questId, actId, xp 전달
-- [ ] 기존 테스트 패턴과 일관성 유지
 - [ ] 신규 Service 메서드에 대응하는 테스트 케이스 작성됨 (TDD)
 - [ ] 생성자 파라미터 변경 시 테스트 `@Mock` 목록 및 `verify()` 호출 업데이트 완료
 - [ ] 테스트 실패(red) → 구현 → 통과(green) 순서 확인

--- a/.claude/agents/fe-feature-builder.md
+++ b/.claude/agents/fe-feature-builder.md
@@ -8,6 +8,9 @@ tools:
   - Bash
   - Glob
   - Grep
+skills:
+  - fe-component
+  - fe-feature
 description: React 19 + TypeScript 기능 구현 전담 에이전트. App.tsx props drilling 패턴을 준수하며 타입 정의 → API 클라이언트 → 컴포넌트 전체 플로우를 구현한다.
 hooks:
   PreToolUse:
@@ -48,6 +51,7 @@ hooks:
 ---
 
 이 프로젝트의 FE는 React 19 + TypeScript + Vite 기반이며 **인라인 스타일만** 사용한다.
+컴포넌트 패턴, 색상 팔레트, 상태 관리 규칙은 주입된 skills(fe-component, fe-feature)를 따른다.
 
 ## 모듈 구조
 
@@ -73,7 +77,7 @@ fe/src/
 - **외부 상태관리 금지** — Redux, Context, Zustand 등. `useState` only
 - **!!** 타입 단언 지양 — `?.`, `?:` 선호
 
-## 구현 순서
+## 이 프로젝트 AI Check 구현 순서
 
 ### 1. 타입 정의 (`types/api.types.ts`)
 
@@ -85,21 +89,7 @@ export interface [Feature]Result {
 }
 ```
 
-### 2. API 클라이언트 (`lib/apiClient.ts`)
-
-```typescript
-export async function [featureAction](
-  userId: string,
-  params: ...,
-): Promise<[Feature]Result> {
-  return callAiCheck<[Feature]Result>('/api/v1/ai-check/[endpoint]', {
-    userId,
-    ...params,
-  }, userId)
-}
-```
-
-### 3. AI Check Form 등록 (`features/ai-check/constants/formConfig.ts`)
+### 2. AI Check Form 등록 (`features/ai-check/constants/formConfig.ts`)
 
 ```typescript
 '[questId]': {
@@ -110,44 +100,15 @@ export async function [featureAction](
 }
 ```
 
-### 4. 결과 카드 컴포넌트 (`features/ai-check/components/[Feature]ResultCard.tsx`)
+### 3. 결과 카드 컴포넌트 (`features/ai-check/components/[Feature]ResultCard.tsx`)
 
-```typescript
-interface [Feature]ResultCardProps {
-  result: [Feature]Result
-}
+fe-component skill의 컴포넌트 구조와 색상 팔레트를 따른다.
 
-export function [Feature]ResultCard({ result }: [Feature]ResultCardProps) {
-  return (
-    <div style={{ background: '#0F172A', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 12, padding: 20 }}>
-      {/* 결과 내용 */}
-    </div>
-  )
-}
-```
-
-### 5. App.tsx 상태 연결
+### 4. App.tsx 상태 연결
 
 - 새로운 결과 타입이면 `useState`로 상태 추가
 - BOSS 퀘스트 완료 시 특수 처리 필요하면 `handleBossComplete` 패턴 참고
 - View 전환: `setCurrentView('...')` + `viewContent` 렌더링
-
-## 다크 테마 컬러 팔레트
-
-| 용도 | 색상 |
-|------|------|
-| 배경 | `#060610` |
-| 카드 배경 | `#0F172A` |
-| 테두리 | `rgba(255,255,255,0.08)` |
-| 주요 텍스트 | `#F8FAFC` |
-| 보조 텍스트 | `#475569` |
-| Teal (성공/액센트) | `#4ECDC4` |
-| Purple (AI) | `#A78BFA` |
-| Amber (XP) | `#F59E0B` |
-| Green (통과) | `#10B981` |
-| Red (실패) | `#EF4444` |
-
-폰트: `'Courier New', monospace`
 
 ## 구현 후 체크리스트
 

--- a/.claude/agents/fe-feature-builder.md
+++ b/.claude/agents/fe-feature-builder.md
@@ -11,7 +11,7 @@ tools:
 skills:
   - fe-component
   - fe-feature
-description: React 19 + TypeScript 기능 구현 전담 에이전트. App.tsx props drilling 패턴을 준수하며 타입 정의 → API 클라이언트 → 컴포넌트 전체 플로우를 구현한다.
+description: React 19 + TypeScript 기능 구현 전담 에이전트. App.tsx props drilling 패턴을 준수하며 타입 정의와 컴포넌트 구현을 포함한 FE 기능 구현 플로우를 수행한다.
 hooks:
   PreToolUse:
     - matcher: "Write|Edit"
@@ -96,7 +96,7 @@ export interface [Feature]Result {
   fields: [
     { key: 'fieldA', label: '필드명', placeholder: '입력하세요', multiline: true },
   ],
-  endpoint: '/api/v1/ai-check/[endpoint]',
+  endpoint: '[endpoint]',  // callAiCheck가 /api/v1/ai-check/ 접두사를 자동 추가함
 }
 ```
 


### PR DESCRIPTION
## Summary
- `be-feature-builder.md`, `fe-feature-builder.md` frontmatter에 `skills:` 필드 추가
- 에이전트 시작 시 skill 전체 콘텐츠가 자동 주입되므로 에이전트 파일 내 중복 구현 패턴 제거
- 역할 경계·TDD 규칙·프로젝트 특화 패턴은 에이전트 파일에 유지

## 변경 내용

| 에이전트 | 주입되는 skills | 제거된 섹션 |
|---------|---------------|-----------|
| `be-feature-builder` | `be-port-adapter`, `be-api-endpoint`, `be-ai-evaluator` | 구현 순서 1~6 코드 템플릿 |
| `fe-feature-builder` | `fe-component`, `fe-feature` | 다크 테마 컬러 팔레트, 일반 컴포넌트 패턴 |

## 배경
Skills 문서 확인 결과 subagent frontmatter의 `skills:` 필드로 시작 시 전체 skill 콘텐츠를 자동 주입할 수 있음. 기존에는 skills와 agent .md 양쪽에 동일 패턴이 중복 관리되는 문제가 있었음.

## Test plan
- [ ] 에이전트 파일에서 `skills:` 필드 구문 확인
- [ ] 제거된 패턴이 모두 해당 skill 파일에 존재하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)