### PR TITLE
fix(be): 코딩 채점 시 expectedOutput 비교 누락 수정

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/judge0/Judge0Adapter.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/judge0/Judge0Adapter.kt
@@ -22,7 +22,7 @@ class Judge0Adapter(
     override fun execute(sourceCode: String, languageId: Int, stdin: String, expectedOutput: String): Judge0Result {
         if (apiKey.isBlank()) {
             log.warn("JUDGE0_API_KEY가 설정되지 않아 mock 응답을 반환합니다")
-            return Judge0Result(stdout = "[MOCK] 채점 생략", stderr = "", status = "Accepted", passed = false)
+            return Judge0Result(stdout = "", stderr = "", status = "API Key Missing", passed = false)
         }
 
         return try {
@@ -57,11 +57,18 @@ data class Judge0Response(
     fun toDomain(expectedOutput: String): Judge0Result {
         val statusDesc = status?.description ?: "Unknown"
         val actualStdout = stdout?.trim() ?: ""
+        val outputMatches = actualStdout == expectedOutput.trim()
+        val passed = statusDesc == "Accepted" && outputMatches
+        val resolvedStatus = when {
+            statusDesc != "Accepted" -> statusDesc
+            !outputMatches -> "Wrong Answer"
+            else -> statusDesc
+        }
         return Judge0Result(
             stdout = actualStdout,
             stderr = stderr ?: "",
-            status = statusDesc,
-            passed = statusDesc == "Accepted" && actualStdout == expectedOutput.trim()
+            status = resolvedStatus,
+            passed = passed
         )
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/judge0/Judge0Adapter.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/judge0/Judge0Adapter.kt
@@ -19,10 +19,10 @@ class Judge0Adapter(
         .baseUrl("https://judge0-ce.p.rapidapi.com")
         .build()
 
-    override fun execute(sourceCode: String, languageId: Int, stdin: String): Judge0Result {
+    override fun execute(sourceCode: String, languageId: Int, stdin: String, expectedOutput: String): Judge0Result {
         if (apiKey.isBlank()) {
             log.warn("JUDGE0_API_KEY가 설정되지 않아 mock 응답을 반환합니다")
-            return Judge0Result(stdout = "[MOCK] 채점 생략", stderr = "", status = "Accepted", passed = true)
+            return Judge0Result(stdout = "[MOCK] 채점 생략", stderr = "", status = "Accepted", passed = false)
         }
 
         return try {
@@ -41,7 +41,7 @@ class Judge0Adapter(
                 .retrieve()
                 .body(Judge0Response::class.java)
 
-            response?.toDomain(stdin) ?: Judge0Result(stderr = "응답 없음", status = "Internal Error")
+            response?.toDomain(expectedOutput) ?: Judge0Result(stderr = "응답 없음", status = "Internal Error")
         } catch (e: Exception) {
             log.error("Judge0 API 호출 실패: ${e.message}", e)
             Judge0Result(stderr = e.message ?: "알 수 없는 오류", status = "Internal Error")
@@ -54,13 +54,14 @@ data class Judge0Response(
     val stderr: String? = null,
     val status: Judge0StatusResponse? = null
 ) {
-    fun toDomain(stdin: String): Judge0Result {
+    fun toDomain(expectedOutput: String): Judge0Result {
         val statusDesc = status?.description ?: "Unknown"
+        val actualStdout = stdout?.trim() ?: ""
         return Judge0Result(
-            stdout = stdout?.trim() ?: "",
+            stdout = actualStdout,
             stderr = stderr ?: "",
             status = statusDesc,
-            passed = statusDesc == "Accepted"
+            passed = statusDesc == "Accepted" && actualStdout == expectedOutput.trim()
         )
     }
 }

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/judge0/Judge0ResponseTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/judge0/Judge0ResponseTest.kt
@@ -1,0 +1,64 @@
+package com.devquest.client.ai.judge0
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class Judge0ResponseTest {
+
+    @Test
+    fun `toDomain - stdout이 expectedOutput과 일치하고 Accepted이면 passed=true`() {
+        val response = Judge0Response(
+            stdout = "25\n",
+            stderr = null,
+            status = Judge0StatusResponse("Accepted")
+        )
+
+        val result = response.toDomain("25")
+
+        assertThat(result.passed).isTrue()
+        assertThat(result.status).isEqualTo("Accepted")
+        assertThat(result.stdout).isEqualTo("25")
+    }
+
+    @Test
+    fun `toDomain - stdout이 expectedOutput과 다르면 passed=false, status=Wrong Answer`() {
+        val response = Judge0Response(
+            stdout = "wrong\n",
+            stderr = null,
+            status = Judge0StatusResponse("Accepted")
+        )
+
+        val result = response.toDomain("25")
+
+        assertThat(result.passed).isFalse()
+        assertThat(result.status).isEqualTo("Wrong Answer")
+    }
+
+    @Test
+    fun `toDomain - Judge0 status가 Accepted가 아니면 passed=false, status 유지`() {
+        val response = Judge0Response(
+            stdout = null,
+            stderr = "Compilation error",
+            status = Judge0StatusResponse("Compilation Error")
+        )
+
+        val result = response.toDomain("25")
+
+        assertThat(result.passed).isFalse()
+        assertThat(result.status).isEqualTo("Compilation Error")
+    }
+
+    @Test
+    fun `toDomain - 빈 stdout과 비어있지 않은 expectedOutput이면 passed=false`() {
+        val response = Judge0Response(
+            stdout = "",
+            stderr = null,
+            status = Judge0StatusResponse("Accepted")
+        )
+
+        val result = response.toDomain("25")
+
+        assertThat(result.passed).isFalse()
+        assertThat(result.status).isEqualTo("Wrong Answer")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
@@ -57,7 +57,7 @@ class CodingQuestService(
             try {
                 val generated = codingProblemGeneratorPort.generate(difficulty, language)
                 val allPassed = generated.testCases.all { tc ->
-                    val result = judge0Port.execute(generated.solutionCode, languageId, tc.input)
+                    val result = judge0Port.execute(generated.solutionCode, languageId, tc.input, tc.expectedOutput)
                     result.passed
                 }
                 if (allPassed) {
@@ -95,7 +95,7 @@ class CodingQuestService(
         var lastStdout = ""
         var lastStderr = ""
         val passed = problem.testCases.all { tc ->
-            val result = judge0Port.execute(userCode, languageId, tc.input)
+            val result = judge0Port.execute(userCode, languageId, tc.input, tc.expectedOutput)
             lastStdout = result.stdout
             lastStderr = result.stderr
             result.passed

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
@@ -75,9 +75,9 @@ class CodingQuestServiceTest {
         whenever(codingProblemPort.findByDifficultyAndLanguage("EASY", "JAVA")).thenReturn(emptyList())
         whenever(codingProblemGeneratorPort.generate("EASY", "JAVA")).thenReturn(generationResult)
         // testCases: input="5"→"25", "3"→"9", "0"→"0"
-        whenever(judge0Port.execute(any(), eq(62), eq("5"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("3"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("5"), eq("25"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("3"), eq("9"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("0"), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
         whenever(codingProblemPort.save(any())).thenReturn(sampleProblem.copy(title = "새 문제"))
 
         val result = service.generateProblem("user1", "JAVA")
@@ -100,9 +100,9 @@ class CodingQuestServiceTest {
     @Test
     fun `submitCode - 모든 테스트케이스 통과 시 passed=true 반환`() {
         whenever(codingProblemPort.findById(1L)).thenReturn(sampleProblem)
-        whenever(judge0Port.execute(any(), eq(62), eq("5"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("3"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("5"), eq("25"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("3"), eq("9"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("0"), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
         whenever(codingSubmissionPort.save(any(), any(), any(), any(), any(), any())).thenReturn(10L)
         // solveCount 1 → 레벨업 조건 불충족
         whenever(userCodingLevelPort.getSolveCount("user1")).thenReturn(1)
@@ -116,7 +116,7 @@ class CodingQuestServiceTest {
     @Test
     fun `submitCode - 하나라도 실패 시 passed=false 반환`() {
         whenever(codingProblemPort.findById(1L)).thenReturn(sampleProblem)
-        whenever(judge0Port.execute(any(), eq(62), eq("5"))).thenReturn(Judge0Result(stdout = "wrong", status = "Wrong Answer", passed = false))
+        whenever(judge0Port.execute(any(), eq(62), eq("5"), eq("25"))).thenReturn(Judge0Result(stdout = "wrong", status = "Wrong Answer", passed = false))
         whenever(codingSubmissionPort.save(any(), any(), any(), any(), any(), any())).thenReturn(11L)
 
         val result = service.submitCode("user1", 1L, "JAVA", "class Main {}")
@@ -128,9 +128,9 @@ class CodingQuestServiceTest {
     @Test
     fun `submitCode - solve_count가 3의 배수가 되면 레벨 업`() {
         whenever(codingProblemPort.findById(1L)).thenReturn(sampleProblem)
-        whenever(judge0Port.execute(any(), eq(62), eq("5"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("3"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
-        whenever(judge0Port.execute(any(), eq(62), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("5"), eq("25"))).thenReturn(Judge0Result(stdout = "25", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("3"), eq("9"))).thenReturn(Judge0Result(stdout = "9", status = "Accepted", passed = true))
+        whenever(judge0Port.execute(any(), eq(62), eq("0"), eq("0"))).thenReturn(Judge0Result(stdout = "0", status = "Accepted", passed = true))
         whenever(codingSubmissionPort.save(any(), any(), any(), any(), any(), any())).thenReturn(12L)
         // solveCount가 2이면 incrementSolveCount 후 3 → 레벨업
         whenever(userCodingLevelPort.getSolveCount("user1")).thenReturn(2)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/Judge0Port.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/Judge0Port.kt
@@ -8,5 +8,5 @@ data class Judge0Result(
 )
 
 interface Judge0Port {
-    fun execute(sourceCode: String, languageId: Int, stdin: String): Judge0Result
+    fun execute(sourceCode: String, languageId: Int, stdin: String, expectedOutput: String): Judge0Result
 }


### PR DESCRIPTION
## Summary
- Judge0 채점 결과가 `Accepted`이면 무조건 통과하던 버그 수정
- `stdout`과 `expectedOutput` 비교 로직 추가
- mock 모드(`JUDGE0_API_KEY` 미설정) 시 `passed = false`로 변경 (운영 환경에서 키 누락 시 안전하게 실패)

## Why
빈 코드를 제출해도 Judge0가 런타임 에러 없이 실행되면 `Accepted` 반환 → 통과 처리됨.
실제 출력값과 예상 출력값 비교 없이 status만 확인한 것이 원인.

## Test plan
- [ ] 빈 코드 제출 → 실패(passed=false) 확인
- [ ] 정답 코드 제출 → 통과(passed=true) 확인