### PR TITLE
test(be): DeveloperClassEvaluator, BossPackageEvaluator 단위 테스트 추가

### DIFF
--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
@@ -1,0 +1,115 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.core.domain.model.evaluation.BossPackageResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class BossPackageEvaluatorTest {
+
+    private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val evaluator = BossPackageEvaluator(chatClient, aiCallExecutor)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
+        whenever(
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(BossPackageResult::class.java)
+        ).thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                resumeContent = "백엔드 개발 5년 경력",
+                githubUrl = "https://github.com/testuser",
+                blogUrl = "https://blog.example.com",
+                targetPosition = "시니어 백엔드 개발자"
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("최종 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
+        val expected = BossPackageResult(
+            overallScore = 85,
+            passed = true,
+            resumeImpactScore = 80,
+            githubConsistencyScore = 90,
+            technicalDepthScore = 85,
+            positionFitScore = 88,
+            differentiationScore = 82,
+            strengths = listOf("GitHub 활동 이력 풍부", "기술 깊이 우수"),
+            improvements = listOf("블로그 콘텐츠 보강 필요"),
+            overallFeedback = "전반적으로 경쟁력 있는 포트폴리오입니다"
+        )
+        whenever(
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(BossPackageResult::class.java)
+        ).thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            resumeContent = "백엔드 개발 5년 경력",
+            githubUrl = "https://github.com/testuser",
+            blogUrl = "https://blog.example.com",
+            targetPosition = "시니어 백엔드 개발자"
+        )
+
+        assertThat(result.overallScore).isEqualTo(85)
+        assertThat(result.passed).isTrue()
+        assertThat(result.resumeImpactScore).isEqualTo(80)
+        assertThat(result.githubConsistencyScore).isEqualTo(90)
+    }
+
+    @Test
+    fun `사용자 프롬프트에 목표 포지션, GitHub URL, 이력서 내용이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(BossPackageResult::class.java)
+        ).thenReturn(
+            BossPackageResult(overallScore = 75, passed = true)
+        )
+
+        evaluator.evaluate(
+            resumeContent = "Java Spring Boot 개발 경력",
+            githubUrl = "https://github.com/testuser",
+            blogUrl = "https://blog.example.com",
+            targetPosition = "시니어 백엔드 개발자"
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("시니어 백엔드 개발자")
+        assertThat(prompt).contains("https://github.com/testuser")
+        assertThat(prompt).contains("Java Spring Boot 개발 경력")
+    }
+
+    @Test
+    fun `블로그 URL이 빈 문자열이면 미제공으로 대체하여 호출된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(BossPackageResult::class.java)
+        ).thenReturn(
+            BossPackageResult(overallScore = 70, passed = true)
+        )
+
+        evaluator.evaluate(
+            resumeContent = "백엔드 개발 경력",
+            githubUrl = "https://github.com/testuser",
+            blogUrl = "",
+            targetPosition = "백엔드 개발자"
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("미제공")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
@@ -1,0 +1,103 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.core.domain.model.evaluation.DeveloperClassResult
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class DeveloperClassEvaluatorTest {
+
+    private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val evaluator = DeveloperClassEvaluator(chatClient, aiCallExecutor)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
+        whenever(
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(DeveloperClassResult::class.java)
+        ).thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.evaluate(
+                skillAssessmentJson = """{"score": 78}""",
+                careerEssayJson = """{"score": 82}"""
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("최종 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
+        val expected = DeveloperClassResult(
+            overallScore = 80,
+            passed = true,
+            developerClass = "시니어 백엔드 엔지니어",
+            classDescription = "높은 기술 역량과 커리어 방향성이 명확한 개발자",
+            strengths = listOf("Java 장기 실무 경험", "아키텍처 설계 능력"),
+            strategies = listOf("클라우드 역량 강화", "리더십 경험 추가"),
+            overallFeedback = "전반적으로 우수한 역량을 보유하고 있습니다"
+        )
+        whenever(
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(DeveloperClassResult::class.java)
+        ).thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            skillAssessmentJson = """{"score": 78}""",
+            careerEssayJson = """{"score": 82}"""
+        )
+
+        assertThat(result.overallScore).isEqualTo(80)
+        assertThat(result.passed).isTrue()
+        assertThat(result.developerClass).isEqualTo("시니어 백엔드 엔지니어")
+        assertThat(result.classDescription).isEqualTo("높은 기술 역량과 커리어 방향성이 명확한 개발자")
+    }
+
+    @Test
+    fun `사용자 프롬프트에 기술 평가 JSON과 커리어 에세이 JSON이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(DeveloperClassResult::class.java)
+        ).thenReturn(
+            DeveloperClassResult(overallScore = 75, passed = true, developerClass = "미드레벨")
+        )
+
+        evaluator.evaluate(
+            skillAssessmentJson = """{"score": 78, "grade": "B"}""",
+            careerEssayJson = """{"score": 82, "grade": "A"}"""
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains(""""score": 78""")
+        assertThat(prompt).contains(""""score": 82""")
+    }
+
+    @Test
+    fun `빈 문자열 입력 시 기본값으로 대체하여 호출된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(DeveloperClassResult::class.java)
+        ).thenReturn(
+            DeveloperClassResult(overallScore = 50, passed = false, developerClass = "주니어")
+        )
+
+        evaluator.evaluate(
+            skillAssessmentJson = "",
+            careerEssayJson = ""
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("{}")
+    }
+}


### PR DESCRIPTION
## Summary
- Issue #86 처리: Copilot 리뷰(PR #85) 지적사항 반영
- `DeveloperClassEvaluatorTest` 4개 케이스 추가
- `BossPackageEvaluatorTest` 4개 케이스 추가

## Test plan
- [ ] null 응답 시 `AiEvaluationException` 발생 확인
- [ ] 정상 응답 매핑 (overallScore, passed, 세부 필드) 확인
- [ ] 프롬프트에 필수 변수 포함 여부 확인
- [ ] 빈 문자열 입력 시 기본값 치환 로직 확인

Closes #86