### PR TITLE
chore: fix agent frontmatter — model alias, tools format, orchestrator path guard

### DIFF
--- a/.claude/agents/be-feature-builder.md
+++ b/.claude/agents/be-feature-builder.md
@@ -1,6 +1,6 @@
 ---
 name: be-feature-builder
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Glob

--- a/.claude/agents/fe-feature-builder.md
+++ b/.claude/agents/fe-feature-builder.md
@@ -1,6 +1,6 @@
 ---
 name: fe-feature-builder
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,15 +1,19 @@
 ---
 name: orchestrator
-model: claude-sonnet-4-6
-tools:
-  - Agent(be-feature-builder, fe-feature-builder, design-reviewer, qa-reviewer)
-  - Read
-  - Glob
-  - Grep
-  - Bash
-  - Write
-  - Edit
+model: sonnet
+tools: "Agent(be-feature-builder, fe-feature-builder, design-reviewer, qa-reviewer), Read, Glob, Grep, Bash, Write, Edit"
 description: Feature Dev 오케스트레이터. 사용자 요청을 분석해 필요한 에이전트만 선택적으로 스폰하며 BE·FE·Design·QA를 조율한다. `claude --agent orchestrator`로 실행.
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: ".claude/scripts/assert-orchestrator-path.sh"
+  PostToolUse:
+    - matcher: ".*"
+      hooks:
+        - type: command
+          command: ".claude/scripts/log-event.sh PostToolUse orchestrator"
 ---
 
 # Feature Dev Orchestrator

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: qa-reviewer
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Glob

--- a/.claude/scripts/assert-orchestrator-path.sh
+++ b/.claude/scripts/assert-orchestrator-path.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# orchestrator 전용: be/ fe/ 코드 파일 쓰기 차단
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if echo "$FILE_PATH" | grep -qE "(^|/)(be|fe)/"; then
+  echo "차단: orchestrator는 be/ 또는 fe/ 코드를 직접 수정할 수 없습니다. 해당 에이전트에 위임하세요. (${FILE_PATH})" >&2
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- `model: claude-sonnet-4-6` → `model: sonnet` alias (5개 에이전트 전체)
- orchestrator `tools:` YAML list → 문자열 형식 (공식 docs 준수)
- `assert-orchestrator-path.sh` 추가 — orchestrator가 `be/`/`fe/` 코드를 직접 수정하려 하면 훅이 차단

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `.claude/agents/*.md` (5개) | `model: sonnet` 통일 |
| `.claude/agents/orchestrator.md` | tools 문자열 형식, PreToolUse/PostToolUse 훅 추가 |
| `.claude/scripts/assert-orchestrator-path.sh` | 신규 — be/fe 경로 쓰기 차단 |

## Test plan

- [ ] 에이전트 파일 프론트매터 파싱 오류 없음 확인
- [ ] orchestrator가 be/ 또는 fe/ 파일 수정 시도 시 훅이 차단하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)