### PR TITLE
fix(be): Flyway Spring Boot 4.x 호환 — @Primary DataSource 사용 + repair-on-migrate

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -1,6 +1,7 @@
 logging:
   level:
     com.devquest: INFO
+    org.flywaydb: INFO
 
 spring:
   h2:
@@ -14,10 +15,8 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
   flyway:
     enabled: true
-    url: jdbc:postgresql://${DB_HOST}/${DB_NAME}?sslmode=require
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
     locations: classpath:db/migration
+    repair-on-migrate: true
 
 server:
   error:


### PR DESCRIPTION
## Summary
- `spring.flyway.url/user/password` 별도 DataSource 설정 제거 — Spring Boot 4.x에서 동작 안 함
- Flyway가 `@Primary` coreDataSource(HikariCP)를 자동 사용하도록 변경
- `repair-on-migrate: true` 추가 — PR #136이 남긴 FAILED migration history entry 자동 복구
- `logging.level.org.flywaydb: INFO` 추가 — Flyway 실행 여부 로그 확인용

## Why
Spring Boot 4.x auto-configuration 변경으로 `spring.flyway.url` 별도 설정이 무시됨.
이로 인해 Flyway가 실행되지 않아 V3 migration(coding_problem 테이블)이 prod DB에 미적용 상태.
또한 PR #136 충돌로 flyway_schema_history에 FAILED entry가 남아 Flyway가 재실행을 거부 중.

## Test plan
- [ ] 배포 후 Fly 로그에서 `Flyway Community Edition` + `Migrating schema ... to version 3` 확인
- [ ] `curl https://api.quest.dhbang.co.kr/health` → 200 OK