### PR TITLE
fix(fe): 코딩 퀘스트 페이지 상태 유지 (뒤로가기 후 복원)

### DIFF
--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { Act, Quest } from '@/types/quest.types'
-import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ActClearReportResult, ResumeCheckResult } from '@/types/api.types'
+import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult, ActClearReportResult, ResumeCheckResult, CodingQuestState } from '@/types/api.types'
 import type { Character } from '@/types/character.types'
 import { QuestMap } from '@/features/quest-map'
 import { QuestDetail, QuestBriefingView } from '@/features/quest-detail'
@@ -76,6 +76,7 @@ export function App() {
   const [aiResults, setAiResults] = useState<Record<string, AiEvaluationResult | BossPackageResult | DeveloperClassResult | JdAnalysisResult | ResumeCheckResult>>(
     INITIAL_PROGRESS_CACHE?.aiResults ?? {}
   )
+  const [codingQuestState, setCodingQuestState] = useState<CodingQuestState | null>(null)
   const [showForm, setShowForm] = useState(false)
   const [showIntro, setShowIntro] = useState(true)
   const [progressLoading, setProgressLoading] = useState(false)
@@ -315,7 +316,13 @@ export function App() {
   }
 
   if (view.kind === 'coding-quest') {
-    return <CodingQuestPage onBack={() => setView({ kind: 'map' })} />
+    return (
+      <CodingQuestPage
+        onBack={() => setView({ kind: 'map' })}
+        savedState={codingQuestState}
+        onStateChange={setCodingQuestState}
+      />
+    )
   }
 
   return (

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import Editor from '@monaco-editor/react'
-import type { CodingProblem, CodingSubmissionResult, CodingLevelResult } from '@/types/api.types'
+import type { CodingProblem, CodingSubmissionResult, CodingLevelResult, CodingQuestState } from '@/types/api.types'
 import { fetchCodingProblem, submitCode, fetchCodingLevel } from '@/lib/apiClient'
 import { HintSection } from './HintSection'
 
@@ -25,20 +25,36 @@ function difficultyColor(difficulty: string): string {
 
 interface CodingQuestPageProps {
   onBack: () => void
+  savedState?: CodingQuestState | null
+  onStateChange?: (state: CodingQuestState) => void
 }
 
-export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
-  const [language, setLanguage] = useState<Language>('JAVA')
-  const [problem, setProblem] = useState<CodingProblem | null>(null)
+export function CodingQuestPage({ onBack, savedState, onStateChange }: CodingQuestPageProps) {
+  const [language, setLanguage] = useState<Language>(savedState?.language ?? 'JAVA')
+  const [problem, setProblem] = useState<CodingProblem | null>(savedState?.problem ?? null)
   const [levelResult, setLevelResult] = useState<CodingLevelResult | null>(null)
-  const [code, setCode] = useState<string>(JAVA_TEMPLATE)
+  const [code, setCode] = useState<string>(savedState?.code ?? JAVA_TEMPLATE)
   const [submitting, setSubmitting] = useState(false)
-  const [result, setResult] = useState<CodingSubmissionResult | null>(null)
+  const [result, setResult] = useState<CodingSubmissionResult | null>(savedState?.result ?? null)
   const [loadingProblem, setLoadingProblem] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [showResult, setShowResult] = useState(false)
+  const [showResult, setShowResult] = useState(savedState?.showResult ?? false)
+  const [hints, setHints] = useState<string[]>(savedState?.hints ?? [])
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
+
+  const notifyStateChange = (patch: Partial<CodingQuestState>) => {
+    if (!onStateChange) return
+    onStateChange({
+      language,
+      problem,
+      code,
+      result,
+      showResult,
+      hints,
+      ...patch,
+    })
+  }
 
   const loadProblem = (lang: Language) => {
     setLoadingProblem(true)
@@ -46,7 +62,11 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
     setResult(null)
     setShowResult(false)
     fetchCodingProblem(lang)
-      .then((p) => setProblem(p))
+      .then((p) => {
+        setProblem(p)
+        setHints([])
+        notifyStateChange({ language: lang, problem: p, result: null, showResult: false, hints: [] })
+      })
       .catch(() => setError('문제를 불러오는 데 실패했습니다.'))
       .finally(() => setLoadingProblem(false))
   }
@@ -55,7 +75,11 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
     fetchCodingLevel()
       .then((l) => setLevelResult(l))
       .catch(() => { /* 레벨 조회 실패 시 무시 */ })
-    loadProblem('JAVA')
+
+    // 저장된 문제가 없을 때만 새 문제 로드
+    if (!savedState?.problem) {
+      loadProblem('JAVA')
+    }
   }, [])
 
   useEffect(() => {
@@ -65,16 +89,32 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
   }, [])
 
   const handleLanguageChange = (lang: Language) => {
+    const newCode = lang === 'JAVA' ? JAVA_TEMPLATE : KOTLIN_TEMPLATE
     setLanguage(lang)
-    setCode(lang === 'JAVA' ? JAVA_TEMPLATE : KOTLIN_TEMPLATE)
+    setCode(newCode)
     setResult(null)
     setShowResult(false)
+    setHints([])
     loadProblem(lang)
+    notifyStateChange({ language: lang, code: newCode, result: null, showResult: false, hints: [] })
   }
 
   const handleNewProblem = () => {
-    setCode(language === 'JAVA' ? JAVA_TEMPLATE : KOTLIN_TEMPLATE)
+    const newCode = language === 'JAVA' ? JAVA_TEMPLATE : KOTLIN_TEMPLATE
+    setCode(newCode)
+    setHints([])
     loadProblem(language)
+    notifyStateChange({ code: newCode, hints: [] })
+  }
+
+  const handleCodeChange = (val: string) => {
+    setCode(val)
+    notifyStateChange({ code: val })
+  }
+
+  const handleHintsChange = (nextHints: string[]) => {
+    setHints(nextHints)
+    notifyStateChange({ hints: nextHints })
   }
 
   const handleSubmit = async () => {
@@ -83,9 +123,11 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
     setResult(null)
     setShowResult(true)
     if (isMobile) setMobileTab('code')
+    notifyStateChange({ result: null, showResult: true })
     try {
       const res = await submitCode(problem.id, language, code)
       setResult(res)
+      notifyStateChange({ result: res, showResult: true })
     } catch {
       setError('제출 중 오류가 발생했습니다.')
     } finally {
@@ -187,7 +229,11 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
               ))}
             </div>
           )}
-          <HintSection problem={problem} />
+          <HintSection
+            problem={problem}
+            initialHints={hints}
+            onHintsChange={handleHintsChange}
+          />
         </>
       ) : null}
     </div>
@@ -228,7 +274,7 @@ export function CodingQuestPage({ onBack }: CodingQuestPageProps) {
           height="100%"
           language={monacoLang}
           value={code}
-          onChange={(val) => setCode(val ?? '')}
+          onChange={(val) => handleCodeChange(val ?? '')}
           theme="vs-dark"
           options={{
             fontSize: 14,

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -59,15 +59,20 @@ export function CodingQuestPage({ onBack, savedState, onStateChange }: CodingQue
   const loadProblem = (lang: Language) => {
     setLoadingProblem(true)
     setError(null)
+    setProblem(null)
     setResult(null)
     setShowResult(false)
+    notifyStateChange({ language: lang, problem: null, result: null, showResult: false, hints: [] })
     fetchCodingProblem(lang)
       .then((p) => {
         setProblem(p)
         setHints([])
         notifyStateChange({ language: lang, problem: p, result: null, showResult: false, hints: [] })
       })
-      .catch(() => setError('문제를 불러오는 데 실패했습니다.'))
+      .catch(() => {
+        setError('문제를 불러오는 데 실패했습니다.')
+        notifyStateChange({ language: lang, problem: null, result: null, showResult: false, hints: [] })
+      })
       .finally(() => setLoadingProblem(false))
   }
 

--- a/fe/src/features/coding-quest/components/HintSection.tsx
+++ b/fe/src/features/coding-quest/components/HintSection.tsx
@@ -4,15 +4,17 @@ import { fetchHint } from '../api/fetchHint'
 
 interface HintSectionProps {
   problem: CodingProblem
+  initialHints?: string[]
+  onHintsChange?: (hints: string[]) => void
 }
 
-export function HintSection({ problem }: HintSectionProps) {
-  const [hints, setHints] = useState<string[]>([])
+export function HintSection({ problem, initialHints, onHintsChange }: HintSectionProps) {
+  const [hints, setHints] = useState<string[]>(initialHints ?? [])
   const [loadingHint, setLoadingHint] = useState(false)
   const [hintError, setHintError] = useState<string | null>(null)
 
   useEffect(() => {
-    setHints([])
+    setHints(initialHints ?? [])
     setLoadingHint(false)
     setHintError(null)
   }, [problem.id])
@@ -29,7 +31,9 @@ export function HintSection({ problem }: HintSectionProps) {
         problem.description,
         nextLevel,
       )
-      setHints((prev) => [...prev, result.hint])
+      const nextHints = [...hints, result.hint]
+      setHints(nextHints)
+      onHintsChange?.(nextHints)
     } catch {
       setHintError('힌트를 불러오는 데 실패했습니다.')
     } finally {

--- a/fe/src/features/coding-quest/components/HintSection.tsx
+++ b/fe/src/features/coding-quest/components/HintSection.tsx
@@ -17,7 +17,7 @@ export function HintSection({ problem, initialHints, onHintsChange }: HintSectio
     setHints(initialHints ?? [])
     setLoadingHint(false)
     setHintError(null)
-  }, [problem.id])
+  }, [problem.id, initialHints])
 
   const handleRequestHint = async () => {
     if (loadingHint || hints.length >= 3) return
@@ -31,9 +31,11 @@ export function HintSection({ problem, initialHints, onHintsChange }: HintSectio
         problem.description,
         nextLevel,
       )
-      const nextHints = [...hints, result.hint]
-      setHints(nextHints)
-      onHintsChange?.(nextHints)
+      setHints((prev) => {
+        const nextHints = [...prev, result.hint]
+        onHintsChange?.(nextHints)
+        return nextHints
+      })
     } catch {
       setHintError('힌트를 불러오는 데 실패했습니다.')
     } finally {

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -188,3 +188,12 @@ export interface CodingSubmissionResult {
 export interface CodingLevelResult {
   level: number
 }
+
+export interface CodingQuestState {
+  language: 'JAVA' | 'KOTLIN'
+  problem: CodingProblem | null
+  code: string
+  result: CodingSubmissionResult | null
+  showResult: boolean
+  hints: string[]
+}


### PR DESCRIPTION
## Summary
- 코딩 퀘스트 페이지에서 뒤로가기 후 재진입 시 상태가 초기화되는 버그 수정
- `language`, `problem`, `code`, `result`, `hints` 상태를 App.tsx로 lift
- HintSection의 hints state도 CodingQuestPage를 거쳐 App.tsx까지 상태 전파

## Why
view가 `coding-quest → map → coding-quest`로 전환될 때 컴포넌트가 언마운트/재마운트되어 모든 로컬 state가 초기화되는 문제. App.tsx에서 상태를 보유하면 언마운트돼도 상태 유지.

## Test plan
- [ ] 코딩 퀘스트 진입 → 코드 일부 작성 → 뒤로가기 → 재진입 → 작성한 코드 유지 확인
- [ ] 뒤로가기 후 재진입 시 동일 문제 표시 확인
- [ ] 힌트 요청 후 뒤로가기 → 재진입 시 힌트 내역 유지 확인
- [ ] 제출 결과 뒤로가기 후 재진입 시 유지 확인