### PR TITLE
fix(fe): 퀘스트 변경 시 AI 폼 상태 초기화 누락 수정

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -364,6 +364,7 @@ export function App() {
 
       {view.kind === 'detail' && (
         <QuestDetail
+          key={view.quest.id}
           quest={view.quest}
           act={view.act}
           completed={completed}


### PR DESCRIPTION
## Summary
- `QuestDetail`에 `key={view.quest.id}` 추가로 퀘스트 변경 시 컴포넌트 완전 재마운트
- 기존: `lastSubmittedValues`가 퀘스트 변경 후에도 남아 이전 퀘스트 값이 새 퀘스트 폼에 채워지는 버그
- 뒤로 갔다가 다시 진입 시 샘플 데이터 대신 이전 제출값이 표시되던 문제 해결

## Test plan
- [ ] 퀘스트 A에서 폼 작성/제출
- [ ] 다른 퀘스트 B로 이동 후 AI 검사 폼 열기 → B의 샘플 데이터가 정상 표시 확인
- [ ] 최초 진입 시 샘플 데이터 자동 채우기 정상 동작 확인