### PR TITLE
chore: orchestrator 9단계 CONTEXT.md 커밋 누락 수정

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -40,12 +40,12 @@
 
 ---
 
-## 현재 상태 (2026-05-11)
+## 현재 상태 (2026-05-12)
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `chore/backfill-may10` |
-| 열린 PR | 진행 중 — 5월 10일 잔디 backfill |
+| 브랜치 | `chore/orchestrator-context-commit` |
+| 열린 PR | 진행 중 — orchestrator CONTEXT.md 커밋 누락 수정 |
 
 ## 최근 완료 (최근 3건)
 

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -45,15 +45,15 @@
 | 항목 | 내용 |
 |------|------|
 | 브랜치 | `chore/orchestrator-context-commit` |
-| 열린 PR | 진행 중 — orchestrator CONTEXT.md 커밋 누락 수정 |
+| 열린 PR | #130 — orchestrator CONTEXT.md 커밋 누락 수정 (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #130 | orchestrator 9단계 CONTEXT.md 커밋 누락 수정 | 2026-05-12 |
 | #127 | Disambiguation Gate + Closing Summary 에이전트 개선 | 2026-05-11 |
-| #125 | progress 로딩 화면 캐시 유무와 무관하게 항상 표시 | 2026-05-07 |
-| #124 | CONTEXT.md 고정 내용 상단 배치로 캐시 최적화 | 2026-05-07 |
+| #126 | passed 판정 주체 BE 이관 (JdAnalysis, ResumeCheck) + PassCriteriaPolicy 적용 | 2026-05-07 |
 
 ## 다음 작업
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -256,7 +256,7 @@ EOF
 > **PR body는 한국어로 작성한다.** (title의 type/scope/message는 영어 컨벤션 유지)
 > **"🤖 Generated with Claude Code" 문구는 PR body에 포함하지 않는다.**
 
-`.claude/CONTEXT.md` 업데이트 — **PR 생성 직후, 세션 종료 전 반드시 실행**:
+`.claude/CONTEXT.md` 업데이트 — **PR 생성 직후 반드시 실행**:
 
 | 셀 | 갱신 값 |
 |----|--------|
@@ -265,6 +265,15 @@ EOF
 
 - "최근 완료"에 PR 번호·내용·날짜 추가 (3건 유지)
 - "다음 작업" 갱신
+
+수정 후 **반드시 커밋**:
+
+```bash
+git add .claude/CONTEXT.md
+git commit -m "chore: CONTEXT.md 갱신 — PR #<번호>"
+```
+
+> 커밋하지 않으면 워킹트리에만 남아 세션 종료 시 유실된다.
 
 ---
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -266,14 +266,15 @@ EOF
 - "최근 완료"에 PR 번호·내용·날짜 추가 (3건 유지)
 - "다음 작업" 갱신
 
-수정 후 **반드시 커밋**:
+수정 후 **반드시 커밋 + push**:
 
 ```bash
 git add .claude/CONTEXT.md
 git commit -m "chore: CONTEXT.md 갱신 — PR #<번호>"
+git push
 ```
 
-> 커밋하지 않으면 워킹트리에만 남아 세션 종료 시 유실된다.
+> 커밋만 하고 push 안 하면 로컬에만 남아 세션 종료 시 유실된다.
 
 ---
 


### PR DESCRIPTION
## Summary
- 9단계(PR 생성 후) CONTEXT.md 수정 후 커밋 명령어 누락으로 워킹트리에만 남아 세션 종료 시 유실되는 문제 수정
- 수정 후 `git add .claude/CONTEXT.md && git commit` 단계를 명시적으로 추가

## Why
CONTEXT.md 갱신이 커밋 없이 세션 종료 → 다음 세션에서 상태 불일치 → backfill PR 반복 발생

## Test plan
- [ ] 다음 기능 PR 완료 후 CONTEXT.md가 feature 브랜치 커밋에 포함되는지 확인