### PR TITLE
fix(fe): progress 로딩 화면 localStorage 캐시 우회 버그 수정

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -44,16 +44,16 @@
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `feat/cache-metrics-advisor` |
-| 열린 PR | #123 — feat(be): AI Evaluator 캐시 메트릭 관측가능성 추가 (CI 대기) |
+| 브랜치 | `fix/progress-loading-screen` |
+| 열린 PR | 진행 중 — progress 로딩 화면 캐시 우회 버그 수정 |
 
 ## 최근 완료 (최근 3건)
 
 | PR | 내용 | 날짜 |
 |----|------|------|
+| #123 | AI Evaluator 캐시 메트릭 관측가능성 추가 (CacheMetricsAdvisor) | 2026-05-07 |
 | #122 | Copilot Review Gate 봇 트리거 제거 + pull_request 폴링 방식 전환 | 2026-05-07 |
 | #121 | ApiResponse success 필드 제거, result/error 기반으로 통일 (진행 데이터 미표시 버그 수정) | 2026-05-07 |
-| #120 | skills 파일 에이전트 본문 통합 + 구식 패턴(AI Adapter, DTO userId, try-catch) 수정 | 2026-05-06 |
 
 ## 다음 작업
 

--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -1,4 +1,4 @@
-# 미완료 작업 (사용자 직접 실행 필요)
+# 미완료 작업
 
 현재 미완료 항목 없음.
 
@@ -6,7 +6,12 @@
 
 ## 완료된 항목
 
-### [Observability] Sentry → 포기, Logtail 연동 완료
+### TASK-1: BE AI Evaluator 캐시 메트릭 관측가능성 추가 (PR #123)
+`CacheMetricsAdvisor` 추가 — 매 AI 평가 호출 후 cache_read_input_tokens / cache_creation_input_tokens INFO 로그 출력.
 
+### TASK-2: Claude Code 세션 프롬프트 구조 최적화 (PR #124)
+CONTEXT.md 고정 내용(비자명적 결정, 참조 문서) 상단 배치, 동적 내용(현재 상태, 최근 완료) 하단으로 분리.
+
+### [Observability] Sentry → 포기, Logtail 연동 완료
 - **Sentry**: Spring Boot 4.x 미지원으로 포기 (PR #52에서 의존성 제거)
 - **Logtail (Better Stack)**: 연동 완료 (fly.io log drain 등록)

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -278,7 +278,8 @@ export function App() {
     )
   }
 
-  if (progressLoading && INITIAL_PROGRESS_CACHE === null) {
+  if (progressLoading) {
+    const hasCache = INITIAL_PROGRESS_CACHE !== null
     return (
       <div
         role="status"
@@ -298,8 +299,12 @@ export function App() {
           gap: 12,
         }}
       >
-        <p style={{ color: '#4ECDC4', fontSize: 14, margin: 0 }}>서버 기동 중...</p>
-        <p style={{ color: '#475569', fontSize: 12, margin: 0 }}>진척 데이터를 불러오는 중입니다 (최대 25초)</p>
+        <p style={{ color: '#4ECDC4', fontSize: 14, margin: 0 }}>
+          {hasCache ? '최신 데이터 동기화 중...' : '서버 기동 중...'}
+        </p>
+        {!hasCache && (
+          <p style={{ color: '#475569', fontSize: 12, margin: 0 }}>진척 데이터를 불러오는 중입니다 (최대 25초)</p>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- `progressLoading && INITIAL_PROGRESS_CACHE === null` 조건에서 캐시 체크를 제거
- 기존 방문자(localStorage 캐시 존재)도 Fly.io cold start 시 로딩 화면이 표시되도록 수정
- 캐시 유무에 따라 메시지 분기: 캐시 있음 → "최신 데이터 동기화 중...", 없음 → "서버 기동 중..." (최대 25초 안내)

## Why
기존 방문자는 `INITIAL_PROGRESS_CACHE !== null`이어서 로딩 조건이 항상 `false`였음.
Fly.io 서버 cold start(~25초) 중에도 stale 캐시 데이터로 맵이 즉시 렌더되어 BE progress가 반영되지 않는 문제.

## Test plan
- [ ] 최초 방문(캐시 없음): 로딩 화면 표시 → BE 응답 후 맵 진입
- [ ] 재방문(캐시 있음): "최신 데이터 동기화 중..." 표시 → BE 응답 완료 시 최신 progress로 맵 렌더