### PR TITLE
feat(be): AI Evaluator 캐시 메트릭 관측가능성 추가

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.beans.factory.annotation.Value
+import com.devquest.client.ai.support.CacheMetricsAdvisor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -18,8 +19,10 @@ class AiClientConfig {
 
     @Bean
     @Primary
-    fun chatClient(chatModel: ChatModel): ChatClient {
-        return ChatClient.builder(chatModel).build()
+    fun chatClient(chatModel: ChatModel, cacheMetricsAdvisor: CacheMetricsAdvisor): ChatClient {
+        return ChatClient.builder(chatModel)
+            .defaultAdvisors(cacheMetricsAdvisor)
+            .build()
     }
 
     @Bean("bossChatClient")
@@ -27,6 +30,7 @@ class AiClientConfig {
         @Value("\${devquest.ai.boss-model:claude-sonnet-4-6}") bossModel: String,
         @Value("\${devquest.ai.boss-max-tokens:4000}") bossMaxTokens: Int,
         @Value("\${spring.ai.anthropic.api-key}") apiKey: String,
+        cacheMetricsAdvisor: CacheMetricsAdvisor,
     ): ChatClient {
         val anthropicClient = AnthropicOkHttpClient.builder()
             .apiKey(apiKey)
@@ -44,6 +48,8 @@ class AiClientConfig {
             .anthropicClient(anthropicClient)
             .options(options)
             .build()
-        return ChatClient.builder(model).build()
+        return ChatClient.builder(model)
+            .defaultAdvisors(cacheMetricsAdvisor)
+            .build()
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -1,0 +1,54 @@
+package com.devquest.client.ai.support
+
+import com.anthropic.models.messages.Usage
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClientRequest
+import org.springframework.ai.chat.client.ChatClientResponse
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Component
+
+@Component
+class CacheMetricsAdvisor : CallAdvisor {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun getName(): String = "CacheMetricsAdvisor"
+
+    override fun getOrder(): Int = Ordered.LOWEST_PRECEDENCE
+
+    override fun adviseCall(request: ChatClientRequest, chain: CallAdvisorChain): ChatClientResponse {
+        val response = chain.nextCall(request)
+
+        runCatching {
+            val nativeUsage = response.chatResponse()?.metadata?.usage?.nativeUsage
+            val usage = nativeUsage as? Usage ?: return@runCatching
+
+            val cacheRead = usage.cacheReadInputTokens().orElse(0L)
+            val cacheCreation = usage.cacheCreationInputTokens().orElse(0L)
+            val inputTokens = usage.inputTokens()
+            val outputTokens = usage.outputTokens()
+
+            log.info(
+                "AI cache metrics — cacheHit={}, cacheReadTokens={}, cacheCreationTokens={}, inputTokens={}, outputTokens={}",
+                cacheRead > 0,
+                cacheRead,
+                cacheCreation,
+                inputTokens,
+                outputTokens,
+            )
+
+            if (cacheCreation > 2_000 && cacheRead == 0L) {
+                log.warn(
+                    "AI cache miss — cacheCreationTokens={} with no cache read. Possible cache break or first call.",
+                    cacheCreation,
+                )
+            }
+        }.onFailure { e ->
+            log.debug("Failed to extract cache metrics: {}", e.message)
+        }
+
+        return response
+    }
+}

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -31,7 +31,7 @@ class CacheMetricsAdvisor : CallAdvisor {
             val outputTokens = usage.outputTokens()
 
             log.info(
-                "AI cache metrics — cacheHit={}, cacheReadTokens={}, cacheCreationTokens={}, inputTokens={}, outputTokens={}",
+                "AI cache metrics — cacheHit={}, cache_read_input_tokens={}, cache_creation_input_tokens={}, input_tokens={}, output_tokens={}",
                 cacheRead > 0,
                 cacheRead,
                 cacheCreation,
@@ -41,12 +41,12 @@ class CacheMetricsAdvisor : CallAdvisor {
 
             if (cacheCreation > 2_000 && cacheRead == 0L) {
                 log.warn(
-                    "AI cache miss — cacheCreationTokens={} with no cache read. Possible cache break or first call.",
+                    "AI cache miss — cache_creation_input_tokens={} with no cache read. Possible cache break or first call.",
                     cacheCreation,
                 )
             }
         }.onFailure { e ->
-            log.debug("Failed to extract cache metrics: {}", e.message)
+            log.debug("Failed to extract cache metrics", e)
         }
 
         return response


### PR DESCRIPTION
## Summary
- Spring AI `CallAdvisor` 패턴으로 `CacheMetricsAdvisor` 추가
- 매 AI 평가 호출 후 `cache_read_input_tokens` / `cache_creation_input_tokens` INFO 로그 출력
- `cacheCreation > 2,000 AND cacheRead == 0` 조건 시 WARN 로그 출력 (캐시 miss 감지)
- `chatClient`, `bossChatClient` 두 빈 모두에 Advisor 등록

## Why
PR #114/#115에서 Prompt Caching을 적용했으나 실제 캐시 hit 여부를 알 방법이 없었음.
Logtail에서 `cacheHit=false` 빈도를 모니터링해 캐시 효율을 파악할 수 있게 됨.

참고: [Cache Break는 조용히 온다 — Claude Code의 2단계 감지 시스템 해부](https://dhbang.co.kr/posts/study/harness-engineering-cache-break-detection/) Phase 2 (Post-response 캐시 토큰 확인) 적용.
글의 이중 임계값(5% relative AND 2,000토큰 absolute) 중 단발성 호출 특성상 절대값(2,000토큰)만 적용.

## Test plan
- [ ] AI 평가 API 호출 후 `AI cache metrics` INFO 로그 출력 확인
- [ ] bossChatClient: 2회 이상 호출 시 두 번째부터 `cacheHit=true` 확인
- [ ] BE CI 통과 확인