### PR TITLE
fix(fe): 401/403 응답 시 토큰 자동 삭제 및 로그인 페이지 이동

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -16,9 +16,10 @@ import { LoginPage } from '@/features/auth/components/LoginPage'
 import { AuthCallback } from '@/features/auth/components/AuthCallback'
 import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
+import { STORAGE_KEYS } from '@/lib/storageKeys'
 import { ACTS } from '@/features/quest-map/constants/questData'
 
-const PROGRESS_CACHE_KEY = 'devquest-progress'
+const PROGRESS_CACHE_KEY = STORAGE_KEYS.PROGRESS
 
 interface ProgressCache {
   completed: Record<string, boolean>

--- a/fe/src/hooks/useAuth.ts
+++ b/fe/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
-const TOKEN_KEY = 'devquest-token'
+import { STORAGE_KEYS } from '@/lib/storageKeys'
+const TOKEN_KEY = STORAGE_KEYS.TOKEN
 export const GITHUB_REDIRECT_URI = `${window.location.origin}/auth/callback`
 
 export function getToken(): string | null {

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,8 +1,9 @@
 import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult } from '@/types/api.types'
 import { getToken, clearToken } from '@/hooks/useAuth'
+import { STORAGE_KEYS } from '@/lib/storageKeys'
 
 const API_BASE = '/api/v1'
-const PROGRESS_CACHE_KEY = 'devquest-progress'
+let reloadScheduled = false
 
 function authHeaders(): HeadersInit {
   const token = getToken()
@@ -12,92 +13,77 @@ function authHeaders(): HeadersInit {
   }
 }
 
-function handleUnauthorized(status: number): void {
-  if (status === 401 || status === 403) {
+function assertOk(res: Response): void {
+  if (res.ok) return
+  if ((res.status === 401 || res.status === 403) && !reloadScheduled) {
+    reloadScheduled = true
     clearToken()
-    localStorage.removeItem(PROGRESS_CACHE_KEY)
+    localStorage.removeItem(STORAGE_KEYS.PROGRESS)
     window.location.reload()
   }
+  throw new Error(`HTTP ${res.status}`)
 }
 
 export async function fetchProgress(): Promise<ProgressResult> {
-  const res = await fetch(`${API_BASE}/progress`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/progress`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<ProgressResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('진행 상황 조회 실패')
   return json.data
 }
 
-export async function completeQuest(
-  questId: string,
-  actId: number,
-  earnedXp: number,
-): Promise<void> {
+export async function completeQuest(questId: string, actId: number, earnedXp: number): Promise<void> {
   const res = await fetch(`${API_BASE}/progress/complete`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify({ questId, actId, earnedXp }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
 }
 
-export async function fetchActClearReport(
-  actId: number,
-  actTitle: string,
-): Promise<ActClearReportResult> {
+export async function fetchActClearReport(actId: number, actTitle: string): Promise<ActClearReportResult> {
   const res = await fetch(`${API_BASE}/ai-check/act-clear-report`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify({ actId, actTitle }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
   const json: ApiResponse<ActClearReportResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('ACT 클리어 리포트 생성 실패')
   return json.data
 }
 
 export async function fetchHistory(): Promise<QuestHistoryItem[]> {
-  const res = await fetch(`${API_BASE}/progress/history`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/progress/history`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('히스토리 조회 실패')
   return json.data
 }
 
 export async function fetchQuestHistory(questId: string): Promise<QuestHistoryItem[]> {
-  const res = await fetch(`${API_BASE}/progress/history/${encodeURIComponent(questId)}`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/progress/history/${encodeURIComponent(questId)}`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('퀘스트 히스토리 조회 실패')
   return json.data
 }
 
-export async function fetchJourneyReport(
-  companyName: string,
-  targetPosition: string,
-): Promise<JourneyReportResult> {
+export async function fetchJourneyReport(companyName: string, targetPosition: string): Promise<JourneyReportResult> {
   const res = await fetch(`${API_BASE}/ai-check/journey-report`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify({ companyName, targetPosition }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
   const json: ApiResponse<JourneyReportResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('여정 리포트 생성 실패')
   return json.data
 }
 
 export async function fetchUserEmail(): Promise<UserEmailResult> {
-  const res = await fetch(`${API_BASE}/user/email`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/user/email`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<UserEmailResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('이메일 조회 실패')
   return json.data
@@ -109,78 +95,61 @@ export async function saveUserEmail(email: string): Promise<UserEmailResult> {
     headers: authHeaders(),
     body: JSON.stringify({ email }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
   const json: ApiResponse<UserEmailResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('이메일 저장 실패')
   return json.data
 }
 
 export async function fetchTechInterviewQuestion(techStack: string): Promise<TechInterviewResult> {
-  const res = await fetch(`${API_BASE}/tech-interview/question?techStack=${encodeURIComponent(techStack)}`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/tech-interview/question?techStack=${encodeURIComponent(techStack)}`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<TechInterviewResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('질문 조회 실패')
   return json.data
 }
 
-export async function evaluateTechInterview(
-  techStack: string,
-  questions: string[],
-  answers: string[],
-): Promise<TechInterviewResult> {
+export async function evaluateTechInterview(techStack: string, questions: string[], answers: string[]): Promise<TechInterviewResult> {
   const res = await fetch(`${API_BASE}/tech-interview/evaluate`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify({ techStack, questions, answers }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
   const json: ApiResponse<TechInterviewResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('평가 실패')
   return json.data
 }
 
 export async function fetchCodingProblem(language: string): Promise<CodingProblem> {
-  const res = await fetch(`${API_BASE}/coding/problem?language=${encodeURIComponent(language)}`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/coding/problem?language=${encodeURIComponent(language)}`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<CodingProblem> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코딩 문제 조회 실패')
   return json.data
 }
 
-export async function submitCode(
-  problemId: number,
-  language: string,
-  userCode: string,
-): Promise<CodingSubmissionResult> {
+export async function submitCode(problemId: number, language: string, userCode: string): Promise<CodingSubmissionResult> {
   const res = await fetch(`${API_BASE}/coding/submit`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify({ problemId, language, userCode }),
   })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  assertOk(res)
   const json: ApiResponse<CodingSubmissionResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코드 제출 실패')
   return json.data
 }
 
 export async function fetchCodingLevel(): Promise<CodingLevelResult> {
-  const res = await fetch(`${API_BASE}/coding/level`, {
-    headers: authHeaders(),
-  })
-  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
+  const res = await fetch(`${API_BASE}/coding/level`, { headers: authHeaders() })
+  assertOk(res)
   const json: ApiResponse<CodingLevelResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코딩 레벨 조회 실패')
   return json.data
 }
 
-export async function callAiCheck<T>(
-  endpoint: string,
-  body: Record<string, unknown>,
-): Promise<T> {
+export async function callAiCheck<T>(endpoint: string, body: Record<string, unknown>): Promise<T> {
   const res = await fetch(`${API_BASE}/ai-check/${endpoint}`, {
     method: 'POST',
     headers: authHeaders(),
@@ -188,22 +157,16 @@ export async function callAiCheck<T>(
   })
 
   if (!res.ok) {
-    handleUnauthorized(res.status)
+    assertOk(res)
     let errorMessage = `HTTP ${res.status}`
     try {
       const errorJson: ApiResponse<unknown> = await res.json()
       if (errorJson.error?.message) errorMessage = errorJson.error.message
-    } catch {
-      // response body not parseable, use default
-    }
+    } catch { /* response body not parseable */ }
     throw new Error(errorMessage)
   }
 
   const json: ApiResponse<T> = await res.json()
-
-  if (json.result !== 'SUCCESS' || json.data == null) {
-    throw new Error(json.error?.message ?? 'AI 평가 오류')
-  }
-
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error(json.error?.message ?? 'AI 평가 오류')
   return json.data
 }

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,7 +1,8 @@
 import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult } from '@/types/api.types'
-import { getToken } from '@/hooks/useAuth'
+import { getToken, clearToken } from '@/hooks/useAuth'
 
 const API_BASE = '/api/v1'
+const PROGRESS_CACHE_KEY = 'devquest-progress'
 
 function authHeaders(): HeadersInit {
   const token = getToken()
@@ -11,11 +12,19 @@ function authHeaders(): HeadersInit {
   }
 }
 
+function handleUnauthorized(status: number): void {
+  if (status === 401 || status === 403) {
+    clearToken()
+    localStorage.removeItem(PROGRESS_CACHE_KEY)
+    window.location.reload()
+  }
+}
+
 export async function fetchProgress(): Promise<ProgressResult> {
   const res = await fetch(`${API_BASE}/progress`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<ProgressResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('진행 상황 조회 실패')
   return json.data
@@ -31,7 +40,7 @@ export async function completeQuest(
     headers: authHeaders(),
     body: JSON.stringify({ questId, actId, earnedXp }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
 }
 
 export async function fetchActClearReport(
@@ -43,7 +52,7 @@ export async function fetchActClearReport(
     headers: authHeaders(),
     body: JSON.stringify({ actId, actTitle }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<ActClearReportResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('ACT 클리어 리포트 생성 실패')
   return json.data
@@ -53,7 +62,7 @@ export async function fetchHistory(): Promise<QuestHistoryItem[]> {
   const res = await fetch(`${API_BASE}/progress/history`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('히스토리 조회 실패')
   return json.data
@@ -63,7 +72,7 @@ export async function fetchQuestHistory(questId: string): Promise<QuestHistoryIt
   const res = await fetch(`${API_BASE}/progress/history/${encodeURIComponent(questId)}`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<QuestHistoryItem[]> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('퀘스트 히스토리 조회 실패')
   return json.data
@@ -78,7 +87,7 @@ export async function fetchJourneyReport(
     headers: authHeaders(),
     body: JSON.stringify({ companyName, targetPosition }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<JourneyReportResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('여정 리포트 생성 실패')
   return json.data
@@ -88,7 +97,7 @@ export async function fetchUserEmail(): Promise<UserEmailResult> {
   const res = await fetch(`${API_BASE}/user/email`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<UserEmailResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('이메일 조회 실패')
   return json.data
@@ -100,7 +109,7 @@ export async function saveUserEmail(email: string): Promise<UserEmailResult> {
     headers: authHeaders(),
     body: JSON.stringify({ email }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<UserEmailResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('이메일 저장 실패')
   return json.data
@@ -110,7 +119,7 @@ export async function fetchTechInterviewQuestion(techStack: string): Promise<Tec
   const res = await fetch(`${API_BASE}/tech-interview/question?techStack=${encodeURIComponent(techStack)}`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<TechInterviewResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('질문 조회 실패')
   return json.data
@@ -126,7 +135,7 @@ export async function evaluateTechInterview(
     headers: authHeaders(),
     body: JSON.stringify({ techStack, questions, answers }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<TechInterviewResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('평가 실패')
   return json.data
@@ -136,7 +145,7 @@ export async function fetchCodingProblem(language: string): Promise<CodingProble
   const res = await fetch(`${API_BASE}/coding/problem?language=${encodeURIComponent(language)}`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<CodingProblem> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코딩 문제 조회 실패')
   return json.data
@@ -152,7 +161,7 @@ export async function submitCode(
     headers: authHeaders(),
     body: JSON.stringify({ problemId, language, userCode }),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<CodingSubmissionResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코드 제출 실패')
   return json.data
@@ -162,7 +171,7 @@ export async function fetchCodingLevel(): Promise<CodingLevelResult> {
   const res = await fetch(`${API_BASE}/coding/level`, {
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) { handleUnauthorized(res.status); throw new Error(`HTTP ${res.status}`) }
   const json: ApiResponse<CodingLevelResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코딩 레벨 조회 실패')
   return json.data
@@ -179,6 +188,7 @@ export async function callAiCheck<T>(
   })
 
   if (!res.ok) {
+    handleUnauthorized(res.status)
     let errorMessage = `HTTP ${res.status}`
     try {
       const errorJson: ApiResponse<unknown> = await res.json()

--- a/fe/src/lib/storageKeys.ts
+++ b/fe/src/lib/storageKeys.ts
@@ -1,0 +1,4 @@
+export const STORAGE_KEYS = {
+  TOKEN: 'devquest-token',
+  PROGRESS: 'devquest-progress',
+} as const


### PR DESCRIPTION
## Summary
- API 응답 401/403 시 토큰·진척 캐시 삭제 후 자동 reload
- 무효화된 토큰으로 화면이 그대로 보이던 UX 버그 수정

## Why
JWT_SECRET 변경으로 기존 토큰이 무효화됐을 때, 앱이 캐시 데이터를 보여주며 정상인 척 하는 문제 발생. 서버 측은 fly secrets set으로 JWT_SECRET 재설정 완료.

## Test plan
- [ ] 브라우저 localStorage의 devquest-token을 만료된 값으로 교체 후 API 호출 → 로그인 페이지로 이동 확인
- [ ] 정상 토큰으로는 기존과 동일하게 동작 확인