### PR TITLE
docs: 인프라 구성도 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,56 @@ core-enum ←── core-domain ←── core-api (bootJar)
 - FE → BE: `/api/*` 경로는 Vercel 프록시로 BE에 포워딩 (`vercel.json`)
 - CI/CD: PR open → BE/FE CI (빌드+테스트), main 머지 → 자동 배포
 
+### 인프라 구성도
+
+```
+사용자 (브라우저)
+    │ HTTPS
+    ▼
+┌─────────────────────────────┐
+│  Vercel  (quest.dhbang.co.kr)│
+│  React SPA 정적 서빙         │
+│  /api/* → 프록시             │
+└──────────────┬──────────────┘
+               │ HTTPS /api/*
+               ▼
+┌─────────────────────────────────────┐
+│  Fly.io  (api.quest.dhbang.co.kr)   │
+│  Spring Boot 4 · Kotlin · port 8080 │
+│  H2 in-memory DB                    │
+│  auto-stop (트래픽 없을 시 정지)      │
+└──────┬──────────────┬───────────────┘
+       │ Claude API   │ OAuth
+       ▼              ▼
+ Anthropic API   GitHub API
+ (Haiku / Sonnet)  (인증)
+       │
+       │ HTTP 배치 (LogtailHttpAppender)
+       ▼
+  Better Stack (로그 수집)
+```
+
+### CI/CD 파이프라인
+
+```
+PR open
+  ├── BE CI: Gradle 빌드 + 테스트 (JaCoCo)
+  ├── FE CI: npm 빌드
+  └── Copilot 리뷰 gate
+
+main 머지
+  ├── BE CD: fly deploy → Fly.io (Tokyo)
+  └── FE CD: vercel --prod → Vercel
+```
+
+### 외부 의존성
+
+| 서비스 | 용도 | 비고 |
+|--------|------|------|
+| Anthropic API | AI 퀘스트 평가 | Haiku(일반) / Sonnet(BOSS) |
+| GitHub OAuth | 사용자 인증 | stateless JWT 발급 |
+| Better Stack | 로그 수집 | prod only, 토큰 미설정 시 비활성화 |
+
 ---
 
 ## 퀘스트 시스템

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ core-enum ←── core-domain ←── core-api (bootJar)
 ┌─────────────────────────────────────┐
 │  Fly.io  (api.quest.dhbang.co.kr)   │
 │  Spring Boot 4 · Kotlin · port 8080 │
-│  H2 in-memory DB                    │
+│  PostgreSQL (prod datasource)        │
 │  auto-stop (트래픽 없을 시 정지)      │
 └──────┬──────────────┬───────────────┘
        │ Claude API   │ OAuth
@@ -167,7 +167,7 @@ core-enum ←── core-domain ←── core-api (bootJar)
 
 ```
 PR open
-  ├── BE CI: Gradle 빌드 + 테스트 (JaCoCo)
+  ├── BE CI: Gradle `:core:core-api:bootJar` + root `test`
   ├── FE CI: npm 빌드
   └── Copilot 리뷰 gate
 
@@ -444,7 +444,8 @@ GET /health
 | earned_xp | INT | 획득 XP |
 | created_at | DATETIME | 평가 시각 |
 
-> 현재 H2 인메모리 DB 사용 (서버 재시작 시 초기화)
+> **로컬**: H2 인메모리 DB (`local` 프로파일, 서버 재시작 시 초기화)
+> **프로덕션**: PostgreSQL (`prod` 프로파일, Fly.io — `DB_HOST`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 시크릿 필요)
 
 ---
 


### PR DESCRIPTION
## Summary
- 인프라 구성도 추가 — 사용자 → Vercel → Fly.io → Anthropic/GitHub/Better Stack 전체 흐름
- CI/CD 파이프라인 다이어그램 추가 (PR open / main 머지 기준)
- 외부 의존성 표 추가 (Anthropic, GitHub OAuth, Better Stack)