### PR TITLE
fix(be): developer-class.st ST4 템플릿 중괄호 이스케이프 처리

### DIFF
--- a/be/clients/client-ai/src/main/resources/prompts/developer-class.st
+++ b/be/clients/client-ai/src/main/resources/prompts/developer-class.st
@@ -23,4 +23,4 @@
 overallScore >= 70이면 passed: true
 
 반드시 다음 JSON 형식으로만 응답하세요 (다른 텍스트 금지):
-{"overallScore": 75, "passed": true, "developerClass": "성장 지향형 백엔드 전문가", "classDescription": "현재 견고한 기술 기반을 보유하고 있으며 지속적인 성장을 추구하는 스타일입니다.", "strengths": ["강점1", "강점2", "강점3"], "strategies": ["전략1: 구체적 내용", "전략2: 구체적 내용", "전략3: 구체적 내용"], "overallFeedback": "종합 피드백 내용..."}
+\{"overallScore": 75, "passed": true, "developerClass": "성장 지향형 백엔드 전문가", "classDescription": "현재 견고한 기술 기반을 보유하고 있으며 지속적인 성장을 추구하는 스타일입니다.", "strengths": ["강점1", "강점2", "강점3"], "strategies": ["전략1: 구체적 내용", "전략2: 구체적 내용", "전략3: 구체적 내용"], "overallFeedback": "종합 피드백 내용..."\}


### PR DESCRIPTION
## Summary
- 1스테이지 보스전 `POST /api/v1/ai-check/developer-class` 500 에러 수정
- 원인: `developer-class.st` 26번째 줄 예시 JSON의 `{`·`}`를 Spring AI ST4 엔진이 템플릿 표현식으로 파싱 → `mismatched input ',' expecting LPAREN`
- 수정: 리터럴 중괄호를 ST4 이스케이프 `\{` `\}`로 처리

## Test plan
- [ ] `POST /api/v1/ai-check/developer-class` 500 에러 재현 안 됨 확인