### PR TITLE
fix(be): Spring Boot 4.x Flyway 수동 구성 — FlywayConfig 빈 + EntityManagerFactoryDependsOnPostProcessor

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -13,11 +13,6 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-    repair-on-migrate: true
-
 server:
   error:
     include-stacktrace: never

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -59,10 +59,3 @@ devquest:
     from: noreply@devquest.kr
     enabled: ${MAIL_ENABLED:false}
 
----
-spring:
-  config:
-    activate:
-      on-profile: "!prod"
-  flyway:
-    enabled: false

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/config/FlywayConfig.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/config/FlywayConfig.kt
@@ -1,0 +1,30 @@
+package com.devquest.storage.db.core.config
+
+import org.flywaydb.core.Flyway
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryDependsOnPostProcessor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import javax.sql.DataSource
+
+@Configuration
+@Profile("prod")
+class FlywayConfig {
+
+    @Bean
+    fun flyway(@Qualifier("coreDataSource") dataSource: DataSource): Flyway {
+        val flyway = Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration")
+            .load()
+        flyway.repair()
+        flyway.migrate()
+        return flyway
+    }
+
+    @Bean
+    fun flywayEntityManagerFactoryDependsOn(): EntityManagerFactoryDependsOnPostProcessor {
+        return EntityManagerFactoryDependsOnPostProcessor("flyway")
+    }
+}


### PR DESCRIPTION
## Summary
- Spring Boot 4.x에서 Flyway auto-configuration이 제거됨을 확인 (`spring-boot-autoconfigure-4.0.3.jar` AutoConfiguration.imports에 Flyway 없음)
- `db-core` 모듈에 `FlywayConfig.kt` 수동 구성 추가 (`@Profile("prod")`)
- `EntityManagerFactoryDependsOnPostProcessor("flyway")`로 JPA가 Flyway 완료 후 초기화되도록 의존성 설정
- `flyway.repair()` → `flyway.migrate()` 순차 호출로 FAILED migration history entry 자동 복구

## Why
PR #140에서 `spring.flyway.*` 프로퍼티 기반으로 @Primary DataSource를 사용하도록 수정했으나,
Spring Boot 4.x에 Flyway auto-configuration 자체가 없어 Flyway가 실행되지 않음.
prod 서버가 `coding_problem` 테이블 누락으로 계속 503 상태.

## Test plan
- [ ] 배포 후 Fly 로그에서 `FlywayConfig` 빈 생성 + Flyway 마이그레이션 V3 적용 확인
- [ ] `curl https://api.quest.dhbang.co.kr/health` → 200 OK