### PR TITLE
chore(be): fly.io suspend 모드 전환 및 HikariCP stale 커넥션 대응

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -32,3 +32,5 @@ storage:
       username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
       maximum-pool-size: 10
+      minimum-idle: 0
+      connection-test-query: SELECT 1

--- a/be/fly.toml
+++ b/be/fly.toml
@@ -13,7 +13,7 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'suspend'
   auto_start_machines = true
   min_machines_running = 0
 


### PR DESCRIPTION
## Summary
- `fly.toml` `auto_stop_machines`: `stop` → `suspend` — cold start 25~35초 → 3~8초로 단축
- `application-prod.yml` HikariCP에 `minimum-idle: 0`, `connection-test-query: SELECT 1` 추가 — suspend 복원 시 stale 커넥션으로 인한 첫 쿼리 실패 방지

## Why
- `stop`: JVM 완전 종료 → 복원 시 JVM 재부팅 필요 (25~35초 cold start)
- `suspend`: 메모리 스냅샷 보존 → 복원 시 3~8초
- 비용 차이 없음 (정지 중 과금 없는 건 동일)
- HikariCP `minimum-idle: 0`: idle 커넥션 미보유 → 복원 시 stale 커넥션 자체 없음
- `connection-test-query`: 커넥션 대출 전 SELECT 1 검증 → 혹시 남은 stale 커넥션 자동 폐기

## Test plan
- [ ] 머지 후 fly deploy 실행
- [ ] 일정 시간 무활동 후 앱 접속 → cold start 시간 측정
- [ ] 첫 요청 정상 응답 확인