### PR TITLE
fix(fe): fetchProgress cold start 타임아웃 시 5회 retry 로직 추가

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -39,7 +39,7 @@ export function App() {
   useEffect(() => {
     if (!isLoggedIn) return
 
-    const MAX_RETRIES = 5
+    const MAX_RETRIES = 6
     const RETRY_INTERVAL_MS = 5000
 
     const applyProgress = (progress: Awaited<ReturnType<typeof fetchProgress>>) => {
@@ -85,7 +85,7 @@ export function App() {
           }
         }
       }
-      // 5회 모두 실패 — 빈 상태로 계속 진행
+      // 6회 모두 실패 — 빈 상태로 계속 진행
       if (!cancelled) setProgressLoading(false)
     }
 
@@ -211,6 +211,9 @@ export function App() {
   if (progressLoading) {
     return (
       <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
         style={{
           maxWidth: 480,
           margin: '0 auto',

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -34,36 +34,66 @@ export function App() {
   const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>>({})
   const [showForm, setShowForm] = useState(false)
   const [showIntro, setShowIntro] = useState(true)
+  const [progressLoading, setProgressLoading] = useState(false)
 
   useEffect(() => {
     if (!isLoggedIn) return
-    fetchProgress()
-      .then((progress) => {
-        const completedMap: Record<string, boolean> = {}
-        const scoresMap: Record<string, number> = {}
-        const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult> = {}
-        progress.completedQuests.forEach((id) => {
-          completedMap[id] = true
-        })
-        Object.entries(progress.questDetails).forEach(([id, detail]) => {
-          if (detail.score > 0) scoresMap[id] = detail.score
-        })
-        Object.entries(progress.questDetails).forEach(([id, detail]) => {
-          if (detail.aiEvaluationJson) {
-            try {
-              const parsed = JSON.parse(detail.aiEvaluationJson)
-              aiResultsMap[id] = parsed
-            } catch { /* 파싱 실패 무시 */ }
+
+    const MAX_RETRIES = 5
+    const RETRY_INTERVAL_MS = 5000
+
+    const applyProgress = (progress: Awaited<ReturnType<typeof fetchProgress>>) => {
+      const completedMap: Record<string, boolean> = {}
+      const scoresMap: Record<string, number> = {}
+      const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult> = {}
+      progress.completedQuests.forEach((id) => {
+        completedMap[id] = true
+      })
+      Object.entries(progress.questDetails).forEach(([id, detail]) => {
+        if (detail.score > 0) scoresMap[id] = detail.score
+      })
+      Object.entries(progress.questDetails).forEach(([id, detail]) => {
+        if (detail.aiEvaluationJson) {
+          try {
+            const parsed = JSON.parse(detail.aiEvaluationJson)
+            aiResultsMap[id] = parsed
+          } catch { /* 파싱 실패 무시 */ }
+        }
+      })
+      setCompleted(completedMap)
+      setAiScores(scoresMap)
+      setAiResults(aiResultsMap)
+      if (progress.lastCompletedAt) setLastCompletedAt(progress.lastCompletedAt)
+    }
+
+    let cancelled = false
+
+    const fetchWithRetry = async () => {
+      setProgressLoading(true)
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+          const progress = await fetchProgress()
+          if (!cancelled) {
+            applyProgress(progress)
+            setProgressLoading(false)
           }
-        })
-        setCompleted(completedMap)
-        setAiScores(scoresMap)
-        setAiResults(aiResultsMap)
-        if (progress.lastCompletedAt) setLastCompletedAt(progress.lastCompletedAt)
-      })
-      .catch(() => {
-        // 서버 미응답 시 로컬 상태로 계속 진행
-      })
+          return
+        } catch {
+          if (cancelled) return
+          if (attempt < MAX_RETRIES - 1) {
+            await new Promise<void>((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS))
+          }
+        }
+      }
+      // 5회 모두 실패 — 빈 상태로 계속 진행
+      if (!cancelled) setProgressLoading(false)
+    }
+
+    fetchWithRetry()
+
+    return () => {
+      cancelled = true
+    }
   }, [isLoggedIn])
 
   const getActProgress = useCallback(
@@ -174,6 +204,29 @@ export function App() {
           ? <OnboardingIntro onComplete={() => setShowIntro(false)} />
           : <CharacterCreate onComplete={handleCharacterComplete} />
         }
+      </div>
+    )
+  }
+
+  if (progressLoading) {
+    return (
+      <div
+        style={{
+          maxWidth: 480,
+          margin: '0 auto',
+          padding: '0 20px',
+          minHeight: '100vh',
+          fontFamily: "'Courier New', monospace",
+          color: '#F8FAFC',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+        }}
+      >
+        <p style={{ color: '#4ECDC4', fontSize: 14, margin: 0 }}>서버 기동 중...</p>
+        <p style={{ color: '#475569', fontSize: 12, margin: 0 }}>진척 데이터를 불러오는 중입니다 (최대 25초)</p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- fly.io 머신 cold start(23초) 구간에서 `fetchProgress()` 실패 시 진척 데이터가 빈 상태로 보이는 문제 수정
- 5초 간격 최대 5회 재시도 (총 최대 25초 대기) — cold start 23초 커버
- retry 중 로딩 화면 표시
- 5회 모두 실패 시 기존처럼 빈 상태로 진행

## Test plan
- [ ] 머신 suspended 상태에서 로그인 시 로딩 화면 표시 확인
- [ ] 머신 기동 완료 후 진척 데이터 정상 로드 확인