### PR TITLE
fix(fe): 수동 퀘스트 완료 시 BE 저장 실패 무음 처리 수정

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -202,10 +202,15 @@ export function App() {
 
   const isBossQuest = (questId: string) => questId.endsWith('-BOSS')
 
-  const handleComplete = (questId: string, xp: number, actId: number, act: Act) => {
+  const handleComplete = async (questId: string, xp: number, actId: number, act: Act) => {
     setCompleted((prev) => ({ ...prev, [questId]: true }))
-    completeQuest(questId, actId, xp).catch(() => {})
-    if (isBossQuest(questId)) triggerActClearReport(act)
+    try {
+      await completeQuest(questId, actId, xp)
+      if (isBossQuest(questId)) triggerActClearReport(act)
+    } catch {
+      setCompleted((prev) => ({ ...prev, [questId]: false }))
+      alert('퀘스트 완료 저장에 실패했습니다. 다시 시도해 주세요.')
+    }
   }
 
   const handleAiResult = (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => {

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -250,14 +250,19 @@ export function App() {
     }
   }
 
-  const handleMockInterviewComplete = (score: number) => {
+  const handleMockInterviewComplete = async (score: number) => {
     if (view.kind === 'detail') {
       const { quest, act } = view
       if (score >= 70) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))
         setAiScores((prev) => ({ ...prev, [quest.id]: score }))
-        completeQuest(quest.id, act.id, quest.xp).catch(() => {})
-        if (isBossQuest(quest.id)) triggerActClearReport(act)
+        try {
+          await completeQuest(quest.id, act.id, quest.xp)
+          if (isBossQuest(quest.id)) triggerActClearReport(act)
+        } catch {
+          setCompleted((prev) => ({ ...prev, [quest.id]: false }))
+          alert('퀘스트 완료 저장에 실패했습니다. 다시 시도해 주세요.')
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- `handleComplete`, `handleMockInterviewComplete`에서 `completeQuest` API 호출을 fire-and-forget(`.catch(() => {})`)에서 async/await + try/catch로 전환
- API 실패 시 낙관적으로 업데이트된 `completed` 상태를 롤백하고 사용자에게 재시도 안내

## Why
BE에 저장되지 않은 상태로 로컬 UI만 완료 표시 → 새로고침 시 `fetchProgress`가 BE 기준으로 덮어써 완료 상태가 사라지는 버그. ACT III 보스 퀘스트(3-BOSS) 완료 후 ACT IV가 잠기는 증상으로 보고됨.

## Test plan
- [ ] 3-BOSS "완료로 표시하기" 클릭 시 ACT CLEAR 리포트 표시 확인
- [ ] 맵 복귀 후 ACT IV 잠금 해제 확인
- [ ] 새로고침 후 ACT IV 잠금 유지 확인 (BE 저장 성공 시)
- [ ] 네트워크 오류 시 alert 표시 및 완료 버튼 재노출 확인