### PR TITLE
fix(fe): ApiResponse success 필드 제거 및 result 기반 검사로 통일

### DIFF
--- a/fe/src/features/interview-coach/api/interviewCoachApi.ts
+++ b/fe/src/features/interview-coach/api/interviewCoachApi.ts
@@ -22,12 +22,12 @@ async function callCoach<T>(path: string, body: Record<string, unknown>): Promis
     let message = `HTTP ${res.status}`
     try {
       const err: ApiResponse<unknown> = await res.json()
-      if (err.message) message = err.message
+      if (err.error?.message) message = err.error.message
     } catch { /* ignore */ }
     throw new Error(message)
   }
   const json: ApiResponse<T> = await res.json()
-  if (json.result !== 'SUCCESS' || json.data == null) throw new Error(json.message ?? '코치 API 오류')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error(json.error?.message ?? '코치 API 오류')
   return json.data
 }
 

--- a/fe/src/features/interview-coach/api/interviewCoachApi.ts
+++ b/fe/src/features/interview-coach/api/interviewCoachApi.ts
@@ -27,7 +27,7 @@ async function callCoach<T>(path: string, body: Record<string, unknown>): Promis
     throw new Error(message)
   }
   const json: ApiResponse<T> = await res.json()
-  if (!json.success || json.data == null) throw new Error(json.message ?? '코치 API 오류')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error(json.message ?? '코치 API 오류')
   return json.data
 }
 

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -98,7 +98,7 @@ export async function callAiCheck<T>(
     let errorMessage = `HTTP ${res.status}`
     try {
       const errorJson: ApiResponse<unknown> = await res.json()
-      if (errorJson.message) errorMessage = errorJson.message
+      if (errorJson.error?.message) errorMessage = errorJson.error.message
     } catch {
       // response body not parseable, use default
     }
@@ -108,7 +108,7 @@ export async function callAiCheck<T>(
   const json: ApiResponse<T> = await res.json()
 
   if (json.result !== 'SUCCESS' || json.data == null) {
-    throw new Error(json.message ?? 'AI 평가 오류')
+    throw new Error(json.error?.message ?? 'AI 평가 오류')
   }
 
   return json.data

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -17,7 +17,7 @@ export async function fetchProgress(): Promise<ProgressResult> {
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<ProgressResult> = await res.json()
-  if (!json.success || json.data == null) throw new Error('진행 상황 조회 실패')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('진행 상황 조회 실패')
   return json.data
 }
 
@@ -45,7 +45,7 @@ export async function fetchActClearReport(
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<ActClearReportResult> = await res.json()
-  if (!json.success || json.data == null) throw new Error('ACT 클리어 리포트 생성 실패')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('ACT 클리어 리포트 생성 실패')
   return json.data
 }
 
@@ -55,7 +55,7 @@ export async function fetchHistory(): Promise<QuestHistoryItem[]> {
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
-  if (!json.success || json.data == null) throw new Error('히스토리 조회 실패')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('히스토리 조회 실패')
   return json.data
 }
 
@@ -65,7 +65,7 @@ export async function fetchQuestHistory(questId: string): Promise<QuestHistoryIt
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
-  if (!json.success || json.data == null) throw new Error('퀘스트 히스토리 조회 실패')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('퀘스트 히스토리 조회 실패')
   return json.data
 }
 
@@ -80,7 +80,7 @@ export async function fetchJourneyReport(
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const json: ApiResponse<JourneyReportResult> = await res.json()
-  if (!json.success || json.data == null) throw new Error('여정 리포트 생성 실패')
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('여정 리포트 생성 실패')
   return json.data
 }
 

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -1,7 +1,7 @@
 export interface ApiResponse<T> {
-  success: boolean
   result: string
   data: T | null
+  error: string | null
   message: string | null
 }
 

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -1,8 +1,13 @@
+export interface ErrorMessage {
+  code: string
+  message: string
+  data: unknown | null
+}
+
 export interface ApiResponse<T> {
   result: string
   data: T | null
-  error: string | null
-  message: string | null
+  error: ErrorMessage | null
 }
 
 export interface QuestDetail {


### PR DESCRIPTION
## Summary
- `ApiResponse<T>` 타입에서 BE가 실제로 보내지 않는 `success: boolean` 필드 제거
- `fetchProgress`, `fetchHistory`, `fetchQuestHistory`, `fetchActClearReport`, `fetchJourneyReport`, `callCoach` 6곳의 `!json.success` 체크를 `json.result !== 'SUCCESS'`로 교체
- `callAiCheck`는 이미 올바른 패턴 사용 중이었음

## Why
BE `ApiResponse`는 `result / data / error` 세 필드만 직렬화. `success` 필드가 없어서 `json.success === undefined → falsy → 항상 throw` 상태였음.
결과적으로 `fetchProgress`가 6회 retry 후 포기 → 진행 데이터 미표시 (ACT1부터 시작처럼 보이는 버그).

## Test plan
- [ ] 로그인 후 퀘스트 맵 진입 시 기존 완료 퀘스트가 정상 표시되는지 확인
- [ ] 성장 기록 페이지 히스토리 정상 로드 확인