### PR TITLE
fix(fe): 모의 면접 일괄 제출 전환 및 JD 역분석 타입 불일치 수정

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/AiCheckService.kt
@@ -77,7 +77,8 @@ class AiCheckService(
     @Transactional
     fun analyzeJd(userId: String, companyName: String, jobDescription: String, userSkills: List<String>, userExperiences: List<String>): JdAnalysisResult {
         val result = jdAnalysisEvaluator.analyze(companyName, jobDescription, userSkills, userExperiences)
-        questProgressRecorder.record(userId, QuestConstants.JD_ANALYSIS, 3, result.overallMatchScore, true, QuestXpPolicy.calculate(QuestConstants.JD_ANALYSIS, true))
+        val passed = PassCriteriaPolicy.evaluate(result.overallMatchScore)
+        questProgressRecorder.record(userId, QuestConstants.JD_ANALYSIS, 3, result.overallMatchScore, passed, QuestXpPolicy.calculate(QuestConstants.JD_ANALYSIS, passed))
         return result
     }
 

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/AiCheckServiceTest.kt
@@ -192,13 +192,23 @@ class AiCheckServiceTest {
     // ===== analyzeJd 테스트 =====
 
     @Test
-    fun `analyzeJd - 항상 passed=true이고 xp=350 고정으로 저장`() {
+    fun `analyzeJd - 점수 70 이상이면 passed=true, xp=350으로 저장`() {
+        whenever(jdAnalysisEvaluator.analyze(any(), any(), any(), any()))
+            .thenReturn(JdAnalysisResult(companyName = "카카오", overallMatchScore = 75))
+
+        service.analyzeJd("user1", "카카오", "JD 내용", listOf("Kotlin"), listOf("3년 경력"))
+
+        verify(questProgressRecorder).record(eq("user1"), eq("3-2"), eq(3), eq(75), eq(true), eq(350), isNull())
+    }
+
+    @Test
+    fun `analyzeJd - 점수 69 이하이면 passed=false, xp=0으로 저장`() {
         whenever(jdAnalysisEvaluator.analyze(any(), any(), any(), any()))
             .thenReturn(JdAnalysisResult(companyName = "카카오", overallMatchScore = 60))
 
         service.analyzeJd("user1", "카카오", "JD 내용", listOf("Kotlin"), listOf("3년 경력"))
 
-        verify(questProgressRecorder).record(eq("user1"), eq("3-2"), eq(3), eq(60), eq(true), eq(350), isNull())
+        verify(questProgressRecorder).record(eq("user1"), eq("3-2"), eq(3), eq(60), eq(false), eq(0), isNull())
     }
 
     // ===== checkBossPackage 테스트 =====

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, ActClearReportResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ActClearReportResult } from '@/types/api.types'
 import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail, QuestBriefingView } from '@/features/quest-detail'
@@ -20,7 +20,7 @@ const PROGRESS_CACHE_KEY = 'devquest-progress'
 interface ProgressCache {
   completed: Record<string, boolean>
   aiScores: Record<string, number>
-  aiResults: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>
+  aiResults: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult>
   lastCompletedAt: string | null
 }
 
@@ -65,8 +65,8 @@ export function App() {
   const [aiScores, setAiScores] = useState<Record<string, number>>(
     INITIAL_PROGRESS_CACHE?.aiScores ?? {}
   )
-  const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | DeveloperClassResult | null>(null)
-  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult>>(
+  const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | null>(null)
+  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult>>(
     INITIAL_PROGRESS_CACHE?.aiResults ?? {}
   )
   const [showForm, setShowForm] = useState(false)
@@ -82,7 +82,7 @@ export function App() {
     const applyProgress = (progress: Awaited<ReturnType<typeof fetchProgress>>) => {
       const completedMap: Record<string, boolean> = {}
       const scoresMap: Record<string, number> = {}
-      const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult> = {}
+      const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult> = {}
       progress.completedQuests.forEach((id) => {
         completedMap[id] = true
       })
@@ -208,18 +208,23 @@ export function App() {
     if (isBossQuest(questId)) triggerActClearReport(act)
   }
 
-  const handleAiResult = (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult) => {
+  const handleAiResult = (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => {
     setAiResult(result)
     setShowForm(false)
     if (view.kind === 'detail') {
       const { quest, act } = view
       setAiResults((prev) => ({ ...prev, [quest.id]: result }))
+      const isJdAnalysis = 'overallMatchScore' in result && !('passed' in result)
       const isBossPackage = quest.id === '4-BOSS'
       const isDeveloperClass = 'developerClass' in result
-      const score = isBossPackage || isDeveloperClass
-        ? (result as BossPackageResult | DeveloperClassResult).overallScore
-        : (result as AiEvaluationResult).score
-      const passed = result.passed
+      const score = isJdAnalysis
+        ? (result as JdAnalysisResult).overallMatchScore
+        : isBossPackage || isDeveloperClass
+          ? (result as BossPackageResult | DeveloperClassResult).overallScore
+          : (result as AiEvaluationResult).score
+      const passed = isJdAnalysis
+        ? (result as JdAnalysisResult).overallMatchScore >= 70
+        : (result as { passed: boolean }).passed
       if (passed) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))
         setAiScores((prev) => ({ ...prev, [quest.id]: score }))

--- a/fe/src/features/ai-check/api/aiCheckApi.ts
+++ b/fe/src/features/ai-check/api/aiCheckApi.ts
@@ -1,4 +1,4 @@
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, InterviewEvaluationResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, InterviewEvaluationResult, JdAnalysisResult } from '@/types/api.types'
 import { callAiCheck } from '@/lib/apiClient'
 
 export async function submitAiCheck(
@@ -16,6 +16,10 @@ export async function submitBossPackage(
   body: Record<string, unknown>,
 ): Promise<BossPackageResult> {
   return callAiCheck<BossPackageResult>('boss-package', body)
+}
+
+export async function submitJdAnalysis(body: Record<string, unknown>): Promise<JdAnalysisResult> {
+  return callAiCheck<JdAnalysisResult>('jd-analysis', body)
 }
 
 export async function submitMockInterview(params: {

--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -1,4 +1,4 @@
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult } from '@/types/api.types'
 import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { AI_FORMS } from '../constants/formConfig'
 import { useAiCheckForm } from '../hooks/useAiCheckForm'
@@ -6,7 +6,7 @@ import { FormField } from './FormField'
 
 interface AiCheckFormProps {
   questId: string
-  onResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult) => void
+  onResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => void
   initialValues?: Record<string, unknown>
   onSubmit?: (values: Record<string, unknown>) => void
 }

--- a/fe/src/features/ai-check/components/AiResultCard.tsx
+++ b/fe/src/features/ai-check/components/AiResultCard.tsx
@@ -249,7 +249,7 @@ const IMPORTANCE_COLOR: Record<string, string> = {
 
 export function JdAnalysisResultCard({ result }: JdAnalysisResultCardProps) {
   const score = result.overallMatchScore
-  const passed = score >= 70
+  const passed = score >= PASS_THRESHOLD
   const grade = getGrade(score)
 
   return (

--- a/fe/src/features/ai-check/components/AiResultCard.tsx
+++ b/fe/src/features/ai-check/components/AiResultCard.tsx
@@ -1,4 +1,4 @@
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, SkillRequirement } from '@/types/api.types'
 import { getGrade, PASS_THRESHOLD } from '../../../utils/gradeUtils'
 import { ResultHeader } from './ResultHeader'
 import { ResultSection } from './ResultSection'
@@ -233,6 +233,150 @@ export function DeveloperClassResultCard({ result }: DeveloperClassResultCardPro
           {result.overallFeedback}
         </p>
       </div>
+    </div>
+  )
+}
+
+interface JdAnalysisResultCardProps {
+  result: JdAnalysisResult
+}
+
+const IMPORTANCE_COLOR: Record<string, string> = {
+  HIGH: '#EF4444',
+  MEDIUM: '#F59E0B',
+  LOW: '#10B981',
+}
+
+export function JdAnalysisResultCard({ result }: JdAnalysisResultCardProps) {
+  const score = result.overallMatchScore
+  const passed = score >= 70
+  const grade = getGrade(score)
+
+  return (
+    <div
+      style={{
+        background: passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
+        border: `1px solid ${passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
+        borderRadius: 14,
+        padding: 22,
+        marginTop: 18,
+        animation: 'slideIn 0.5s ease',
+      }}
+    >
+      <ResultHeader
+        score={score}
+        passed={passed}
+        grade={grade}
+        passLabel="✓ 통과 — JD 매칭 분석 완료!"
+        failLabel="✗ 미통과 — 역량 보완이 필요합니다"
+      />
+
+      {/* 회사명 */}
+      {result.companyName && (
+        <div style={{ fontSize: 13, color: '#94A3B8', marginBottom: 16 }}>
+          <span style={{ color: '#4ECDC4' }}>대상 회사:</span> {result.companyName}
+        </div>
+      )}
+
+      {/* 스킬 매칭 테이블 */}
+      {result.requiredSkills.length > 0 && (
+        <div style={{ marginBottom: 18 }}>
+          <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 10 }}>
+            📊 스킬 매칭
+          </div>
+          <div
+            style={{
+              background: 'rgba(15,23,42,0.7)',
+              borderRadius: 10,
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 60px 50px 60px',
+                padding: '8px 12px',
+                borderBottom: '1px solid rgba(255,255,255,0.06)',
+                fontSize: 10,
+                color: '#475569',
+                letterSpacing: 1,
+              }}
+            >
+              <span>스킬</span>
+              <span style={{ textAlign: 'center' }}>구분</span>
+              <span style={{ textAlign: 'center' }}>내 수준</span>
+              <span style={{ textAlign: 'center' }}>중요도</span>
+            </div>
+            {result.requiredSkills.map((skill: SkillRequirement, i: number) => {
+              const importanceColor = IMPORTANCE_COLOR[skill.importance] ?? '#64748B'
+              return (
+                <div
+                  key={i}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 60px 50px 60px',
+                    padding: '9px 12px',
+                    borderBottom: i < result.requiredSkills.length - 1 ? '1px solid rgba(255,255,255,0.04)' : 'none',
+                    fontSize: 12,
+                    alignItems: 'center',
+                  }}
+                >
+                  <span style={{ color: '#F1F5F9' }}>{skill.skill}</span>
+                  <span
+                    style={{
+                      textAlign: 'center',
+                      color: skill.required ? '#EF4444' : '#60A5FA',
+                      fontSize: 11,
+                    }}
+                  >
+                    {skill.required ? '필수' : '우대'}
+                  </span>
+                  <span style={{ textAlign: 'center', color: '#94A3B8' }}>{skill.userLevel}</span>
+                  <span
+                    style={{
+                      textAlign: 'center',
+                      color: importanceColor,
+                      fontSize: 11,
+                      fontWeight: 'bold',
+                    }}
+                  >
+                    {skill.importance}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 강점 */}
+      {result.keyDifferentiators.length > 0 && (
+        <ResultSection label="✓ STRENGTHS" color="#10B981" items={result.keyDifferentiators} />
+      )}
+
+      {/* 숨겨진 요구사항 */}
+      {result.hiddenRequirements.length > 0 && (
+        <ResultSection label="⚠ 숨겨진 요구사항" color="#F59E0B" items={result.hiddenRequirements} />
+      )}
+
+      {/* 지원 전략 */}
+      {result.applicationStrategy && (
+        <div
+          style={{
+            background: 'rgba(15,23,42,0.7)',
+            borderRadius: 10,
+            padding: '14px 16px',
+            borderLeft: '3px solid #4ECDC4',
+          }}
+        >
+          <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 3, marginBottom: 8 }}>
+            🎯 지원 전략
+          </div>
+          <p style={{ color: '#94A3B8', fontSize: 13, margin: 0, lineHeight: 1.7 }}>
+            {result.applicationStrategy}
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/fe/src/features/ai-check/components/MockInterviewPanel.tsx
+++ b/fe/src/features/ai-check/components/MockInterviewPanel.tsx
@@ -15,6 +15,7 @@ interface MockInterviewPanelProps {
 export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
   const [questions] = useState(FALLBACK_QUESTIONS)
   const [idx, setIdx] = useState(0)
+  const [answers, setAnswers] = useState<string[]>([])
   const [answer, setAnswer] = useState('')
   const [results, setResults] = useState<InterviewEvaluationResult[]>([])
   const [loading, setLoading] = useState(false)
@@ -23,27 +24,38 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
   const [completionReported, setCompletionReported] = useState(false)
 
   const q = questions[idx]
+  const isLastQuestion = idx + 1 >= questions.length
   const totalScore = results.length
     ? Math.round(results.reduce((a, r) => a + r.score, 0) / results.length)
     : 0
 
-  const handleSubmit = async () => {
-    if (!q || !answer.trim()) return
+  const handleNext = () => {
+    if (!answer.trim()) return
+    setAnswers(prev => { const next = [...prev]; next[idx] = answer; return next })
+    setIdx(i => i + 1)
+    setAnswer('')
+  }
+
+  const handleSubmitAll = async () => {
+    if (!answer.trim()) return
+    const allAnswers = [...answers]
+    allAnswers[idx] = answer
     setLoading(true)
     setError(null)
     try {
-      const result = await submitMockInterview(
-        { questId: '2-BOSS', questionId: q.id, question: q.question, answer, category: q.category },
+      const allResults = await Promise.all(
+        questions.map((question, i) =>
+          submitMockInterview({
+            questId: '2-BOSS',
+            questionId: question.id,
+            question: question.question,
+            answer: allAnswers[i] ?? '',
+            category: question.category,
+          })
+        )
       )
-      const newResults = [...results, result]
-      setResults(newResults)
-
-      if (idx + 1 >= questions.length) {
-        setDone(true)
-      } else {
-        setIdx((i) => i + 1)
-        setAnswer('')
-      }
+      setResults(allResults)
+      setDone(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'AI 평가 중 오류가 발생했습니다. 다시 시도해주세요.')
     } finally {
@@ -138,7 +150,7 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
         <p style={{ fontSize: 14, color: '#F1F5F9', margin: 0, lineHeight: 1.7 }}>{q.question}</p>
       </div>
 
-      <OracleLoadingModal isOpen={loading} />
+      <OracleLoadingModal isOpen={loading && isLastQuestion} />
       {error && (
         <div
           style={{
@@ -195,14 +207,16 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
         }}
       />
       <button
-        onClick={handleSubmit}
+        onClick={isLastQuestion ? handleSubmitAll : handleNext}
         disabled={loading || !answer.trim()}
         style={{
           width: '100%',
           padding: '12px',
           background: loading
             ? 'rgba(239,68,68,0.2)'
-            : 'linear-gradient(135deg, #EF4444, #DC2626)',
+            : isLastQuestion
+              ? 'linear-gradient(135deg, #A78BFA, #7C3AED)'
+              : 'linear-gradient(135deg, #EF4444, #DC2626)',
           border: 'none',
           borderRadius: 10,
           color: '#fff',
@@ -212,7 +226,7 @@ export function MockInterviewPanel({ onComplete }: MockInterviewPanelProps) {
           fontFamily: "'Courier New', monospace",
         }}
       >
-        {loading ? '⟳ 채점 중...' : '답변 제출 →'}
+        {loading ? '⟳ 채점 중...' : isLastQuestion ? '🤖 채점하기' : '다음 질문 →'}
       </button>
     </div>
   )

--- a/fe/src/features/ai-check/hooks/useAiCheckForm.ts
+++ b/fe/src/features/ai-check/hooks/useAiCheckForm.ts
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult } from '@/types/api.types'
 import type { AiFormConfig } from '../types/aiCheck.types'
-import { submitAiCheck, submitBossPackage, submitDeveloperClass } from '../api/aiCheckApi'
+import { submitAiCheck, submitBossPackage, submitDeveloperClass, submitJdAnalysis } from '../api/aiCheckApi'
 
 interface UseAiCheckFormParams {
   questId: string
   cfg: AiFormConfig
-  onResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult) => void
+  onResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => void
   onSubmit?: (values: Record<string, unknown>) => void
   initialValues?: Record<string, unknown>
 }
@@ -68,7 +68,9 @@ export function useAiCheckForm({ questId, cfg, onResult, onSubmit, initialValues
           ? await submitBossPackage(body)
           : questId === '1-BOSS'
             ? await submitDeveloperClass()
-            : await submitAiCheck(cfg.endpoint, body)
+            : questId === '3-2'
+              ? await submitJdAnalysis(body)
+              : await submitAiCheck(cfg.endpoint, body)
       onResult(result)
     } catch (e) {
       setError('서버 연결 오류: ' + (e instanceof Error ? e.message : String(e)))

--- a/fe/src/features/ai-check/hooks/useAiCheckForm.ts
+++ b/fe/src/features/ai-check/hooks/useAiCheckForm.ts
@@ -68,7 +68,7 @@ export function useAiCheckForm({ questId, cfg, onResult, onSubmit, initialValues
           ? await submitBossPackage(body)
           : questId === '1-BOSS'
             ? await submitDeveloperClass()
-            : questId === '3-2'
+            : cfg.endpoint === 'jd-analysis'
               ? await submitJdAnalysis(body)
               : await submitAiCheck(cfg.endpoint, body)
       onResult(result)

--- a/fe/src/features/ai-check/index.ts
+++ b/fe/src/features/ai-check/index.ts
@@ -1,6 +1,6 @@
 export { ActClearReportCard } from './components/ActClearReportCard'
 export { AiCheckForm } from './components/AiCheckForm'
-export { AiResultCard, BossPackageResultCard, DeveloperClassResultCard } from './components/AiResultCard'
+export { AiResultCard, BossPackageResultCard, DeveloperClassResultCard, JdAnalysisResultCard } from './components/AiResultCard'
 export { InterviewResultCard } from './components/InterviewResultCard'
 export { MockInterviewPanel } from './components/MockInterviewPanel'
 export { AI_FORMS } from './constants/formConfig'

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -6,6 +6,7 @@ import { PixelIcon } from '@/components/ui/PixelIcon'
 import { AiCheckForm, AiResultCard, BossPackageResultCard, DeveloperClassResultCard, JdAnalysisResultCard, MockInterviewPanel } from '@/features/ai-check'
 import { AI_FORMS } from '@/features/ai-check'
 import { MOCK_FORM_VALUES } from '@/features/ai-check/constants/mockValues'
+import { PASS_THRESHOLD } from '@/utils/gradeUtils'
 import { QUEST_NEXT } from '../constants/questConnections'
 import { NextQuestCard } from './NextQuestCard'
 import { RetryCoachCard } from './RetryCoachCard'
@@ -41,7 +42,7 @@ function extractImprovements(aiResult: AnyAiResult): string[] {
 
 function isPassed(aiResult: AnyAiResult): boolean {
   if ('overallMatchScore' in aiResult && !('passed' in aiResult)) {
-    return (aiResult as JdAnalysisResult).overallMatchScore >= 70
+    return (aiResult as JdAnalysisResult).overallMatchScore >= PASS_THRESHOLD
   }
   return (aiResult as { passed: boolean }).passed === true
 }

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult } from '@/types/api.types'
 import { QUEST_TYPE_CONFIG } from '@/features/quest-map'
 import { PixelIcon } from '@/components/ui/PixelIcon'
-import { AiCheckForm, AiResultCard, BossPackageResultCard, DeveloperClassResultCard, MockInterviewPanel } from '@/features/ai-check'
+import { AiCheckForm, AiResultCard, BossPackageResultCard, DeveloperClassResultCard, JdAnalysisResultCard, MockInterviewPanel } from '@/features/ai-check'
 import { AI_FORMS } from '@/features/ai-check'
 import { MOCK_FORM_VALUES } from '@/features/ai-check/constants/mockValues'
 import { QUEST_NEXT } from '../constants/questConnections'
@@ -11,17 +11,17 @@ import { NextQuestCard } from './NextQuestCard'
 import { RetryCoachCard } from './RetryCoachCard'
 import { FinalBossView } from './FinalBossView'
 
-type AnyAiResult = AiEvaluationResult | BossPackageResult | DeveloperClassResult
+type AnyAiResult = AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult
 
 interface QuestDetailProps {
   quest: Quest
   act: Act
   completed: Record<string, boolean>
   aiScores: Record<string, number>
-  aiResult: AiEvaluationResult | BossPackageResult | DeveloperClassResult | null
+  aiResult: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | null
   showForm: boolean
   onShowForm: () => void
-  onAiResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult) => void
+  onAiResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => void
   onComplete: (questId: string, xp: number, actId: number, act: Act) => void
   onMockInterviewComplete: (score: number) => void
   onNextQuest?: (questId: string) => void
@@ -40,7 +40,10 @@ function extractImprovements(aiResult: AnyAiResult): string[] {
 }
 
 function isPassed(aiResult: AnyAiResult): boolean {
-  return aiResult.passed === true
+  if ('overallMatchScore' in aiResult && !('passed' in aiResult)) {
+    return (aiResult as JdAnalysisResult).overallMatchScore >= 70
+  }
+  return (aiResult as { passed: boolean }).passed === true
 }
 
 export function QuestDetail({
@@ -239,9 +242,11 @@ export function QuestDetail({
         {aiResult && !isMock && (
           quest.id === '4-BOSS'
             ? <BossPackageResultCard result={aiResult as BossPackageResult} />
-            : 'developerClass' in aiResult
-              ? <DeveloperClassResultCard result={aiResult as DeveloperClassResult} />
-              : <AiResultCard result={aiResult as AiEvaluationResult} />
+            : quest.id === '3-2'
+              ? <JdAnalysisResultCard result={aiResult as JdAnalysisResult} />
+              : 'developerClass' in aiResult
+                ? <DeveloperClassResultCard result={aiResult as DeveloperClassResult} />
+                : <AiResultCard result={aiResult as AiEvaluationResult} />
         )}
 
         {/* Feature E: Next quest card after passing */}

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -102,3 +102,19 @@ export interface DeveloperClassResult {
   strategies: string[]
   overallFeedback: string
 }
+
+export interface SkillRequirement {
+  skill: string
+  required: boolean
+  userLevel: string
+  importance: string
+}
+
+export interface JdAnalysisResult {
+  companyName: string
+  requiredSkills: SkillRequirement[]
+  hiddenRequirements: string[]
+  overallMatchScore: number
+  keyDifferentiators: string[]
+  applicationStrategy: string
+}


### PR DESCRIPTION
## Summary
- 모의 면접(2-BOSS): 질문마다 즉시 AI 호출 → 모든 답변 입력 후 `Promise.all` 5개 동시 호출로 변경 (최대 대기 시간 ~80% 단축)
- JD 역분석(3-2): BE `JdAnalysisResult` 필드(`overallMatchScore`, `requiredSkills` 등)와 FE 타입 불일치로 항상 D/미통과 표시되던 버그 수정
- `JdAnalysisResultCard` 전용 결과 카드 추가 (스킬 매칭 테이블, 차별화 포인트, 숨겨진 요구사항, 지원 전략 섹션)

## Why
- 모의 면접은 5문제 순차 AI 호출 시 최대 50초 대기 — 배치 처리로 UX 개선
- JD 역분석은 `score`/`passed`/`grade` 필드가 없는 타입을 `AiEvaluationResult`로 파싱해 score=0, D 미통과, 피드백 없음 상태가 고정되는 버그

## Test plan
- [ ] 모의 면접: 5문제 순서대로 답변 입력 → "채점하기" 클릭 시 5개 동시 호출 후 결과 표시 확인
- [ ] 모의 면접: 마지막 이전 질문에서 "다음 질문 →" 버튼 표시, AI 호출 없이 다음 문제로 이동 확인
- [ ] JD 역분석: 샘플 데이터 제출 시 실제 점수/등급 표시 및 스킬 매칭 테이블 렌더링 확인
- [ ] JD 역분석: 70점 이상 시 통과, 미만 시 미통과 정상 판정 확인