### PR TITLE
fix(fe): 개발용 서버 연동 배너 제거

### DIFF
--- a/fe/src/features/quest-map/components/QuestMap.tsx
+++ b/fe/src/features/quest-map/components/QuestMap.tsx
@@ -33,24 +33,6 @@ export function QuestMap({ onSelectAct, onSelectQuest, onOpenCoach, completed, g
         </p>
       </div>
 
-      <div
-        style={{
-          background: 'rgba(78,205,196,0.04)',
-          border: '1px solid rgba(78,205,196,0.15)',
-          borderRadius: 10,
-          padding: '10px 16px',
-          marginBottom: 20,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          fontSize: 12,
-        }}
-      >
-        <span style={{ color: '#4ECDC4' }}>🔌</span>
-        <span style={{ color: '#475569' }}>Spring Boot 4.x + Spring AI 연동 필요</span>
-        <span style={{ color: '#1E293B', marginLeft: 'auto' }}>localhost:8080</span>
-      </div>
-
       {lastCompletedAt && (() => {
         const days = Math.floor((Date.now() - new Date(lastCompletedAt).getTime()) / (1000 * 60 * 60 * 24))
         return days >= 1 ? (


### PR DESCRIPTION
## Summary
- QuestMap 랜딩 화면 상단의 🔌 Spring Boot 4.x + Spring AI 연동 필요 / localhost:8080 개발용 배너 제거

## Test plan
- [ ] 로그인 후 QuestMap 화면에 배너가 표시되지 않는지 확인