### PR TITLE
feat(fe): 코딩 연습 화면 LeetCode 스타일 레이아웃 개편

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,6 +8,7 @@
       "name": "devquest-fe",
       "version": "0.0.1",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^3.8.1"
@@ -1008,6 +1009,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1582,6 +1606,14 @@
       "dependencies": {
         "@types/d3-path": "^1"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2298,6 +2330,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
@@ -2914,6 +2956,19 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2925,6 +2980,17 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -3334,6 +3400,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.8.1"

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -313,6 +313,10 @@ export function App() {
     )
   }
 
+  if (view.kind === 'coding-quest') {
+    return <CodingQuestPage onBack={() => setView({ kind: 'map' })} />
+  }
+
   return (
     <div
       style={{
@@ -324,7 +328,7 @@ export function App() {
         color: '#F8FAFC',
       }}
     >
-      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth' || view.kind === 'briefing' || view.kind === 'settings' || view.kind === 'tech-interview' || view.kind === 'coding-quest') && (
+      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth' || view.kind === 'briefing' || view.kind === 'settings' || view.kind === 'tech-interview') && (
         <button
           onClick={() => setView({ kind: 'map' })}
           style={{
@@ -471,9 +475,6 @@ export function App() {
         <TechInterviewPage />
       )}
 
-      {view.kind === 'coding-quest' && (
-        <CodingQuestPage />
-      )}
     </div>
   )
 }

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import Editor from '@monaco-editor/react'
 import type { CodingProblem, CodingSubmissionResult, CodingLevelResult } from '@/types/api.types'
 import { fetchCodingProblem, submitCode, fetchCodingLevel } from '@/lib/apiClient'
 
@@ -20,7 +21,11 @@ function difficultyColor(difficulty: string): string {
   return '#f44336'
 }
 
-export function CodingQuestPage() {
+interface CodingQuestPageProps {
+  onBack: () => void
+}
+
+export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
   const [language, setLanguage] = useState<Language>('JAVA')
   const [problem, setProblem] = useState<CodingProblem | null>(null)
   const [levelResult, setLevelResult] = useState<CodingLevelResult | null>(null)
@@ -29,11 +34,13 @@ export function CodingQuestPage() {
   const [result, setResult] = useState<CodingSubmissionResult | null>(null)
   const [loadingProblem, setLoadingProblem] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showResult, setShowResult] = useState(false)
 
   const loadProblem = (lang: Language) => {
     setLoadingProblem(true)
     setError(null)
     setResult(null)
+    setShowResult(false)
     fetchCodingProblem(lang)
       .then((p) => setProblem(p))
       .catch(() => setError('문제를 불러오는 데 실패했습니다.'))
@@ -51,6 +58,7 @@ export function CodingQuestPage() {
     setLanguage(lang)
     setCode(lang === 'JAVA' ? JAVA_TEMPLATE : KOTLIN_TEMPLATE)
     setResult(null)
+    setShowResult(false)
     loadProblem(lang)
   }
 
@@ -63,6 +71,7 @@ export function CodingQuestPage() {
     if (!problem) return
     setSubmitting(true)
     setResult(null)
+    setShowResult(true)
     try {
       const res = await submitCode(problem.id, language, code)
       setResult(res)
@@ -74,23 +83,84 @@ export function CodingQuestPage() {
   }
 
   const levelLabel = levelResult ? `Lv.${levelResult.level}` : 'Lv.-'
-  const diffLabel = problem ? problem.difficulty : '...'
+  const diffLabel = problem?.difficulty ?? '...'
+  const monacoLang = language === 'JAVA' ? 'java' : 'kotlin'
+  const fileName = language === 'JAVA' ? 'Main.java' : 'Main.kt'
 
   return (
-    <div style={{ fontFamily: "'Courier New', monospace", color: '#F8FAFC', padding: '16px 0' }}>
-      {/* 상단 바 */}
-      <div style={{
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: 16,
-        flexWrap: 'wrap',
-        gap: 8,
-      }}>
-        <span style={{ fontSize: 13, color: '#4ECDC4', fontWeight: 700 }}>
-          {levelLabel} · <span style={{ color: difficultyColor(diffLabel) }}>{diffLabel}</span> 문제
-        </span>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        flexDirection: 'column',
+        background: '#060610',
+        fontFamily: "'Courier New', monospace",
+        color: '#F8FAFC',
+        zIndex: 1000,
+      }}
+    >
+      {/* TopBar */}
+      <div
+        style={{
+          height: 48,
+          flexShrink: 0,
+          background: '#0A0E1A',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 16px',
+          gap: 12,
+        }}
+      >
+        {/* 좌: 뒤로가기 */}
+        <button
+          onClick={onBack}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#475569',
+            cursor: 'pointer',
+            fontSize: 13,
+            fontFamily: "'Courier New', monospace",
+            padding: '4px 8px',
+            borderRadius: 4,
+            whiteSpace: 'nowrap',
+          }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#F8FAFC' }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#475569' }}
+        >
+          ← 퀘스트 맵
+        </button>
+
+        {/* 중앙: 제목 + 난이도 + 레벨 */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, justifyContent: 'center', minWidth: 0 }}>
+          <span style={{ fontSize: 13, color: '#4ECDC4', fontWeight: 700, whiteSpace: 'nowrap' }}>{levelLabel}</span>
+          {problem && (
+            <>
+              <span style={{ fontSize: 14, fontWeight: 700, color: '#F8FAFC', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {problem.title}
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: difficultyColor(diffLabel),
+                  background: `${difficultyColor(diffLabel)}20`,
+                  border: `1px solid ${difficultyColor(diffLabel)}50`,
+                  padding: '2px 7px',
+                  borderRadius: 4,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {diffLabel}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* 우: 언어 토글 + 새 문제 + 제출 */}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
           {(['JAVA', 'KOTLIN'] as Language[]).map((lang) => (
             <button
               key={lang}
@@ -99,8 +169,8 @@ export function CodingQuestPage() {
                 background: language === lang ? 'rgba(78,205,196,0.15)' : 'transparent',
                 border: `1px solid ${language === lang ? '#4ECDC4' : 'rgba(255,255,255,0.08)'}`,
                 color: language === lang ? '#4ECDC4' : '#475569',
-                padding: '4px 12px',
-                borderRadius: 6,
+                padding: '4px 10px',
+                borderRadius: 4,
                 cursor: 'pointer',
                 fontSize: 12,
                 fontFamily: "'Courier New', monospace",
@@ -117,65 +187,97 @@ export function CodingQuestPage() {
               border: '1px solid rgba(167,139,250,0.3)',
               color: '#A78BFA',
               padding: '4px 12px',
-              borderRadius: 6,
+              borderRadius: 4,
               cursor: loadingProblem ? 'not-allowed' : 'pointer',
               fontSize: 12,
               fontFamily: "'Courier New', monospace",
               opacity: loadingProblem ? 0.6 : 1,
             }}
           >
-            새 문제 받기
+            새 문제
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !problem}
+            style={{
+              background: submitting || !problem ? 'rgba(78,205,196,0.3)' : '#4ECDC4',
+              border: 'none',
+              color: '#060610',
+              padding: '4px 16px',
+              borderRadius: 4,
+              cursor: submitting || !problem ? 'not-allowed' : 'pointer',
+              fontSize: 12,
+              fontFamily: "'Courier New', monospace",
+              fontWeight: 700,
+              opacity: !problem ? 0.5 : 1,
+            }}
+          >
+            {submitting ? '채점 중...' : '제출'}
           </button>
         </div>
       </div>
 
-      {/* 2컬럼 레이아웃 */}
-      <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
-        {/* 왼쪽: 문제 정보 */}
-        <div style={{
-          flex: '0 0 45%',
-          background: '#0F172A',
-          border: '1px solid rgba(255,255,255,0.08)',
-          borderRadius: 10,
-          padding: 16,
-          minWidth: 0,
-        }}>
+      {/* 본문 영역 */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* 문제 패널 (38%) */}
+        <div
+          style={{
+            width: '38%',
+            flexShrink: 0,
+            background: '#0F172A',
+            borderRight: '1px solid rgba(255,255,255,0.08)',
+            overflowY: 'auto',
+            padding: 24,
+          }}
+        >
           {loadingProblem ? (
             <p style={{ color: '#475569', fontSize: 13, margin: 0 }}>문제 불러오는 중...</p>
           ) : error && !problem ? (
             <p style={{ color: '#EF4444', fontSize: 13, margin: 0 }}>{error}</p>
           ) : problem ? (
             <>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-                <span style={{ fontSize: 14, fontWeight: 700, color: '#F8FAFC' }}>{problem.title}</span>
-                <span style={{
-                  fontSize: 11,
-                  color: difficultyColor(problem.difficulty),
-                  background: `${difficultyColor(problem.difficulty)}20`,
-                  border: `1px solid ${difficultyColor(problem.difficulty)}50`,
-                  padding: '2px 7px',
-                  borderRadius: 4,
-                }}>
+              <div style={{ marginBottom: 6 }}>
+                <span style={{ fontSize: 12, color: '#475569' }}>{levelLabel}</span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+                <span style={{ fontSize: 16, fontWeight: 700, color: '#F8FAFC' }}>{problem.title}</span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: difficultyColor(problem.difficulty),
+                    background: `${difficultyColor(problem.difficulty)}20`,
+                    border: `1px solid ${difficultyColor(problem.difficulty)}50`,
+                    padding: '2px 7px',
+                    borderRadius: 4,
+                  }}
+                >
                   {problem.difficulty}
                 </span>
               </div>
-              <p style={{ fontSize: 13, color: '#CBD5E1', margin: '0 0 14px', lineHeight: 1.6 }}>
+              <p style={{ fontSize: 14, color: '#CBD5E1', margin: '0 0 20px', lineHeight: 1.7 }}>
                 {problem.description}
               </p>
               {problem.testCases.length > 0 && (
                 <div>
-                  <p style={{ fontSize: 11, color: '#475569', margin: '0 0 6px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>예시</p>
+                  <p style={{ fontSize: 11, color: '#475569', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>예시</p>
                   {problem.testCases.slice(0, 2).map((tc, i) => (
-                    <div key={i} style={{
-                      background: '#1E293B',
-                      border: '1px solid rgba(255,255,255,0.06)',
-                      borderRadius: 6,
-                      padding: '8px 10px',
-                      marginBottom: 6,
-                      fontSize: 12,
-                    }}>
-                      <div style={{ color: '#475569', marginBottom: 2 }}>입력: <span style={{ color: '#F1F5F9' }}>{tc.input}</span></div>
-                      <div style={{ color: '#475569' }}>출력: <span style={{ color: '#4ECDC4' }}>{tc.expectedOutput}</span></div>
+                    <div
+                      key={i}
+                      style={{
+                        background: '#1E293B',
+                        border: '1px solid rgba(255,255,255,0.06)',
+                        borderRadius: 6,
+                        padding: '10px 12px',
+                        marginBottom: 8,
+                        fontSize: 13,
+                      }}
+                    >
+                      <div style={{ color: '#475569', marginBottom: 4 }}>
+                        입력: <span style={{ color: '#F1F5F9', fontFamily: 'monospace' }}>{tc.input}</span>
+                      </div>
+                      <div style={{ color: '#475569' }}>
+                        출력: <span style={{ color: '#4ECDC4', fontFamily: 'monospace' }}>{tc.expectedOutput}</span>
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -184,97 +286,112 @@ export function CodingQuestPage() {
           ) : null}
         </div>
 
-        {/* 오른쪽: 코드 에디터 + 제출 + 결과 */}
-        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
-          <textarea
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-            spellCheck={false}
+        {/* 에디터 패널 (62%) */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {/* 파일명 탭 */}
+          <div
             style={{
-              fontFamily: 'monospace',
-              whiteSpace: 'pre',
-              fontSize: 14,
-              width: '100%',
-              minHeight: 300,
-              background: '#1e1e1e',
-              color: '#d4d4d4',
-              padding: 12,
-              border: 'none',
-              resize: 'vertical',
-              borderRadius: 8,
-              outline: 'none',
-              boxSizing: 'border-box',
-            }}
-          />
-
-          <button
-            onClick={handleSubmit}
-            disabled={submitting || !problem}
-            style={{
-              background: submitting ? 'rgba(78,205,196,0.05)' : 'rgba(78,205,196,0.15)',
-              border: '1px solid rgba(78,205,196,0.4)',
-              color: '#4ECDC4',
-              padding: '10px 0',
-              borderRadius: 8,
-              cursor: submitting || !problem ? 'not-allowed' : 'pointer',
-              fontSize: 14,
-              fontFamily: "'Courier New', monospace",
-              fontWeight: 700,
-              opacity: !problem ? 0.5 : 1,
-              width: '100%',
+              background: '#0A0E1A',
+              borderBottom: '1px solid rgba(255,255,255,0.08)',
+              padding: '0 16px',
+              display: 'flex',
+              alignItems: 'stretch',
             }}
           >
-            {submitting ? '채점 중...' : '제출'}
-          </button>
+            <div
+              style={{
+                padding: '8px 16px',
+                fontSize: 12,
+                color: '#F8FAFC',
+                background: '#1E293B',
+                borderTop: '2px solid #4ECDC4',
+                borderRight: '1px solid rgba(255,255,255,0.08)',
+                borderLeft: '1px solid rgba(255,255,255,0.08)',
+              }}
+            >
+              {fileName}
+            </div>
+          </div>
 
-          {/* 결과 영역 */}
-          {submitting && (
-            <div style={{
-              background: 'rgba(78,205,196,0.04)',
-              border: '1px solid rgba(78,205,196,0.2)',
-              borderRadius: 8,
-              padding: '12px 14px',
-              fontSize: 13,
-              color: '#4ECDC4',
-            }}>
-              채점 중...
-            </div>
-          )}
-          {result && !submitting && (
-            <div style={{
-              background: result.passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
-              border: `1px solid ${result.passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
-              borderRadius: 8,
-              padding: '12px 14px',
-              fontSize: 13,
-            }}>
-              <p style={{ margin: '0 0 6px', color: result.passed ? '#10B981' : '#EF4444', fontWeight: 700 }}>
-                {result.passed ? '✓ 통과! 모든 테스트케이스 통과' : '✗ 실패'}
-              </p>
-              {result.passed && result.stdout && (
-                <p style={{ margin: '0 0 4px', color: '#CBD5E1', fontSize: 12 }}>
-                  stdout: <code>{result.stdout}</code>
-                </p>
+          {/* Monaco Editor */}
+          <div style={{ flex: 1, overflow: 'hidden' }}>
+            <Editor
+              height="100%"
+              language={monacoLang}
+              value={code}
+              onChange={(val) => setCode(val ?? '')}
+              theme="vs-dark"
+              options={{
+                fontSize: 14,
+                fontFamily: 'Consolas, "Courier New", monospace',
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                lineNumbers: 'on',
+                padding: { top: 12, bottom: 12 },
+                automaticLayout: true,
+              }}
+            />
+          </div>
+
+          {/* 결과 패널 */}
+          <div
+            style={{
+              height: showResult ? 160 : 0,
+              overflow: 'hidden',
+              transition: 'height 0.25s ease',
+              borderTop: showResult ? '1px solid rgba(255,255,255,0.08)' : 'none',
+              background: '#0A0E1A',
+              flexShrink: 0,
+            }}
+          >
+            <div style={{ padding: '12px 20px', height: '100%', overflowY: 'auto', boxSizing: 'border-box' }}>
+              {submitting && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#4ECDC4', fontSize: 13 }}>
+                  <span style={{ animation: 'spin 1s linear infinite' }}>⟳</span>
+                  채점 중...
+                </div>
               )}
-              {!result.passed && (result.stderr || result.message) && (
-                <p style={{ margin: 0, color: '#EF4444', fontSize: 12, whiteSpace: 'pre-wrap' }}>
-                  {result.stderr || result.message}
-                </p>
+              {result && !submitting && (
+                <div
+                  style={{
+                    background: result.passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
+                    border: `1px solid ${result.passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
+                    borderRadius: 8,
+                    padding: '12px 14px',
+                    fontSize: 13,
+                  }}
+                >
+                  <p style={{ margin: '0 0 6px', color: result.passed ? '#10B981' : '#EF4444', fontWeight: 700 }}>
+                    {result.passed ? '✓ 모든 테스트케이스 통과' : '✗ 실패'}
+                  </p>
+                  {result.passed && result.stdout && (
+                    <p style={{ margin: '0 0 4px', color: '#CBD5E1', fontSize: 12 }}>
+                      stdout: <code style={{ fontFamily: 'monospace' }}>{result.stdout}</code>
+                    </p>
+                  )}
+                  {!result.passed && (result.stderr || result.message) && (
+                    <p style={{ margin: 0, color: '#EF4444', fontSize: 12, whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+                      {result.stderr ?? result.message}
+                    </p>
+                  )}
+                </div>
+              )}
+              {error && !submitting && !result && (
+                <div
+                  style={{
+                    background: 'rgba(239,68,68,0.04)',
+                    border: '1px solid rgba(239,68,68,0.25)',
+                    borderRadius: 8,
+                    padding: '10px 14px',
+                    fontSize: 13,
+                    color: '#EF4444',
+                  }}
+                >
+                  {error}
+                </div>
               )}
             </div>
-          )}
-          {error && !submitting && !result && (
-            <div style={{
-              background: 'rgba(239,68,68,0.04)',
-              border: '1px solid rgba(239,68,68,0.25)',
-              borderRadius: 8,
-              padding: '10px 14px',
-              fontSize: 13,
-              color: '#EF4444',
-            }}>
-              {error}
-            </div>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/fe/src/styles/global.css
+++ b/fe/src/styles/global.css
@@ -14,6 +14,11 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 @keyframes slideIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- Monaco Editor(`@monaco-editor/react`) 도입 — textarea → VS Code 동일 엔진 에디터 교체
- CodingQuestPage를 `position: fixed; inset: 0` 풀스크린으로 분리, 기존 480px 컨테이너 탈출
- LeetCode 스타일 레이아웃: 상단 탭바(뒤로가기·제목·난이도·언어토글·새문제·제출) + 좌(문제 패널 38%) / 우(에디터 62%) 2패널 + 하단 결과 패널(제출 후 슬라이드업)
- VS Code 파일탭 스타일 (`Main.java` / `Main.kt`), 라인 넘버, syntax highlighting 적용

## Test plan
- [ ] 코딩 연습 진입 시 풀스크린으로 열리는지 확인
- [ ] JAVA / KOTLIN 언어 전환 시 에디터 언어 및 파일탭 변경 확인
- [ ] 문제 패널 스크롤, 에디터 코드 입력 정상 동작 확인
- [ ] 제출 후 결과 패널 슬라이드업 확인
- [ ] ← 퀘스트 맵 버튼으로 복귀 확인