### PR TITLE
fix(fe): 성장 기록 화면 텍스트 가독성 개선

### DIFF
--- a/fe/src/features/growth/components/ActPassRate.tsx
+++ b/fe/src/features/growth/components/ActPassRate.tsx
@@ -26,13 +26,13 @@ export function ActPassRate({ history }: ActPassRateProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="name"
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
           <YAxis
             domain={[0, 100]}
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
@@ -49,7 +49,7 @@ export function ActPassRate({ history }: ActPassRateProps) {
               `${value}% (${(props.payload as { total: number } | undefined)?.total ?? 0}회 시도)`,
               '합격률',
             ]}
-            labelStyle={{ color: '#475569' }}
+            labelStyle={{ color: '#94A3B8' }}
           />
           <Bar dataKey="rate" radius={[4, 4, 0, 0]}>
             {data.map((_, i) => (

--- a/fe/src/features/growth/components/GradeDistribution.tsx
+++ b/fe/src/features/growth/components/GradeDistribution.tsx
@@ -21,13 +21,13 @@ export function GradeDistribution({ history }: GradeDistributionProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="grade"
-            tick={{ fill: '#475569', fontSize: 13, fontFamily: "'Courier New', monospace", fontWeight: 'bold' }}
+            tick={{ fill: '#64748B', fontSize: 13, fontFamily: "'Courier New', monospace", fontWeight: 'bold' }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
           <YAxis
             allowDecimals={false}
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
@@ -41,7 +41,7 @@ export function GradeDistribution({ history }: GradeDistributionProps) {
               color: '#F8FAFC',
             }}
             formatter={(value) => [`${value}회`, '횟수']}
-            labelStyle={{ color: '#475569' }}
+            labelStyle={{ color: '#94A3B8' }}
           />
           <Bar dataKey="count" radius={[4, 4, 0, 0]}>
             {data.map((entry) => (

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -210,7 +210,7 @@ export function GrowthDashboard() {
               <div
                 style={{
                   fontSize: 12,
-                  color: '#475569',
+                  color: '#94A3B8',
                   marginBottom: 10,
                   textTransform: 'uppercase',
                   letterSpacing: '0.05em',
@@ -234,7 +234,7 @@ export function GrowthDashboard() {
               <div
                 style={{
                   fontSize: 12,
-                  color: '#475569',
+                  color: '#94A3B8',
                   marginBottom: 10,
                   textTransform: 'uppercase',
                   letterSpacing: '0.05em',

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -132,7 +132,7 @@ export function GrowthDashboard() {
                   style={{
                     padding: '32px 0',
                     textAlign: 'center',
-                    color: '#94A3B8',
+                    color: '#64748B',
                     fontSize: 13,
                   }}
                 >

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -69,14 +69,14 @@ export function GrowthDashboard() {
           ⚔️ 성장 기록
         </h2>
         {!loading && (
-          <div style={{ fontSize: 12, color: '#475569' }}>
+          <div style={{ fontSize: 12, color: '#94A3B8' }}>
             총 {history.length}회 시도 · 획득 XP {xpTotal.toLocaleString()}
           </div>
         )}
       </div>
 
       {loading ? (
-        <div style={{ textAlign: 'center', color: '#475569', fontSize: 13, padding: '40px 0' }}>
+        <div style={{ textAlign: 'center', color: '#94A3B8', fontSize: 13, padding: '40px 0' }}>
           로딩 중...
         </div>
       ) : (
@@ -86,7 +86,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
@@ -111,7 +111,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
@@ -132,7 +132,7 @@ export function GrowthDashboard() {
                   style={{
                     padding: '32px 0',
                     textAlign: 'center',
-                    color: '#475569',
+                    color: '#94A3B8',
                     fontSize: 13,
                   }}
                 >
@@ -145,7 +145,7 @@ export function GrowthDashboard() {
                       <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
                       <XAxis
                         dataKey="questId"
-                        tick={{ fill: '#475569', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+                        tick={{ fill: '#64748B', fontSize: 9, fontFamily: "'Courier New', monospace" }}
                         axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
                         tickLine={false}
                         interval={0}
@@ -155,7 +155,7 @@ export function GrowthDashboard() {
                       />
                       <YAxis
                         domain={[0, 100]}
-                        tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+                        tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
                         axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
                         tickLine={false}
                       />
@@ -169,7 +169,7 @@ export function GrowthDashboard() {
                           color: '#F8FAFC',
                         }}
                         formatter={(value) => [`${value ?? ''}점`, '최고점']}
-                        labelStyle={{ color: '#475569' }}
+                        labelStyle={{ color: '#94A3B8' }}
                       />
                       <Bar dataKey="score" fill="#A78BFA" radius={[4, 4, 0, 0]} />
                     </BarChart>
@@ -184,7 +184,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
@@ -263,7 +263,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
@@ -288,7 +288,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
@@ -313,7 +313,7 @@ export function GrowthDashboard() {
             <div
               style={{
                 fontSize: 12,
-                color: '#475569',
+                color: '#94A3B8',
                 marginBottom: 10,
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -34,7 +34,7 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="hour"
-            tick={{ fill: '#475569', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 9, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
             interval={2}
@@ -42,7 +42,7 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
           <YAxis
             allowDecimals={false}
             domain={[0, maxCount]}
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
@@ -56,7 +56,7 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
               color: '#F8FAFC',
             }}
             formatter={(value) => [`${value}회`, '시도']}
-            labelStyle={{ color: '#475569' }}
+            labelStyle={{ color: '#94A3B8' }}
           />
           <Bar dataKey="count" fill="#60A5FA" radius={[2, 2, 0, 0]} />
         </BarChart>

--- a/fe/src/features/growth/components/QuestAttemptCount.tsx
+++ b/fe/src/features/growth/components/QuestAttemptCount.tsx
@@ -22,7 +22,7 @@ export function QuestAttemptCount({ history }: QuestAttemptCountProps) {
         style={{
           padding: '32px 0',
           textAlign: 'center',
-          color: '#475569',
+          color: '#64748B',
           fontSize: 13,
           fontFamily: "'Courier New', monospace",
         }}
@@ -39,7 +39,7 @@ export function QuestAttemptCount({ history }: QuestAttemptCountProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="questId"
-            tick={{ fill: '#475569', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 9, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
             interval={0}
@@ -49,7 +49,7 @@ export function QuestAttemptCount({ history }: QuestAttemptCountProps) {
           />
           <YAxis
             allowDecimals={false}
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
@@ -63,7 +63,7 @@ export function QuestAttemptCount({ history }: QuestAttemptCountProps) {
               color: '#F8FAFC',
             }}
             formatter={(value) => [`${value}회`, '시도 횟수']}
-            labelStyle={{ color: '#475569' }}
+            labelStyle={{ color: '#94A3B8' }}
           />
           <Bar dataKey="count" fill="#F59E0B" radius={[4, 4, 0, 0]} />
         </BarChart>

--- a/fe/src/features/growth/components/QuestHistoryList.tsx
+++ b/fe/src/features/growth/components/QuestHistoryList.tsx
@@ -22,7 +22,7 @@ export function QuestHistoryList({ history }: QuestHistoryListProps) {
         style={{
           padding: '20px 0',
           textAlign: 'center',
-          color: '#475569',
+          color: '#64748B',
           fontSize: 13,
           fontFamily: "'Courier New', monospace",
         }}
@@ -65,7 +65,7 @@ export function QuestHistoryList({ history }: QuestHistoryListProps) {
           </span>
           <span style={{ color: '#F8FAFC', minWidth: 48, textAlign: 'right' }}>{item.score}점</span>
           <span style={{ color: '#F59E0B', minWidth: 56, textAlign: 'right' }}>+{item.earnedXp} XP</span>
-          <span style={{ color: '#475569', minWidth: 72, textAlign: 'right' }}>{formatDate(item.createdAt)}</span>
+          <span style={{ color: '#64748B', minWidth: 72, textAlign: 'right' }}>{formatDate(item.createdAt)}</span>
         </div>
       ))}
     </div>

--- a/fe/src/features/growth/components/ScoreTimeline.tsx
+++ b/fe/src/features/growth/components/ScoreTimeline.tsx
@@ -30,7 +30,7 @@ export function ScoreTimeline({ history }: ScoreTimelineProps) {
         style={{
           padding: '32px 0',
           textAlign: 'center',
-          color: '#475569',
+          color: '#64748B',
           fontSize: 13,
           fontFamily: "'Courier New', monospace",
         }}
@@ -47,13 +47,13 @@ export function ScoreTimeline({ history }: ScoreTimelineProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="date"
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
           <YAxis
             domain={[0, 100]}
-            tick={{ fill: '#475569', fontSize: 11, fontFamily: "'Courier New', monospace" }}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
           />
@@ -70,7 +70,7 @@ export function ScoreTimeline({ history }: ScoreTimelineProps) {
               `${value ?? ''}점`,
               (props.payload as ChartDataPoint | undefined)?.questId ?? '',
             ]}
-            labelStyle={{ color: '#475569' }}
+            labelStyle={{ color: '#94A3B8' }}
           />
           <Line
             type="monotone"

--- a/fe/src/features/growth/components/StreakBadge.tsx
+++ b/fe/src/features/growth/components/StreakBadge.tsx
@@ -55,10 +55,10 @@ export function StreakBadge({ history }: StreakBadgeProps) {
       }}
     >
       <div style={{ textAlign: 'center' }}>
-        <div style={{ fontSize: 48, fontWeight: 'bold', color: streak > 0 ? '#F59E0B' : '#334155', lineHeight: 1 }}>
+        <div style={{ fontSize: 48, fontWeight: 'bold', color: streak > 0 ? '#F59E0B' : '#475569', lineHeight: 1 }}>
           {streak}
         </div>
-        <div style={{ fontSize: 12, color: '#475569', marginTop: 6 }}>연속 학습일</div>
+        <div style={{ fontSize: 12, color: '#94A3B8', marginTop: 6 }}>연속 학습일</div>
       </div>
       <div style={{ fontSize: 36 }}>{streak >= 7 ? '🔥' : streak >= 3 ? '⚡' : streak > 0 ? '✨' : '💤'}</div>
     </div>


### PR DESCRIPTION
## Summary
- 성장 기록 화면 전체 섹션 레이블, 차트 축, 툴팁 레이블, 빈 상태 텍스트의 저대비 색상 교체
- 섹션 레이블·툴팁: `#475569` → `#94A3B8` (slate-400)
- 차트 축 tick·날짜: `#475569` → `#64748B` (slate-500)
- StreakBadge 0일 숫자: `#334155` → `#475569` (완전 소멸 방지)

## 수정 파일
`GrowthDashboard`, `ScoreTimeline`, `QuestHistoryList`, `ActPassRate`, `GradeDistribution`, `HourlyActivity`, `QuestAttemptCount`, `StreakBadge` 총 8개

## Test plan
- [ ] 성장 기록 화면 진입 후 섹션 레이블 가시성 확인
- [ ] 차트 축 숫자/라벨 가시성 확인
- [ ] 스트릭 0일 상태 숫자 가시성 확인