### PR TITLE
fix(be): CoreDataSource @Primary 추가 — Flyway 미실행 버그 수정

### DIFF
--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/config/CoreDataSourceConfig.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/config/CoreDataSourceConfig.kt
@@ -5,6 +5,7 @@ import com.zaxxer.hikari.HikariDataSource
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import javax.sql.DataSource
 
 @Configuration
@@ -17,6 +18,7 @@ class CoreDataSourceConfig {
     }
 
     @Bean
+    @Primary
     fun coreDataSource(): DataSource {
         return HikariDataSource(coreHikariConfig())
     }


### PR DESCRIPTION
## Summary
- `coreDataSource()` 빈에 `@Primary` 누락으로 Flyway 자동설정이 DataSource를 찾지 못해 마이그레이션이 실행되지 않음
- 결과: V2(user_email), V3(coding_quest) 테이블 미생성 → Hibernate validation 실패 → 앱 시작 불가
- `@Primary` 추가로 Flyway가 올바른 DataSource를 사용하도록 수정

## Test plan
- [ ] 배포 후 flyway_schema_history에 V2, V3 기록 확인
- [ ] coding_problem, user_email, user_coding_level, coding_submission 테이블 생성 확인
- [ ] 앱 정상 기동 확인