### PR TITLE
fix(fe): 모의 면접 흐름 개선 및 progress 캐시 추가

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -100,7 +100,7 @@ export function App() {
       setCompleted(completedMap)
       setAiScores(scoresMap)
       setAiResults(aiResultsMap)
-      if (progress.lastCompletedAt) setLastCompletedAt(progress.lastCompletedAt)
+      setLastCompletedAt(progress.lastCompletedAt ?? null)
       saveProgressCache({
         completed: completedMap,
         aiScores: scoresMap,
@@ -136,6 +136,17 @@ export function App() {
 
     return () => {
       cancelled = true
+    }
+  }, [isLoggedIn])
+
+  useEffect(() => {
+    if (!isLoggedIn) return
+    saveProgressCache({ completed, aiScores, aiResults, lastCompletedAt })
+  }, [completed, aiScores, aiResults, lastCompletedAt, isLoggedIn])
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      localStorage.removeItem(PROGRESS_CACHE_KEY)
     }
   }, [isLoggedIn])
 

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -15,6 +15,35 @@ import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
 import { ACTS } from '@/features/quest-map/constants/questData'
 
+const PROGRESS_CACHE_KEY = 'devquest-progress'
+
+interface ProgressCache {
+  completed: Record<string, boolean>
+  aiScores: Record<string, number>
+  aiResults: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>
+  lastCompletedAt: string | null
+}
+
+function loadProgressCache(): ProgressCache | null {
+  try {
+    const raw = localStorage.getItem(PROGRESS_CACHE_KEY)
+    return raw ? (JSON.parse(raw) as ProgressCache) : null
+  } catch {
+    return null
+  }
+}
+
+function saveProgressCache(cache: ProgressCache): void {
+  try {
+    localStorage.setItem(PROGRESS_CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // ignore
+  }
+}
+
+// 모듈 로드 시 1회 읽음 (컴포넌트 리렌더와 무관)
+const INITIAL_PROGRESS_CACHE = loadProgressCache()
+
 type View =
   | { kind: 'map' }
   | { kind: 'briefing'; act: Act; quest: Quest }
@@ -27,11 +56,19 @@ export function App() {
   const { isLoggedIn } = useAuth()
   const { character, setCharacter } = useCharacter()
   const [view, setView] = useState<View>({ kind: 'map' })
-  const [completed, setCompleted] = useState<Record<string, boolean>>({})
-  const [lastCompletedAt, setLastCompletedAt] = useState<string | null>(null)
-  const [aiScores, setAiScores] = useState<Record<string, number>>({})
+  const [completed, setCompleted] = useState<Record<string, boolean>>(
+    INITIAL_PROGRESS_CACHE?.completed ?? {}
+  )
+  const [lastCompletedAt, setLastCompletedAt] = useState<string | null>(
+    INITIAL_PROGRESS_CACHE?.lastCompletedAt ?? null
+  )
+  const [aiScores, setAiScores] = useState<Record<string, number>>(
+    INITIAL_PROGRESS_CACHE?.aiScores ?? {}
+  )
   const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | DeveloperClassResult | null>(null)
-  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>>({})
+  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>>(
+    INITIAL_PROGRESS_CACHE?.aiResults ?? {}
+  )
   const [showForm, setShowForm] = useState(false)
   const [showIntro, setShowIntro] = useState(true)
   const [progressLoading, setProgressLoading] = useState(false)
@@ -64,6 +101,12 @@ export function App() {
       setAiScores(scoresMap)
       setAiResults(aiResultsMap)
       if (progress.lastCompletedAt) setLastCompletedAt(progress.lastCompletedAt)
+      saveProgressCache({
+        completed: completedMap,
+        aiScores: scoresMap,
+        aiResults: aiResultsMap,
+        lastCompletedAt: progress.lastCompletedAt ?? null,
+      })
     }
 
     let cancelled = false
@@ -192,6 +235,7 @@ export function App() {
       if (score >= 70) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))
         setAiScores((prev) => ({ ...prev, [quest.id]: score }))
+        completeQuest(quest.id, act.id, quest.xp).catch(() => {})
         if (isBossQuest(quest.id)) triggerActClearReport(act)
       }
     }
@@ -208,7 +252,7 @@ export function App() {
     )
   }
 
-  if (progressLoading) {
+  if (progressLoading && INITIAL_PROGRESS_CACHE === null) {
     return (
       <div
         role="status"

--- a/fe/src/features/ai-check/components/MockInterviewPanel.tsx
+++ b/fe/src/features/ai-check/components/MockInterviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import type { InterviewEvaluationResult } from '@/types/api.types'
 import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { ProgressBar } from '@/components/ui/ProgressBar'
@@ -18,16 +18,8 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
   const [answer, setAnswer] = useState('')
   const [results, setResults] = useState<InterviewEvaluationResult[]>([])
   const [loading, setLoading] = useState(false)
-  const [lastResult, setLastResult] = useState<InterviewEvaluationResult | null>(null)
   const [done, setDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [])
 
   const q = questions[idx]
   const totalScore = results.length
@@ -44,18 +36,14 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
       )
       const newResults = [...results, result]
       setResults(newResults)
-      setLastResult(result)
 
       if (idx + 1 >= questions.length) {
         const avg = Math.round(newResults.reduce((a, r) => a + r.score, 0) / newResults.length)
         setDone(true)
         onComplete(avg)
       } else {
-        timerRef.current = setTimeout(() => {
-          setIdx((i) => i + 1)
-          setAnswer('')
-          setLastResult(null)
-        }, 2000)
+        setIdx((i) => i + 1)
+        setAnswer('')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'AI 평가 중 오류가 발생했습니다. 다시 시도해주세요.')
@@ -67,45 +55,27 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
   if (done) {
     const passed = totalScore >= PASS_THRESHOLD
     return (
-      <div style={{ textAlign: 'center', padding: '28px 0' }}>
-        <div style={{ fontSize: 44, marginBottom: 12 }}>{passed ? '🏆' : '📚'}</div>
-        <div
-          style={{
-            fontSize: 24,
-            fontWeight: 'bold',
-            color: passed ? '#10B981' : '#EF4444',
-            marginBottom: 6,
-          }}
-        >
-          최종 점수: {totalScore}/100
+      <div>
+        <div style={{ textAlign: 'center', padding: '20px 0 16px' }}>
+          <div style={{ fontSize: 44, marginBottom: 10 }}>{passed ? '🏆' : '📚'}</div>
+          <div style={{ fontSize: 24, fontWeight: 'bold', color: passed ? '#10B981' : '#EF4444', marginBottom: 6 }}>
+            최종 점수: {totalScore}/100
+          </div>
+          <div style={{ fontSize: 13, color: '#64748B', marginBottom: 20 }}>
+            {passed ? '+800 XP 획득! 다음 Act 해금' : '70점 이상 필요. 재도전하세요'}
+          </div>
         </div>
-        <div style={{ fontSize: 13, color: '#64748B', marginBottom: 20 }}>
-          {passed ? '+800 XP 획득! 다음 Act 해금' : '70점 이상 필요. 재도전하세요'}
+
+        <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 12 }}>
+          📋 질문별 결과
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           {results.map((r, i) => (
-            <div
-              key={i}
-              style={{
-                background: 'rgba(13,17,23,0.7)',
-                borderRadius: 8,
-                padding: '9px 14px',
-                display: 'flex',
-                justifyContent: 'space-between',
-              }}
-            >
-              <span style={{ fontSize: 13, color: '#64748B' }}>
-                Q{i + 1}. {questions[i]?.category}
-              </span>
-              <span
-                style={{
-                  fontSize: 13,
-                  fontWeight: 'bold',
-                  color: r.score >= PASS_THRESHOLD ? '#10B981' : '#EF4444',
-                }}
-              >
-                {r.score}점
-              </span>
+            <div key={i}>
+              <div style={{ fontSize: 12, color: '#475569', marginBottom: 6 }}>
+                Q{i + 1}. {questions[i]?.category} — {questions[i]?.question}
+              </div>
+              <InterviewResultCard result={r} />
             </div>
           ))}
         </div>
@@ -160,70 +130,65 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
         </div>
       )}
 
-      {lastResult && <InterviewResultCard result={lastResult} />}
-      {!lastResult && (
-        <>
-          <button
-            type="button"
-            onClick={() => setAnswer(MOCK_INTERVIEW_SAMPLE_ANSWER)}
-            style={{
-              background: 'none',
-              border: '1px solid rgba(78,205,196,0.3)',
-              borderRadius: 6,
-              color: '#4ECDC4',
-              fontSize: 11,
-              padding: '4px 10px',
-              cursor: 'pointer',
-              fontFamily: "'Courier New', monospace",
-              marginBottom: 8,
-              display: 'block',
-            }}
-          >
-            샘플 답변 채우기
-          </button>
-          <textarea
-            value={answer}
-            onChange={(e) => setAnswer(e.target.value)}
-            rows={5}
-            placeholder="답변을 구체적으로 작성해주세요..."
-            style={{
-              width: '100%',
-              background: '#0A0E1A',
-              border: '1px solid rgba(255,255,255,0.08)',
-              borderRadius: 8,
-              padding: '10px 13px',
-              color: '#F1F5F9',
-              fontSize: 13,
-              outline: 'none',
-              resize: 'vertical',
-              boxSizing: 'border-box',
-              lineHeight: 1.6,
-              fontFamily: "'Courier New', monospace",
-              marginBottom: 10,
-            }}
-          />
-          <button
-            onClick={handleSubmit}
-            disabled={loading || !answer.trim()}
-            style={{
-              width: '100%',
-              padding: '12px',
-              background: loading
-                ? 'rgba(239,68,68,0.2)'
-                : 'linear-gradient(135deg, #EF4444, #DC2626)',
-              border: 'none',
-              borderRadius: 10,
-              color: '#fff',
-              fontSize: 14,
-              fontWeight: 'bold',
-              cursor: loading ? 'not-allowed' : 'pointer',
-              fontFamily: "'Courier New', monospace",
-            }}
-          >
-            {loading ? '⟳ 채점 중...' : '답변 제출 →'}
-          </button>
-        </>
-      )}
+      <button
+        type="button"
+        onClick={() => setAnswer(MOCK_INTERVIEW_SAMPLE_ANSWER)}
+        style={{
+          background: 'none',
+          border: '1px solid rgba(78,205,196,0.3)',
+          borderRadius: 6,
+          color: '#4ECDC4',
+          fontSize: 11,
+          padding: '4px 10px',
+          cursor: 'pointer',
+          fontFamily: "'Courier New', monospace",
+          marginBottom: 8,
+          display: 'block',
+        }}
+      >
+        샘플 답변 채우기
+      </button>
+      <textarea
+        value={answer}
+        onChange={(e) => setAnswer(e.target.value)}
+        rows={5}
+        placeholder="답변을 구체적으로 작성해주세요..."
+        style={{
+          width: '100%',
+          background: '#0A0E1A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          padding: '10px 13px',
+          color: '#F1F5F9',
+          fontSize: 13,
+          outline: 'none',
+          resize: 'vertical',
+          boxSizing: 'border-box',
+          lineHeight: 1.6,
+          fontFamily: "'Courier New', monospace",
+          marginBottom: 10,
+        }}
+      />
+      <button
+        onClick={handleSubmit}
+        disabled={loading || !answer.trim()}
+        style={{
+          width: '100%',
+          padding: '12px',
+          background: loading
+            ? 'rgba(239,68,68,0.2)'
+            : 'linear-gradient(135deg, #EF4444, #DC2626)',
+          border: 'none',
+          borderRadius: 10,
+          color: '#fff',
+          fontSize: 14,
+          fontWeight: 'bold',
+          cursor: loading ? 'not-allowed' : 'pointer',
+          fontFamily: "'Courier New', monospace",
+        }}
+      >
+        {loading ? '⟳ 채점 중...' : '답변 제출 →'}
+      </button>
     </div>
   )
 }

--- a/fe/src/features/ai-check/components/MockInterviewPanel.tsx
+++ b/fe/src/features/ai-check/components/MockInterviewPanel.tsx
@@ -20,6 +20,7 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
   const [loading, setLoading] = useState(false)
   const [done, setDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [completionReported, setCompletionReported] = useState(false)
 
   const q = questions[idx]
   const totalScore = results.length
@@ -38,9 +39,7 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
       setResults(newResults)
 
       if (idx + 1 >= questions.length) {
-        const avg = Math.round(newResults.reduce((a, r) => a + r.score, 0) / newResults.length)
         setDone(true)
-        onComplete(avg)
       } else {
         setIdx((i) => i + 1)
         setAnswer('')
@@ -79,6 +78,32 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
             </div>
           ))}
         </div>
+        {!completionReported && (
+          <button
+            type="button"
+            onClick={() => {
+              setCompletionReported(true)
+              onComplete(totalScore)
+            }}
+            style={{
+              width: '100%',
+              padding: '12px',
+              background: totalScore >= PASS_THRESHOLD
+                ? 'linear-gradient(135deg, #10B981, #059669)'
+                : 'rgba(78,205,196,0.1)',
+              border: totalScore >= PASS_THRESHOLD ? 'none' : '1px solid rgba(78,205,196,0.3)',
+              borderRadius: 10,
+              color: totalScore >= PASS_THRESHOLD ? '#060610' : '#4ECDC4',
+              fontSize: 14,
+              fontWeight: 'bold',
+              cursor: 'pointer',
+              fontFamily: "'Courier New', monospace",
+              marginTop: 20,
+            }}
+          >
+            {totalScore >= PASS_THRESHOLD ? '🏆 완료 저장 & Act III 해금' : '📚 결과 확인 완료'}
+          </button>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- 모의 면접(2-BOSS) 질문 간 결과 카드 제거 — 즉시 다음 문제로 이동
- 모의 면접 완료 후 전체 질문별 상세 결과(`InterviewResultCard`) 표시
- progress를 localStorage에 캐시 — 새로고침 시 즉시 이전 상태 복원, 로딩 화면 없음
- `handleMockInterviewComplete`에서 `completeQuest()` 호출 누락 수정 — 모의 면접 완료가 서버에 저장됨

## Why
직접 플로우 테스트 중 식별된 버그 4건:
1. 각 질문 답변 후 상세 결과가 매번 노출되다 다음 문제로 넘어가는 UX 문제
2. 최종 화면에 개별 피드백 없이 점수표만 표시
3. 새로고침 시 fly.io cold start 동안 "서버 기동 중..." 최대 30초 노출
4. 새로고침 시 진척 데이터 초기화 (2-BOSS 완료 상태 서버 미저장 포함)

## Test plan
- [ ] 2-BOSS 모의 면접: 답변 제출 후 결과 카드 없이 즉시 다음 문제로 이동
- [ ] 2-BOSS 전체 완료 후 모든 질문별 InterviewResultCard 표시 확인
- [ ] 퀘스트 완료 후 새로고침 시 캐시에서 즉시 복원 (로딩 화면 미노출) 확인
- [ ] 2-BOSS 통과 후 새로고침 시 완료 상태 유지 확인