### PR TITLE
fix(fe): 코딩 퀘스트 페이지 모바일 반응형 대응

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -54,17 +54,17 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 (PR #146 머지 완료) |
+| 브랜치 | `fix/coding-page-mobile-responsive` |
+| 열린 PR | #148 — 코딩 퀘스트 페이지 모바일 반응형 대응 (머지 대기) |
 
 
 ## 최근 완료 (최근 3건)
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #148 | 코딩 퀘스트 페이지 모바일 반응형 대응 — 탭 레이아웃, TopBar 버튼 최소화 | 2026-05-23 |
 | #147 | 코딩 채점 expectedOutput 비교 누락 수정 — 빈 코드 통과 버그 제거 | 2026-05-22 |
 | #146 | 401/403 시 토큰 자동 삭제 + 로그인 이동, storageKeys 공용 상수화, JWT_SECRET 재설정 | 2026-05-22 |
-| #145 | CLAUDE.md 다이어트 206→117줄 — 중복 섹션 제거, Copilot 리뷰 반영 | 2026-05-21 |
 | #144 | 코딩 연습 화면 LeetCode 스타일 개편 — Monaco Editor, 풀스크린 레이아웃, 상단 탭바 | 2026-05-21 |
 | #143 | superpowers 기반 스킬 7종 추가 — brainstorming/writing-plans/tdd/debugging/verification/executing/parallel | 2026-05-20 |
 

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -344,6 +344,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
             whiteSpace: 'nowrap',
             flexShrink: 0,
           }}
+          aria-label="퀘스트 맵으로 돌아가기"
           onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#F8FAFC' }}
           onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#475569' }}
         >
@@ -400,6 +401,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
           <button
             onClick={handleNewProblem}
             disabled={loadingProblem}
+            aria-label="새 문제 불러오기"
             style={{
               background: 'rgba(167,139,250,0.1)',
               border: '1px solid rgba(167,139,250,0.3)',
@@ -438,6 +440,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
       {/* 모바일 탭 바 */}
       {isMobile && (
         <div
+          role="tablist"
           style={{
             display: 'flex',
             background: '#0A0E1A',
@@ -451,6 +454,8 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
             return (
               <button
                 key={tab}
+                role="tab"
+                aria-selected={isActive}
                 onClick={() => setMobileTab(tab)}
                 style={{
                   flex: 1,

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -14,6 +14,7 @@ const KOTLIN_TEMPLATE = `fun main() {
 }`
 
 type Language = 'JAVA' | 'KOTLIN'
+type MobileTab = 'problem' | 'code'
 
 function difficultyColor(difficulty: string): string {
   if (difficulty === 'EASY') return '#4caf50'
@@ -35,6 +36,8 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
   const [loadingProblem, setLoadingProblem] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showResult, setShowResult] = useState(false)
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
+  const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
 
   const loadProblem = (lang: Language) => {
     setLoadingProblem(true)
@@ -52,6 +55,12 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
       .then((l) => setLevelResult(l))
       .catch(() => { /* 레벨 조회 실패 시 무시 */ })
     loadProblem('JAVA')
+  }, [])
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768)
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
   }, [])
 
   const handleLanguageChange = (lang: Language) => {
@@ -72,6 +81,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
     setSubmitting(true)
     setResult(null)
     setShowResult(true)
+    if (isMobile) setMobileTab('code')
     try {
       const res = await submitCode(problem.id, language, code)
       setResult(res)
@@ -86,6 +96,211 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
   const diffLabel = problem?.difficulty ?? '...'
   const monacoLang = language === 'JAVA' ? 'java' : 'kotlin'
   const fileName = language === 'JAVA' ? 'Main.java' : 'Main.kt'
+
+  const problemPanel = (
+    <div
+      style={{
+        background: '#0F172A',
+        overflowY: 'auto',
+        padding: 24,
+        ...(isMobile ? { flex: 1 } : { width: '38%', flexShrink: 0, borderRight: '1px solid rgba(255,255,255,0.08)' }),
+      }}
+    >
+      {/* 모바일에서만 제목/난이도/레벨 표시 */}
+      {isMobile && problem && (
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ marginBottom: 4 }}>
+            <span style={{ fontSize: 12, color: '#475569' }}>{levelLabel}</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 16, fontWeight: 700, color: '#F8FAFC' }}>{problem.title}</span>
+            <span
+              style={{
+                fontSize: 11,
+                color: difficultyColor(problem.difficulty),
+                background: `${difficultyColor(problem.difficulty)}20`,
+                border: `1px solid ${difficultyColor(problem.difficulty)}50`,
+                padding: '2px 7px',
+                borderRadius: 4,
+              }}
+            >
+              {problem.difficulty}
+            </span>
+          </div>
+        </div>
+      )}
+      {loadingProblem ? (
+        <p style={{ color: '#475569', fontSize: 13, margin: 0 }}>문제 불러오는 중...</p>
+      ) : error && !problem ? (
+        <p style={{ color: '#EF4444', fontSize: 13, margin: 0 }}>{error}</p>
+      ) : problem ? (
+        <>
+          {/* 데스크탑에서만 문제 패널 내 제목/레벨/난이도 표시 */}
+          {!isMobile && (
+            <>
+              <div style={{ marginBottom: 6 }}>
+                <span style={{ fontSize: 12, color: '#475569' }}>{levelLabel}</span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+                <span style={{ fontSize: 16, fontWeight: 700, color: '#F8FAFC' }}>{problem.title}</span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: difficultyColor(problem.difficulty),
+                    background: `${difficultyColor(problem.difficulty)}20`,
+                    border: `1px solid ${difficultyColor(problem.difficulty)}50`,
+                    padding: '2px 7px',
+                    borderRadius: 4,
+                  }}
+                >
+                  {problem.difficulty}
+                </span>
+              </div>
+            </>
+          )}
+          <p style={{ fontSize: 14, color: '#CBD5E1', margin: '0 0 20px', lineHeight: 1.7 }}>
+            {problem.description}
+          </p>
+          {problem.testCases.length > 0 && (
+            <div>
+              <p style={{ fontSize: 11, color: '#475569', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>예시</p>
+              {problem.testCases.slice(0, 2).map((tc, i) => (
+                <div
+                  key={i}
+                  style={{
+                    background: '#1E293B',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    borderRadius: 6,
+                    padding: '10px 12px',
+                    marginBottom: 8,
+                    fontSize: 13,
+                  }}
+                >
+                  <div style={{ color: '#475569', marginBottom: 4 }}>
+                    입력: <span style={{ color: '#F1F5F9', fontFamily: 'monospace' }}>{tc.input}</span>
+                  </div>
+                  <div style={{ color: '#475569' }}>
+                    출력: <span style={{ color: '#4ECDC4', fontFamily: 'monospace' }}>{tc.expectedOutput}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
+  )
+
+  const editorPanel = (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* 파일명 탭 (데스크탑에서만) */}
+      {!isMobile && (
+        <div
+          style={{
+            background: '#0A0E1A',
+            borderBottom: '1px solid rgba(255,255,255,0.08)',
+            padding: '0 16px',
+            display: 'flex',
+            alignItems: 'stretch',
+          }}
+        >
+          <div
+            style={{
+              padding: '8px 16px',
+              fontSize: 12,
+              color: '#F8FAFC',
+              background: '#1E293B',
+              borderTop: '2px solid #4ECDC4',
+              borderRight: '1px solid rgba(255,255,255,0.08)',
+              borderLeft: '1px solid rgba(255,255,255,0.08)',
+            }}
+          >
+            {fileName}
+          </div>
+        </div>
+      )}
+
+      {/* Monaco Editor */}
+      <div style={{ flex: 1, overflow: 'hidden' }}>
+        <Editor
+          height="100%"
+          language={monacoLang}
+          value={code}
+          onChange={(val) => setCode(val ?? '')}
+          theme="vs-dark"
+          options={{
+            fontSize: 14,
+            fontFamily: 'Consolas, "Courier New", monospace',
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            lineNumbers: 'on',
+            padding: { top: 12, bottom: 12 },
+            automaticLayout: true,
+          }}
+        />
+      </div>
+
+      {/* 결과 패널 */}
+      <div
+        style={{
+          height: showResult ? 160 : 0,
+          overflow: 'hidden',
+          transition: 'height 0.25s ease',
+          borderTop: showResult ? '1px solid rgba(255,255,255,0.08)' : 'none',
+          background: '#0A0E1A',
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ padding: '12px 20px', height: '100%', overflowY: 'auto', boxSizing: 'border-box' }}>
+          {submitting && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#4ECDC4', fontSize: 13 }}>
+              <span style={{ animation: 'spin 1s linear infinite' }}>⟳</span>
+              채점 중...
+            </div>
+          )}
+          {result && !submitting && (
+            <div
+              style={{
+                background: result.passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
+                border: `1px solid ${result.passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
+                borderRadius: 8,
+                padding: '12px 14px',
+                fontSize: 13,
+              }}
+            >
+              <p style={{ margin: '0 0 6px', color: result.passed ? '#10B981' : '#EF4444', fontWeight: 700 }}>
+                {result.passed ? '✓ 모든 테스트케이스 통과' : '✗ 실패'}
+              </p>
+              {result.passed && result.stdout && (
+                <p style={{ margin: '0 0 4px', color: '#CBD5E1', fontSize: 12 }}>
+                  stdout: <code style={{ fontFamily: 'monospace' }}>{result.stdout}</code>
+                </p>
+              )}
+              {!result.passed && (result.stderr || result.message) && (
+                <p style={{ margin: 0, color: '#EF4444', fontSize: 12, whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+                  {result.stderr ?? result.message}
+                </p>
+              )}
+            </div>
+          )}
+          {error && !submitting && !result && (
+            <div
+              style={{
+                background: 'rgba(239,68,68,0.04)',
+                border: '1px solid rgba(239,68,68,0.25)',
+                borderRadius: 8,
+                padding: '10px 14px',
+                fontSize: 13,
+                color: '#EF4444',
+              }}
+            >
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 
   return (
     <div
@@ -111,7 +326,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: '0 16px',
-          gap: 12,
+          gap: isMobile ? 6 : 12,
         }}
       >
         {/* 좌: 뒤로가기 */}
@@ -122,45 +337,48 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
             border: 'none',
             color: '#475569',
             cursor: 'pointer',
-            fontSize: 13,
+            fontSize: isMobile ? 16 : 13,
             fontFamily: "'Courier New', monospace",
-            padding: '4px 8px',
+            padding: isMobile ? '4px 6px' : '4px 8px',
             borderRadius: 4,
             whiteSpace: 'nowrap',
+            flexShrink: 0,
           }}
           onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#F8FAFC' }}
           onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#475569' }}
         >
-          ← 퀘스트 맵
+          {isMobile ? '←' : '← 퀘스트 맵'}
         </button>
 
-        {/* 중앙: 제목 + 난이도 + 레벨 */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, justifyContent: 'center', minWidth: 0 }}>
-          <span style={{ fontSize: 13, color: '#4ECDC4', fontWeight: 700, whiteSpace: 'nowrap' }}>{levelLabel}</span>
-          {problem && (
-            <>
-              <span style={{ fontSize: 14, fontWeight: 700, color: '#F8FAFC', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {problem.title}
-              </span>
-              <span
-                style={{
-                  fontSize: 11,
-                  color: difficultyColor(diffLabel),
-                  background: `${difficultyColor(diffLabel)}20`,
-                  border: `1px solid ${difficultyColor(diffLabel)}50`,
-                  padding: '2px 7px',
-                  borderRadius: 4,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {diffLabel}
-              </span>
-            </>
-          )}
-        </div>
+        {/* 중앙: 제목 + 난이도 + 레벨 (데스크탑에서만) */}
+        {!isMobile && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, justifyContent: 'center', minWidth: 0 }}>
+            <span style={{ fontSize: 13, color: '#4ECDC4', fontWeight: 700, whiteSpace: 'nowrap' }}>{levelLabel}</span>
+            {problem && (
+              <>
+                <span style={{ fontSize: 14, fontWeight: 700, color: '#F8FAFC', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {problem.title}
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: difficultyColor(diffLabel),
+                    background: `${difficultyColor(diffLabel)}20`,
+                    border: `1px solid ${difficultyColor(diffLabel)}50`,
+                    padding: '2px 7px',
+                    borderRadius: 4,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {diffLabel}
+                </span>
+              </>
+            )}
+          </div>
+        )}
 
         {/* 우: 언어 토글 + 새 문제 + 제출 */}
-        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+        <div style={{ display: 'flex', gap: isMobile ? 4 : 6, alignItems: 'center', flexShrink: 0 }}>
           {(['JAVA', 'KOTLIN'] as Language[]).map((lang) => (
             <button
               key={lang}
@@ -169,7 +387,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
                 background: language === lang ? 'rgba(78,205,196,0.15)' : 'transparent',
                 border: `1px solid ${language === lang ? '#4ECDC4' : 'rgba(255,255,255,0.08)'}`,
                 color: language === lang ? '#4ECDC4' : '#475569',
-                padding: '4px 10px',
+                padding: isMobile ? '4px 6px' : '4px 10px',
                 borderRadius: 4,
                 cursor: 'pointer',
                 fontSize: 12,
@@ -186,7 +404,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
               background: 'rgba(167,139,250,0.1)',
               border: '1px solid rgba(167,139,250,0.3)',
               color: '#A78BFA',
-              padding: '4px 12px',
+              padding: isMobile ? '4px 6px' : '4px 12px',
               borderRadius: 4,
               cursor: loadingProblem ? 'not-allowed' : 'pointer',
               fontSize: 12,
@@ -194,7 +412,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
               opacity: loadingProblem ? 0.6 : 1,
             }}
           >
-            새 문제
+            {isMobile ? '↺' : '새 문제'}
           </button>
           <button
             onClick={handleSubmit}
@@ -203,7 +421,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
               background: submitting || !problem ? 'rgba(78,205,196,0.3)' : '#4ECDC4',
               border: 'none',
               color: '#060610',
-              padding: '4px 16px',
+              padding: isMobile ? '4px 8px' : '4px 16px',
               borderRadius: 4,
               cursor: submitting || !problem ? 'not-allowed' : 'pointer',
               fontSize: 12,
@@ -217,183 +435,59 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
         </div>
       </div>
 
-      {/* 본문 영역 */}
-      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        {/* 문제 패널 (38%) */}
+      {/* 모바일 탭 바 */}
+      {isMobile && (
         <div
           style={{
-            width: '38%',
+            display: 'flex',
+            background: '#0A0E1A',
+            borderBottom: '1px solid rgba(255,255,255,0.08)',
             flexShrink: 0,
-            background: '#0F172A',
-            borderRight: '1px solid rgba(255,255,255,0.08)',
-            overflowY: 'auto',
-            padding: 24,
           }}
         >
-          {loadingProblem ? (
-            <p style={{ color: '#475569', fontSize: 13, margin: 0 }}>문제 불러오는 중...</p>
-          ) : error && !problem ? (
-            <p style={{ color: '#EF4444', fontSize: 13, margin: 0 }}>{error}</p>
-          ) : problem ? (
-            <>
-              <div style={{ marginBottom: 6 }}>
-                <span style={{ fontSize: 12, color: '#475569' }}>{levelLabel}</span>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-                <span style={{ fontSize: 16, fontWeight: 700, color: '#F8FAFC' }}>{problem.title}</span>
-                <span
-                  style={{
-                    fontSize: 11,
-                    color: difficultyColor(problem.difficulty),
-                    background: `${difficultyColor(problem.difficulty)}20`,
-                    border: `1px solid ${difficultyColor(problem.difficulty)}50`,
-                    padding: '2px 7px',
-                    borderRadius: 4,
-                  }}
-                >
-                  {problem.difficulty}
-                </span>
-              </div>
-              <p style={{ fontSize: 14, color: '#CBD5E1', margin: '0 0 20px', lineHeight: 1.7 }}>
-                {problem.description}
-              </p>
-              {problem.testCases.length > 0 && (
-                <div>
-                  <p style={{ fontSize: 11, color: '#475569', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>예시</p>
-                  {problem.testCases.slice(0, 2).map((tc, i) => (
-                    <div
-                      key={i}
-                      style={{
-                        background: '#1E293B',
-                        border: '1px solid rgba(255,255,255,0.06)',
-                        borderRadius: 6,
-                        padding: '10px 12px',
-                        marginBottom: 8,
-                        fontSize: 13,
-                      }}
-                    >
-                      <div style={{ color: '#475569', marginBottom: 4 }}>
-                        입력: <span style={{ color: '#F1F5F9', fontFamily: 'monospace' }}>{tc.input}</span>
-                      </div>
-                      <div style={{ color: '#475569' }}>
-                        출력: <span style={{ color: '#4ECDC4', fontFamily: 'monospace' }}>{tc.expectedOutput}</span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </>
-          ) : null}
+          {(['problem', 'code'] as MobileTab[]).map((tab) => {
+            const label = tab === 'problem' ? '문제' : '코드'
+            const isActive = mobileTab === tab
+            return (
+              <button
+                key={tab}
+                onClick={() => setMobileTab(tab)}
+                style={{
+                  flex: 1,
+                  padding: '10px 0',
+                  background: 'none',
+                  border: 'none',
+                  borderBottom: isActive ? '2px solid #4ECDC4' : '2px solid transparent',
+                  color: isActive ? '#4ECDC4' : '#475569',
+                  fontSize: 13,
+                  fontFamily: "'Courier New', monospace",
+                  cursor: 'pointer',
+                  fontWeight: isActive ? 700 : 400,
+                }}
+              >
+                {label}
+              </button>
+            )
+          })}
         </div>
+      )}
 
-        {/* 에디터 패널 (62%) */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-          {/* 파일명 탭 */}
-          <div
-            style={{
-              background: '#0A0E1A',
-              borderBottom: '1px solid rgba(255,255,255,0.08)',
-              padding: '0 16px',
-              display: 'flex',
-              alignItems: 'stretch',
-            }}
-          >
-            <div
-              style={{
-                padding: '8px 16px',
-                fontSize: 12,
-                color: '#F8FAFC',
-                background: '#1E293B',
-                borderTop: '2px solid #4ECDC4',
-                borderRight: '1px solid rgba(255,255,255,0.08)',
-                borderLeft: '1px solid rgba(255,255,255,0.08)',
-              }}
-            >
-              {fileName}
-            </div>
+      {/* 본문 영역 */}
+      {isMobile ? (
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'problem' ? 'flex' : 'none', flexDirection: 'column' }}>
+            {problemPanel}
           </div>
-
-          {/* Monaco Editor */}
-          <div style={{ flex: 1, overflow: 'hidden' }}>
-            <Editor
-              height="100%"
-              language={monacoLang}
-              value={code}
-              onChange={(val) => setCode(val ?? '')}
-              theme="vs-dark"
-              options={{
-                fontSize: 14,
-                fontFamily: 'Consolas, "Courier New", monospace',
-                minimap: { enabled: false },
-                scrollBeyondLastLine: false,
-                lineNumbers: 'on',
-                padding: { top: 12, bottom: 12 },
-                automaticLayout: true,
-              }}
-            />
-          </div>
-
-          {/* 결과 패널 */}
-          <div
-            style={{
-              height: showResult ? 160 : 0,
-              overflow: 'hidden',
-              transition: 'height 0.25s ease',
-              borderTop: showResult ? '1px solid rgba(255,255,255,0.08)' : 'none',
-              background: '#0A0E1A',
-              flexShrink: 0,
-            }}
-          >
-            <div style={{ padding: '12px 20px', height: '100%', overflowY: 'auto', boxSizing: 'border-box' }}>
-              {submitting && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#4ECDC4', fontSize: 13 }}>
-                  <span style={{ animation: 'spin 1s linear infinite' }}>⟳</span>
-                  채점 중...
-                </div>
-              )}
-              {result && !submitting && (
-                <div
-                  style={{
-                    background: result.passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
-                    border: `1px solid ${result.passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
-                    borderRadius: 8,
-                    padding: '12px 14px',
-                    fontSize: 13,
-                  }}
-                >
-                  <p style={{ margin: '0 0 6px', color: result.passed ? '#10B981' : '#EF4444', fontWeight: 700 }}>
-                    {result.passed ? '✓ 모든 테스트케이스 통과' : '✗ 실패'}
-                  </p>
-                  {result.passed && result.stdout && (
-                    <p style={{ margin: '0 0 4px', color: '#CBD5E1', fontSize: 12 }}>
-                      stdout: <code style={{ fontFamily: 'monospace' }}>{result.stdout}</code>
-                    </p>
-                  )}
-                  {!result.passed && (result.stderr || result.message) && (
-                    <p style={{ margin: 0, color: '#EF4444', fontSize: 12, whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
-                      {result.stderr ?? result.message}
-                    </p>
-                  )}
-                </div>
-              )}
-              {error && !submitting && !result && (
-                <div
-                  style={{
-                    background: 'rgba(239,68,68,0.04)',
-                    border: '1px solid rgba(239,68,68,0.25)',
-                    borderRadius: 8,
-                    padding: '10px 14px',
-                    fontSize: 13,
-                    color: '#EF4444',
-                  }}
-                >
-                  {error}
-                </div>
-              )}
-            </div>
+          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'code' ? 'flex' : 'none', flexDirection: 'column' }}>
+            {editorPanel}
           </div>
         </div>
-      </div>
+      ) : (
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          {problemPanel}
+          {editorPanel}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 모바일(< 768px)에서 TopBar 버튼 오버플로 및 좌우 분할 레이아웃 깨짐 수정
- 모바일: 문제/코드 탭 방식으로 전환, TopBar 버튼 텍스트 최소화 (←, ↺)
- 제출 시 코드 탭 자동 전환으로 결과 즉시 확인 가능
- 데스크탑(≥ 768px): 기존 38%/62% 분할 레이아웃 유지

## Test plan
- [ ] 모바일(375px 기준) 문제 탭 / 코드 탭 전환 확인
- [ ] 제출 후 코드 탭 자동 전환 + 결과 표시 확인
- [ ] 데스크탑에서 기존 레이아웃 유지 확인
- [ ] Monaco Editor 탭 전환 후 높이 정상 렌더 확인 (실기기)