### PR TITLE
chore: be-feature-builder·qa-reviewer 스폰 프롬프트에 ultrathink 추가

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -44,13 +44,14 @@
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `chore/fix-readme-neon-db` |
-| 열린 PR | #133 — README DB 정보 Neon으로 수정 (머지 대기) |
+| 브랜치 | `chore/add-ultrathink-to-agents` |
+| 열린 PR | #134 — be-feature-builder·qa-reviewer 스폰 프롬프트에 ultrathink 추가 (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #134 | be-feature-builder·qa-reviewer 스폰 프롬프트에 ultrathink 추가 | 2026-05-15 |
 | #133 | README DB 정보 Fly.io → Neon으로 수정 | 2026-05-15 |
 | #132 | 모의 면접 기술스택·연차 개인화 + 인성 질문 혼합 생성 | 2026-05-14 |
 | #131 | CONTEXT.md 헤더 날짜 제거 + orchestrator 0단계 날짜 지침 보완 | 2026-05-14 |

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -137,6 +137,8 @@ git checkout -b <prefix>/<feature-name> origin/main
 
 ```
 Agent(subagent_type: "be-feature-builder", prompt: """
+  ultrathink
+
   ## 브랜치
   이미 생성됨: <브랜치명>
   git fetch origin && git checkout <브랜치명>
@@ -208,6 +210,8 @@ Agent(subagent_type: "fe-feature-builder", prompt: """
 
 ```
 Agent(subagent_type: "qa-reviewer", prompt: """
+  ultrathink
+
   ## 리뷰 대상
   기능명: <기능명>
   브랜치: <브랜치명>


### PR DESCRIPTION
## Summary
- orchestrator가 be-feature-builder, qa-reviewer 스폰 시 프롬프트 첫 줄에 `ultrathink` 추가
- `ultrathink` 키워드가 user message에 있으면 effort가 medium → high로 상향됨 (Claude Code 내부 메커니즘)
- 복잡한 구현(BE)과 깊은 검토(QA)에서 추론 깊이 향상 기대
- FE builder·design reviewer는 상대적으로 단순한 작업이라 생략

## 참고
- [/effort max는 다음 세션에 사라진다 — Effort·Fast Mode·Thinking 해부](https://dhbang.co.kr/posts/study/harness-engineering-effort-fast-mode-thinking/)