### PR TITLE
fix: passed 판정 주체를 BE로 이관 (JdAnalysis, ResumeCheck)

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
@@ -29,6 +29,7 @@ class JdAnalysisEvaluator(
 
         return aiCallExecutor.execute {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JdAnalysisResult::class.java)
+                ?.let { it.copy(passed = it.overallMatchScore >= 70) }
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.core.domain.PassCriteriaPolicy
 import com.devquest.core.domain.model.evaluation.JdAnalysisResult
 import com.devquest.core.domain.port.JdAnalysisEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -29,7 +30,7 @@ class JdAnalysisEvaluator(
 
         return aiCallExecutor.execute {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JdAnalysisResult::class.java)
-                ?.let { it.copy(passed = it.overallMatchScore >= 70) }
+                ?.let { it.copy(passed = PassCriteriaPolicy.evaluate(it.overallMatchScore)) }
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
@@ -28,6 +28,7 @@ class ResumeCheckEvaluator(
 
         return aiCallExecutor.execute {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(ResumeCheckResult::class.java)
+                ?.let { it.copy(passed = it.overallScore >= 70) }
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.core.domain.PassCriteriaPolicy
 import com.devquest.core.domain.model.evaluation.ResumeCheckResult
 import com.devquest.core.domain.port.ResumeEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -28,7 +29,7 @@ class ResumeCheckEvaluator(
 
         return aiCallExecutor.execute {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(ResumeCheckResult::class.java)
-                ?.let { it.copy(passed = it.overallScore >= 70) }
+                ?.let { it.copy(passed = PassCriteriaPolicy.evaluate(it.overallScore)) }
         }
     }
 }

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
@@ -57,5 +57,38 @@ class JdAnalysisEvaluatorTest {
 
         assertThat(result.companyName).isEqualTo("토스")
         assertThat(result.overallMatchScore).isEqualTo(85)
+        assertThat(result.passed).isTrue()
+    }
+
+    @Test
+    fun `overallMatchScore가 70 이상이면 passed가 true이다`() {
+        val expected = JdAnalysisResult(overallMatchScore = 70)
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.analyze(
+            companyName = "토스",
+            jobDescription = "백엔드 개발자",
+            userSkills = listOf("Kotlin"),
+            userExperiences = listOf("3년 경력")
+        )
+
+        assertThat(result.passed).isTrue()
+    }
+
+    @Test
+    fun `overallMatchScore가 70 미만이면 passed가 false이다`() {
+        val expected = JdAnalysisResult(overallMatchScore = 69)
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.analyze(
+            companyName = "토스",
+            jobDescription = "백엔드 개발자",
+            userSkills = listOf("Kotlin"),
+            userExperiences = listOf("3년 경력")
+        )
+
+        assertThat(result.passed).isFalse()
     }
 }

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
@@ -57,5 +57,36 @@ class ResumeCheckEvaluatorTest {
         assertThat(result.overallScore).isEqualTo(72)
         assertThat(result.starMethodScore).isEqualTo(28)
         assertThat(result.keywordMatchScore).isEqualTo(22)
+        assertThat(result.passed).isTrue()
+    }
+
+    @Test
+    fun `overallScore가 70 이상이면 passed가 true이다`() {
+        val expected = ResumeCheckResult(overallScore = 70)
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(ResumeCheckResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            targetCompany = "토스",
+            targetJd = "백엔드 개발자 채용",
+            resumeContent = "3년 경력의 백엔드 개발자입니다"
+        )
+
+        assertThat(result.passed).isTrue()
+    }
+
+    @Test
+    fun `overallScore가 70 미만이면 passed가 false이다`() {
+        val expected = ResumeCheckResult(overallScore = 69)
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(ResumeCheckResult::class.java))
+            .thenReturn(expected)
+
+        val result = evaluator.evaluate(
+            targetCompany = "토스",
+            targetJd = "백엔드 개발자 채용",
+            resumeContent = "3년 경력의 백엔드 개발자입니다"
+        )
+
+        assertThat(result.passed).isFalse()
     }
 }

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/JdAnalysisResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/JdAnalysisResult.kt
@@ -5,6 +5,7 @@ data class JdAnalysisResult(
     val requiredSkills: List<SkillRequirement> = emptyList(),
     val hiddenRequirements: List<String> = emptyList(),
     val overallMatchScore: Int = 0,
+    val passed: Boolean = false,
     val keyDifferentiators: List<String> = emptyList(),
     val applicationStrategy: String = ""
 )

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/ResumeCheckResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/evaluation/ResumeCheckResult.kt
@@ -2,6 +2,7 @@ package com.devquest.core.domain.model.evaluation
 
 data class ResumeCheckResult(
     val overallScore: Int = 0,
+    val passed: Boolean = false,
     val starMethodScore: Int = 0,
     val quantificationScore: Int = 0,
     val keywordMatchScore: Int = 0,

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ActClearReportResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ActClearReportResult, ResumeCheckResult } from '@/types/api.types'
 import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail, QuestBriefingView } from '@/features/quest-detail'
@@ -20,7 +20,7 @@ const PROGRESS_CACHE_KEY = 'devquest-progress'
 interface ProgressCache {
   completed: Record<string, boolean>
   aiScores: Record<string, number>
-  aiResults: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult>
+  aiResults: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult>
   lastCompletedAt: string | null
 }
 
@@ -65,8 +65,8 @@ export function App() {
   const [aiScores, setAiScores] = useState<Record<string, number>>(
     INITIAL_PROGRESS_CACHE?.aiScores ?? {}
   )
-  const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | null>(null)
-  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult>>(
+  const [aiResult, setAiResult] = useState<AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult | null>(null)
+  const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult>>(
     INITIAL_PROGRESS_CACHE?.aiResults ?? {}
   )
   const [showForm, setShowForm] = useState(false)
@@ -82,7 +82,7 @@ export function App() {
     const applyProgress = (progress: Awaited<ReturnType<typeof fetchProgress>>) => {
       const completedMap: Record<string, boolean> = {}
       const scoresMap: Record<string, number> = {}
-      const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult> = {}
+      const aiResultsMap: Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult> = {}
       progress.completedQuests.forEach((id) => {
         completedMap[id] = true
       })
@@ -213,7 +213,7 @@ export function App() {
     }
   }
 
-  const handleAiResult = (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => {
+  const handleAiResult = (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult) => {
     setAiResult(result)
     setShowForm(false)
     if (view.kind === 'detail') {

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -219,7 +219,7 @@ export function App() {
     if (view.kind === 'detail') {
       const { quest, act } = view
       setAiResults((prev) => ({ ...prev, [quest.id]: result }))
-      const isJdAnalysis = 'overallMatchScore' in result && !('passed' in result)
+      const isJdAnalysis = 'overallMatchScore' in result && !('developerClass' in result) && quest.id !== '4-BOSS'
       const isBossPackage = quest.id === '4-BOSS'
       const isDeveloperClass = 'developerClass' in result
       const score = isJdAnalysis
@@ -227,9 +227,7 @@ export function App() {
         : isBossPackage || isDeveloperClass
           ? (result as BossPackageResult | DeveloperClassResult).overallScore
           : (result as AiEvaluationResult).score
-      const passed = isJdAnalysis
-        ? (result as JdAnalysisResult).overallMatchScore >= 70
-        : (result as { passed: boolean }).passed
+      const passed = (result as { passed: boolean }).passed
       if (passed) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))
         setAiScores((prev) => ({ ...prev, [quest.id]: score }))

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -226,7 +226,7 @@ export function App() {
         ? (result as JdAnalysisResult).overallMatchScore
         : isBossPackage || isDeveloperClass
           ? (result as BossPackageResult | DeveloperClassResult).overallScore
-          : (result as AiEvaluationResult).score
+          : (result as AiEvaluationResult).score ?? (result as { overallScore?: number }).overallScore ?? 0
       const passed = (result as { passed: boolean }).passed
       if (passed) {
         setCompleted((prev) => ({ ...prev, [quest.id]: true }))

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -6,7 +6,6 @@ import { PixelIcon } from '@/components/ui/PixelIcon'
 import { AiCheckForm, AiResultCard, BossPackageResultCard, DeveloperClassResultCard, JdAnalysisResultCard, MockInterviewPanel } from '@/features/ai-check'
 import { AI_FORMS } from '@/features/ai-check'
 import { MOCK_FORM_VALUES } from '@/features/ai-check/constants/mockValues'
-import { PASS_THRESHOLD } from '@/utils/gradeUtils'
 import { QUEST_NEXT } from '../constants/questConnections'
 import { NextQuestCard } from './NextQuestCard'
 import { RetryCoachCard } from './RetryCoachCard'
@@ -41,9 +40,6 @@ function extractImprovements(aiResult: AnyAiResult): string[] {
 }
 
 function isPassed(aiResult: AnyAiResult): boolean {
-  if ('overallMatchScore' in aiResult && !('passed' in aiResult)) {
-    return (aiResult as JdAnalysisResult).overallMatchScore >= PASS_THRESHOLD
-  }
   return (aiResult as { passed: boolean }).passed === true
 }
 

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -40,7 +40,21 @@ function extractImprovements(aiResult: AnyAiResult): string[] {
 }
 
 function isPassed(aiResult: AnyAiResult): boolean {
-  return (aiResult as { passed: boolean }).passed === true
+  // passed 필드가 있으면 (신규 BE 응답) 그대로 사용
+  if ('passed' in aiResult) {
+    return (aiResult as { passed: boolean }).passed === true
+  }
+  // 구버전 캐시 (passed 없음) — 점수 필드로 fallback
+  if ('overallMatchScore' in aiResult) {
+    return (aiResult as JdAnalysisResult).overallMatchScore >= 70
+  }
+  if ('overallScore' in aiResult) {
+    return (aiResult as { overallScore: number }).overallScore >= 70
+  }
+  if ('score' in aiResult) {
+    return (aiResult as { score: number }).score >= 70
+  }
+  return false
 }
 
 export function QuestDetail({

--- a/fe/src/features/quest-detail/components/QuestDetail.tsx
+++ b/fe/src/features/quest-detail/components/QuestDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ResumeCheckResult } from '@/types/api.types'
 import { QUEST_TYPE_CONFIG } from '@/features/quest-map'
 import { PixelIcon } from '@/components/ui/PixelIcon'
 import { AiCheckForm, AiResultCard, BossPackageResultCard, DeveloperClassResultCard, JdAnalysisResultCard, MockInterviewPanel } from '@/features/ai-check'
@@ -11,17 +11,17 @@ import { NextQuestCard } from './NextQuestCard'
 import { RetryCoachCard } from './RetryCoachCard'
 import { FinalBossView } from './FinalBossView'
 
-type AnyAiResult = AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult
+type AnyAiResult = AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult
 
 interface QuestDetailProps {
   quest: Quest
   act: Act
   completed: Record<string, boolean>
   aiScores: Record<string, number>
-  aiResult: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | null
+  aiResult: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult | null
   showForm: boolean
   onShowForm: () => void
-  onAiResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult) => void
+  onAiResult: (result: AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult) => void
   onComplete: (questId: string, xp: number, actId: number, act: Act) => void
   onMockInterviewComplete: (score: number) => void
   onNextQuest?: (questId: string) => void

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -108,6 +108,29 @@ export interface DeveloperClassResult {
   overallFeedback: string
 }
 
+export interface ResumeImprovement {
+  section: string
+  original: string
+  issue: string
+  suggestion: string
+}
+
+export interface ResumeRewrite {
+  original: string
+  improved: string
+  explanation: string
+}
+
+export interface ResumeCheckResult {
+  overallScore: number
+  passed: boolean
+  starMethodScore: number
+  quantificationScore: number
+  keywordMatchScore: number
+  improvements: ResumeImprovement[]
+  rewrittenExamples: ResumeRewrite[]
+}
+
 export interface SkillRequirement {
   skill: string
   required: boolean

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -120,6 +120,7 @@ export interface JdAnalysisResult {
   requiredSkills: SkillRequirement[]
   hiddenRequirements: string[]
   overallMatchScore: number
+  passed: boolean
   keyDifferentiators: string[]
   applicationStrategy: string
 }


### PR DESCRIPTION
## Summary
- FE에서 직접 계산하던 `overallMatchScore >= 70` 등 passed 판정을 BE로 이관
- `JdAnalysisResult`, `ResumeCheckResult` 도메인 모델에 `passed: Boolean` 필드 추가
- 각 Evaluator에서 `result.copy(passed = score >= 70)` 후처리로 판정 — AI 프롬프트 변경 없음
- FE `isPassed()` 단순화, `App.tsx` JdAnalysis 분기 제거, `ResumeCheckResult` 타입 계약 명시

## Why
비즈니스 로직(통과 기준 70점)이 FE에 하드코딩되어 있었음. 기준 변경 시 FE 재배포 필요하고, 퀘스트마다 판정이 분산되어 일관성 없음. 아울러 `ResumeCheckResult`에 `passed` 필드가 아예 없어 항상 실패로 판정되는 버그도 함께 수정.

## Test plan
- [ ] 이력서 STAR 검토 퀘스트: 70점 이상 시 퀘스트 통과 및 다음 단계 진행 확인
- [ ] JD 역분석 퀘스트: 70점 이상 시 퀘스트 통과 확인
- [ ] 두 퀘스트 모두 70점 미만 시 RetryCoachCard 표시 확인