### PR TITLE
fix(be): prevent 502 recurrence — SpringBootTest smoke test + fly health check

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -213,14 +213,18 @@ gh pr create \
   --title "<type>(<scope>): <message>" \
   --body "$(cat <<'EOF'
 ## Summary
-- ...
+- <변경 내용 1-3줄 요약>
+
+## Why
+<!-- 변경 이유가 자명하지 않을 때만 작성 -->
 
 ## Test plan
-- [ ] ...
+- [ ] <수행한 테스트>
 EOF
 )"
 ```
 
+> **PR body는 한국어로 작성한다.** (title의 type/scope/message는 영어 컨벤션 유지)
 > **"🤖 Generated with Claude Code" 문구는 PR body에 포함하지 않는다.**
 
 `.claude/CONTEXT.md` 업데이트 — **PR 생성 직후, 세션 종료 전 반드시 실행**:

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -6,7 +6,7 @@ import com.devquest.core.domain.PassCriteriaPolicy
 import com.devquest.core.domain.QuestConstants
 import com.devquest.core.domain.QuestXpPolicy
 import com.devquest.core.enums.QuestStatus
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/be/core/core-api/src/test/kotlin/com/devquest/ApplicationContextTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/ApplicationContextTest.kt
@@ -1,0 +1,17 @@
+package com.devquest
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+class ApplicationContextTest {
+
+    @Test
+    fun `Spring ApplicationContext loads successfully`() {
+        // Context load itself is the assertion.
+        // If any bean fails to wire (e.g., missing ObjectMapper bean),
+        // this test fails and CI catches it before deployment.
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -2,7 +2,7 @@ package com.devquest.core.domain
 
 import com.devquest.core.domain.model.evaluation.*
 import com.devquest.core.domain.port.*
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/be/core/core-api/src/test/resources/application-test.yml
+++ b/be/core/core-api/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+devquest:
+  auth:
+    github-client-id: test-client-id
+    github-client-secret: test-client-secret
+    jwt-secret: test-jwt-secret-key-that-is-at-least-256-bits-long-for-hs256-in-testing
+    jwt-expiration-ms: 3600000

--- a/be/fly.toml
+++ b/be/fly.toml
@@ -22,6 +22,13 @@ primary_region = 'nrt'
     hard_limit = 25
     soft_limit = 20
 
+[[http_service.checks]]
+  grace_period = "60s"
+  interval = "15s"
+  method = "get"
+  path = "/health"
+  timeout = "10s"
+
 [[vm]]
   memory = '512mb'
   cpu_kind = 'shared'


### PR DESCRIPTION
## Summary
- `AiCheckService` ObjectMapper import 수정: Jackson 2.x(`com.fasterxml`) → Jackson 3.x(`tools.jackson`) — Spring Boot 4 auto-configure 대상과 불일치로 bean 주입 실패하던 것 수정
- `ApplicationContextTest` 추가: `@SpringBootTest(NONE)`으로 전체 Spring 컨텍스트 로드 검증 → 향후 bean 누락 시 CI 빌드 실패
- `fly.toml` 헬스 체크 추가: 배포 시 앱 시작 실패하면 트래픽 라우팅 차단 (cold start 동작은 유지)

## Why
- PR #85에서 ObjectMapper를 AiCheckService 생성자에 추가했으나, Spring Boot 4는 Jackson 3.x(`tools.jackson`) ObjectMapper를 bean으로 등록 — Jackson 2.x 클래스는 classpath에 있어도 주입 불가
- CI에 `@SpringBootTest`가 없어서 컨텍스트 초기화 실패를 배포 전 감지 못함
- fly.toml에 헬스 체크가 없어서 시작 실패한 인스턴스에도 트래픽이 라우팅됨

## Test plan
- [x] `ApplicationContextTest PASSED` (로컬 실행 확인)
- [x] 전체 test suite `BUILD SUCCESSFUL`
- [ ] fly.io 배포 후 `fly status`에서 헬스 체크 green 확인
- [ ] 프로덕션에서 AI 검사 502 미발생 확인