### PR TITLE
chore: Copilot gate — 신규 코멘트 시 재평가 강제

### DIFF
--- a/.github/workflows/copilot-review-evaluator.yml
+++ b/.github/workflows/copilot-review-evaluator.yml
@@ -30,9 +30,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // pull_request_review_comment 이벤트에서 reply 아닌 경우 스킵 (action_required 방지)
-            if (context.eventName === 'pull_request_review_comment' && !context.payload.comment?.in_reply_to_id) {
-              core.notice('Copilot 초기 코멘트 — 평가 스킵');
+            // pull_request_review_comment 이벤트에서 Copilot 외 새 코멘트는 스킵
+            // Copilot 새 코멘트는 스킵하지 않고 재평가 → gate를 failure로 갱신
+            if (context.eventName === 'pull_request_review_comment'
+                && !context.payload.comment?.in_reply_to_id
+                && context.payload.comment?.user?.login !== 'copilot-pull-request-reviewer[bot]') {
+              core.notice('Copilot 외 초기 코멘트 — 평가 스킵');
               return;
             }
 


### PR DESCRIPTION
## Summary
- Copilot 새 코멘트 게시 시 gate 재평가를 스킵하던 조건 수정
- Copilot 코멘트 → 재평가 → 미처리 있으면 `failure` → 머지 차단

## Why
`review.submitted` 이벤트에서 evaluator가 실행될 때 인라인 코멘트가 아직 없어 SUCCESS로 기록된 뒤, 뒤따라 오는 코멘트 이벤트를 스킵해 gate가 SUCCESS 그대로 유지되는 문제. PR #97이 Copilot 미처리 코멘트 상태로 머지된 원인.

## 변경 내용
`copilot-review-evaluator.yml`: `pull_request_review_comment.created` 이벤트에서 Copilot 본인 코멘트는 스킵하지 않고 재평가 진행. Copilot 외 사용자의 새 코멘트만 스킵.

## Test plan
- [ ] PR에서 Copilot 리뷰 코멘트 달린 후 gate가 `failure`로 전환되는지 확인
- [ ] 코멘트에 답글 달면 gate가 `success`로 복귀하는지 확인