### PR TITLE
chore(orchestrator): tools 와일드카드 변경 및 mcpServers 제거

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
 model: sonnet
-tools: "Agent(be-feature-builder, fe-feature-builder, design-reviewer, qa-reviewer), Read, Glob, Grep, Bash, Write, Edit, mcp__playwright, mcp__notion"
+tools: "*"
 description: Feature Dev 오케스트레이터. 사용자 요청을 분석해 필요한 에이전트만 선택적으로 스폰하며 BE·FE·Design·QA를 조율한다. `claude --agent orchestrator`로 실행.
 hooks:
   UserPromptSubmit:


### PR DESCRIPTION
## Summary
- orchestrator agent의 `tools`를 개별 목록에서 `"*"`(와일드카드)로 변경
- 동작하지 않던 `mcpServers` 필드 제거
- 이로써 playwright 등 MCP 도구 접근 가능