### PR TITLE
feat(fe): 모바일 UX 개선 — AI 폼 다단계화, 성장 차트 탭 네비게이션, 코딩 에디터 최적화

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -54,8 +54,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `feat/mobile-ux` |
+| 열린 PR | #156 — 모바일 UX 개선 (머지 대기) |
 
 
 
@@ -63,6 +63,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #156 | 모바일 UX 개선 — AI 폼 다단계화, 성장 차트 탭 네비게이션, 코딩 에디터 최적화 | 2026-05-28 |
 | #155 | PR 절차 문서화 — git-strategy.md Copilot 리뷰 처리 절차 추가, orchestrator 9단계 git-strategy 참조로 교체 | 2026-05-27 |
 | #154 | orchestrator tools 와일드카드 변경 및 mcpServers 제거 (머지 완료) | 2026-05-27 |
 | #153 | .claude 구조 개편 — skills universal/project 분리, pair-programmer 에이전트 추가, orchestrator 브랜치 규칙 명시 | 2026-05-26 |

--- a/fe/src/features/ai-check/components/AiCheckForm.tsx
+++ b/fe/src/features/ai-check/components/AiCheckForm.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { AiEvaluationResult, BossPackageResult, DeveloperClassResult, JdAnalysisResult } from '@/types/api.types'
 import { OracleLoadingModal } from '@/components/ui/OracleLoadingModal'
 import { AI_FORMS } from '../constants/formConfig'
@@ -13,18 +14,63 @@ interface AiCheckFormProps {
 
 export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCheckFormProps) {
   const cfg = AI_FORMS[questId]
+  const [currentStep, setCurrentStep] = useState(0)
+  const [stepError, setStepError] = useState('')
 
   const { values, loading, error, activeHint, set, setListItem, setActiveHint, handleSubmit } =
     useAiCheckForm({ questId, cfg: cfg!, onResult, onSubmit, initialValues })
 
   if (!cfg) return null
 
+  const fields = cfg.fields
+  const isMultiStep = fields.length > 1
+
+  const validateCurrentStep = (): string | null => {
+    const field = fields[currentStep]
+    if (!field) return null
+    const val = values[field.key]
+    if (field.type === 'text' || field.type === 'textarea') {
+      if (!val || !(val as string).trim()) {
+        return `'${field.label}' 항목을 입력해주세요`
+      }
+    } else if (field.type === 'list') {
+      const arr = (val as string[] | undefined) ?? []
+      const hasNonEmpty = arr.some((s) => (typeof s === 'string' ? s : '').trim().length > 0)
+      if (!hasNonEmpty) {
+        return `'${field.label}' 항목을 최소 1개 이상 입력해주세요`
+      }
+    } else if (field.type === 'tag-search') {
+      const arr = (val as string[] | undefined) ?? []
+      if (arr.length === 0) {
+        return `'${field.label}' 항목을 최소 1개 이상 선택해주세요`
+      }
+    }
+    return null
+  }
+
+  const handleNext = () => {
+    const err = validateCurrentStep()
+    if (err) {
+      setStepError(err)
+      return
+    }
+    setStepError('')
+    setCurrentStep((s) => s + 1)
+  }
+
+  const handlePrev = () => {
+    setStepError('')
+    setCurrentStep((s) => s - 1)
+  }
+
+  const isLastStep = currentStep === fields.length - 1
+
   return (
     <div style={{ marginTop: 18, animation: 'slideIn 0.3s ease' }}>
       <div style={{ fontSize: 10, color: '#4ECDC4', letterSpacing: 4, marginBottom: 14 }}>
-        🤖 AI SUBMISSION FORM
+        AI SUBMISSION FORM
       </div>
-      {cfg.description && cfg.fields.length === 0 && (
+      {cfg.description && fields.length === 0 && (
         <div
           style={{
             background: 'rgba(167,139,250,0.06)',
@@ -40,18 +86,80 @@ export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCh
           {cfg.description}
         </div>
       )}
-      {cfg.fields.map((f) => (
+
+      {/* 진행 표시기 (멀티스텝 시만) */}
+      {isMultiStep && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginBottom: 16,
+          }}
+        >
+          {fields.map((_, i) => (
+            <div
+              key={i}
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: i <= currentStep ? '#4ECDC4' : 'rgba(255,255,255,0.2)',
+                transition: 'background 0.2s ease',
+              }}
+            />
+          ))}
+          <span style={{ fontSize: 11, color: '#475569', marginLeft: 4 }}>
+            {currentStep + 1} / {fields.length}
+          </span>
+        </div>
+      )}
+
+      {/* 필드 렌더링 */}
+      {isMultiStep ? (
         <FormField
-          key={f.key}
-          field={f}
-          value={values[f.key]}
+          key={fields[currentStep]?.key}
+          field={fields[currentStep]!}
+          value={values[fields[currentStep]?.key ?? '']}
           activeHint={activeHint}
           onActiveHintChange={setActiveHint}
-          onChange={(val) => set(f.key, val)}
-          onListItemChange={(index, val) => setListItem(f.key, index, val)}
+          onChange={(val) => set(fields[currentStep]!.key, val)}
+          onListItemChange={(index, val) => setListItem(fields[currentStep]!.key, index, val)}
         />
-      ))}
+      ) : (
+        fields.map((f) => (
+          <FormField
+            key={f.key}
+            field={f}
+            value={values[f.key]}
+            activeHint={activeHint}
+            onActiveHintChange={setActiveHint}
+            onChange={(val) => set(f.key, val)}
+            onListItemChange={(index, val) => setListItem(f.key, index, val)}
+          />
+        ))
+      )}
+
       <OracleLoadingModal isOpen={loading} />
+
+      {/* 스텝 오류 메시지 */}
+      {stepError && (
+        <div
+          style={{
+            background: 'rgba(239,68,68,0.08)',
+            border: '1px solid rgba(239,68,68,0.25)',
+            borderRadius: 8,
+            padding: 11,
+            marginBottom: 12,
+            fontSize: 13,
+            color: '#EF4444',
+          }}
+        >
+          {stepError}
+        </div>
+      )}
+
+      {/* 제출 오류 메시지 */}
       {error && (
         <div
           style={{
@@ -64,30 +172,98 @@ export function AiCheckForm({ questId, onResult, initialValues, onSubmit }: AiCh
             color: '#EF4444',
           }}
         >
-          ⚠ {error}
+          {error}
         </div>
       )}
-      <button
-        onClick={handleSubmit}
-        disabled={loading}
-        style={{
-          width: '100%',
-          padding: '12px',
-          background: loading
-            ? 'rgba(78,205,196,0.2)'
-            : 'linear-gradient(135deg, #4ECDC4, #2DD4BF)',
-          border: 'none',
-          borderRadius: 10,
-          color: '#060610',
-          fontSize: 14,
-          fontWeight: 'bold',
-          cursor: loading ? 'not-allowed' : 'pointer',
-          fontFamily: "'Courier New', monospace",
-          letterSpacing: 1,
-        }}
-      >
-        {loading ? '⟳ AI 분석 중... (30초 소요)' : '🤖 AI 제출하기'}
-      </button>
+
+      {/* 버튼 영역 */}
+      {isMultiStep ? (
+        <div style={{ display: 'flex', gap: 8 }}>
+          {currentStep > 0 && (
+            <button
+              onClick={handlePrev}
+              disabled={loading}
+              style={{
+                flex: 1,
+                padding: '12px',
+                background: 'rgba(255,255,255,0.06)',
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 10,
+                color: '#94A3B8',
+                fontSize: 14,
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              ← 이전
+            </button>
+          )}
+          {isLastStep ? (
+            <button
+              onClick={handleSubmit}
+              disabled={loading}
+              style={{
+                flex: currentStep > 0 ? 2 : 1,
+                padding: '12px',
+                background: loading
+                  ? 'rgba(78,205,196,0.2)'
+                  : 'linear-gradient(135deg, #4ECDC4, #2DD4BF)',
+                border: 'none',
+                borderRadius: 10,
+                color: '#060610',
+                fontSize: 14,
+                fontWeight: 'bold',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                fontFamily: "'Courier New', monospace",
+                letterSpacing: 1,
+              }}
+            >
+              {loading ? '⟳ AI 분석 중... (30초 소요)' : 'AI 제출하기'}
+            </button>
+          ) : (
+            <button
+              onClick={handleNext}
+              disabled={loading}
+              style={{
+                flex: currentStep > 0 ? 2 : 1,
+                padding: '12px',
+                background: 'rgba(78,205,196,0.12)',
+                border: '1px solid rgba(78,205,196,0.3)',
+                borderRadius: 10,
+                color: '#4ECDC4',
+                fontSize: 14,
+                fontWeight: 'bold',
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              다음 →
+            </button>
+          )}
+        </div>
+      ) : (
+        <button
+          onClick={handleSubmit}
+          disabled={loading}
+          style={{
+            width: '100%',
+            padding: '12px',
+            background: loading
+              ? 'rgba(78,205,196,0.2)'
+              : 'linear-gradient(135deg, #4ECDC4, #2DD4BF)',
+            border: 'none',
+            borderRadius: 10,
+            color: '#060610',
+            fontSize: 14,
+            fontWeight: 'bold',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            fontFamily: "'Courier New', monospace",
+            letterSpacing: 1,
+          }}
+        >
+          {loading ? '⟳ AI 분석 중... (30초 소요)' : 'AI 제출하기'}
+        </button>
+      )}
     </div>
   )
 }

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -140,6 +140,15 @@ export function CodingQuestPage({ onBack, savedState, onStateChange }: CodingQue
     }
   }
 
+  const editorOptions = {
+    fontSize: isMobile ? 13 : 14,
+    wordWrap: isMobile ? ('on' as const) : ('off' as const),
+    lineNumbers: isMobile ? ('off' as const) : ('on' as const),
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    padding: { top: isMobile ? 12 : 8 },
+  }
+
   const levelLabel = levelResult ? `Lv.${levelResult.level}` : 'Lv.-'
   const diffLabel = problem?.difficulty ?? '...'
   const monacoLang = language === 'JAVA' ? 'java' : 'kotlin'
@@ -282,12 +291,8 @@ export function CodingQuestPage({ onBack, savedState, onStateChange }: CodingQue
           onChange={(val) => handleCodeChange(val ?? '')}
           theme="vs-dark"
           options={{
-            fontSize: 14,
+            ...editorOptions,
             fontFamily: 'Consolas, "Courier New", monospace',
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-            lineNumbers: 'on',
-            padding: { top: 12, bottom: 12 },
             automaticLayout: true,
           }}
         />

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -10,6 +10,16 @@ import { StreakBadge } from './StreakBadge'
 import { HourlyActivity } from './HourlyActivity'
 import { QuestAttemptCount } from './QuestAttemptCount'
 
+type ChartTab = 'score' | 'act' | 'grade' | 'hourly' | 'quest'
+
+const CHART_TABS: { key: ChartTab; label: string }[] = [
+  { key: 'score', label: '점수 추이' },
+  { key: 'act', label: 'ACT 합격률' },
+  { key: 'grade', label: '등급 분포' },
+  { key: 'hourly', label: '시간대' },
+  { key: 'quest', label: '퀘스트' },
+]
+
 interface BestScoreEntry {
   questId: string
   score: number
@@ -35,6 +45,7 @@ export function GrowthDashboard() {
   const [history, setHistory] = useState<QuestHistoryItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [selectedChart, setSelectedChart] = useState<ChartTab>('score')
 
   useEffect(() => {
     setLoading(true)
@@ -66,7 +77,7 @@ export function GrowthDashboard() {
             marginBottom: 4,
           }}
         >
-          ⚔️ 성장 기록
+          성장 기록
         </h2>
         {!loading && (
           <div style={{ fontSize: 12, color: '#94A3B8' }}>
@@ -81,31 +92,6 @@ export function GrowthDashboard() {
         </div>
       ) : (
         <>
-          {/* 전체 XP 성장 그래프 */}
-          <section style={{ marginBottom: 28 }}>
-            <div
-              style={{
-                fontSize: 12,
-                color: '#94A3B8',
-                marginBottom: 10,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              점수 변화 추이
-            </div>
-            <div
-              style={{
-                background: '#0F172A',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 10,
-                padding: '16px 8px 8px',
-              }}
-            >
-              <ScoreTimeline history={history} />
-            </div>
-          </section>
-
           {/* 퀘스트별 최고점 바 차트 */}
           <section style={{ marginBottom: 28 }}>
             <div
@@ -179,7 +165,63 @@ export function GrowthDashboard() {
             </div>
           </section>
 
-          {/* ACT별 합격률 */}
+          {/* 차트 탭 섹션 */}
+          <section style={{ marginBottom: 28 }}>
+            {/* 탭 바 */}
+            <div
+              style={{
+                overflowX: 'auto',
+                whiteSpace: 'nowrap',
+                borderBottom: '1px solid rgba(255,255,255,0.08)',
+                marginBottom: 12,
+              }}
+            >
+              {CHART_TABS.map((tab) => {
+                const isActive = selectedChart === tab.key
+                return (
+                  <button
+                    key={tab.key}
+                    onClick={() => setSelectedChart(tab.key)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      padding: '8px 12px',
+                      background: 'none',
+                      border: 'none',
+                      borderBottom: isActive ? '2px solid #4ECDC4' : '2px solid transparent',
+                      color: isActive ? '#4ECDC4' : '#64748B',
+                      fontSize: 12,
+                      fontFamily: "'Courier New', monospace",
+                      cursor: 'pointer',
+                      whiteSpace: 'nowrap',
+                      marginBottom: -1,
+                      transition: 'color 0.15s ease',
+                    }}
+                  >
+                    {tab.label}
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* 선택된 차트 */}
+            <div
+              style={{
+                background: '#0F172A',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 10,
+                padding: '16px 8px 8px',
+              }}
+            >
+              {selectedChart === 'score' && <ScoreTimeline history={history} />}
+              {selectedChart === 'act' && <ActPassRate history={history} />}
+              {selectedChart === 'grade' && <GradeDistribution history={history} />}
+              {selectedChart === 'hourly' && <HourlyActivity history={history} />}
+              {selectedChart === 'quest' && <QuestAttemptCount history={history} />}
+            </div>
+          </section>
+
+          {/* 연속 스트릭 (항상 표시) */}
           <section style={{ marginBottom: 28 }}>
             <div
               style={{
@@ -190,125 +232,23 @@ export function GrowthDashboard() {
                 letterSpacing: '0.05em',
               }}
             >
-              ACT별 합격률
+              연속 학습 스트릭
             </div>
             <div
               style={{
                 background: '#0F172A',
                 border: '1px solid rgba(255,255,255,0.08)',
                 borderRadius: 10,
-                padding: '16px 8px 8px',
+                padding: '8px',
+                display: 'flex',
+                alignItems: 'center',
               }}
             >
-              <ActPassRate history={history} />
+              <StreakBadge history={history} />
             </div>
           </section>
 
-          {/* 등급 분포 + 연속 스트릭 */}
-          <section style={{ marginBottom: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16 }}>
-            <div>
-              <div
-                style={{
-                  fontSize: 12,
-                  color: '#94A3B8',
-                  marginBottom: 10,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                }}
-              >
-                등급 분포
-              </div>
-              <div
-                style={{
-                  background: '#0F172A',
-                  border: '1px solid rgba(255,255,255,0.08)',
-                  borderRadius: 10,
-                  padding: '16px 8px 8px',
-                  height: '100%',
-                }}
-              >
-                <GradeDistribution history={history} />
-              </div>
-            </div>
-            <div>
-              <div
-                style={{
-                  fontSize: 12,
-                  color: '#94A3B8',
-                  marginBottom: 10,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                }}
-              >
-                연속 학습 스트릭
-              </div>
-              <div
-                style={{
-                  background: '#0F172A',
-                  border: '1px solid rgba(255,255,255,0.08)',
-                  borderRadius: 10,
-                  padding: '8px',
-                  height: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-              >
-                <StreakBadge history={history} />
-              </div>
-            </div>
-          </section>
-
-          {/* 시간대별 활동 */}
-          <section style={{ marginBottom: 28 }}>
-            <div
-              style={{
-                fontSize: 12,
-                color: '#94A3B8',
-                marginBottom: 10,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              시간대별 활동
-            </div>
-            <div
-              style={{
-                background: '#0F172A',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 10,
-                padding: '16px 8px 8px',
-              }}
-            >
-              <HourlyActivity history={history} />
-            </div>
-          </section>
-
-          {/* 퀘스트별 시도 횟수 */}
-          <section style={{ marginBottom: 28 }}>
-            <div
-              style={{
-                fontSize: 12,
-                color: '#94A3B8',
-                marginBottom: 10,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              퀘스트별 시도 횟수 (많은 순)
-            </div>
-            <div
-              style={{
-                background: '#0F172A',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 10,
-                padding: '16px 8px 8px',
-              }}
-            >
-              <QuestAttemptCount history={history} />
-            </div>
-          </section>
-
-          {/* 최근 시도 목록 */}
+          {/* 최근 시도 목록 (항상 표시) */}
           <section>
             <div
               style={{

--- a/fe/src/features/growth/components/GrowthDashboard.tsx
+++ b/fe/src/features/growth/components/GrowthDashboard.tsx
@@ -169,6 +169,7 @@ export function GrowthDashboard() {
           <section style={{ marginBottom: 28 }}>
             {/* 탭 바 */}
             <div
+              role="tablist"
               style={{
                 overflowX: 'auto',
                 whiteSpace: 'nowrap',
@@ -181,6 +182,8 @@ export function GrowthDashboard() {
                 return (
                   <button
                     key={tab.key}
+                    role="tab"
+                    aria-selected={isActive}
                     onClick={() => setSelectedChart(tab.key)}
                     style={{
                       display: 'inline-flex',

--- a/fe/src/features/growth/components/HourlyActivity.tsx
+++ b/fe/src/features/growth/components/HourlyActivity.tsx
@@ -21,7 +21,7 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
     if (hour !== null) hourCounts[hour] = (hourCounts[hour] ?? 0) + 1
   }
   const counts = Array.from({ length: 24 }, (_, hour) => ({
-    hour: `${String(hour).padStart(2, '0')}시`,
+    hour,
     count: hourCounts[hour] ?? 0,
   }))
 
@@ -34,10 +34,10 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
           <XAxis
             dataKey="hour"
-            tick={{ fill: '#64748B', fontSize: 9, fontFamily: "'Courier New', monospace" }}
+            tickFormatter={(v: number) => v % 4 === 0 ? `${v}시` : ''}
+            tick={{ fill: '#64748B', fontSize: 11, fontFamily: "'Courier New', monospace" }}
             axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
             tickLine={false}
-            interval={2}
           />
           <YAxis
             allowDecimals={false}
@@ -56,6 +56,7 @@ export function HourlyActivity({ history }: HourlyActivityProps) {
               color: '#F8FAFC',
             }}
             formatter={(value) => [`${value}회`, '시도']}
+            labelFormatter={(label) => `${label}시`}
             labelStyle={{ color: '#94A3B8' }}
           />
           <Bar dataKey="count" fill="#60A5FA" radius={[2, 2, 0, 0]} />


### PR DESCRIPTION
## 변경 사항

### 1. AI 검사 폼 다단계화
- 폼 필드 2~6개를 한 번에 보여주던 방식 → 필드 하나씩 스텝 방식으로 전환
- 상단 dot 진행 표시기 (완료: #4ECDC4, 미완료: 반투명)
- "이전 / 다음 / 제출" 버튼으로 스텝 이동, 현재 필드 빈 값 시 진행 불가
- 단일 필드 퀘스트(developer-class 등)는 기존 단일 폼 유지

### 2. 성장 차트 탭 네비게이션
- 5개 차트(점수 추이 / ACT 합격률 / 등급 분포 / 시간대 / 퀘스트) 수직 나열 → 탭으로 전환
- 탭 바 가로 스크롤 지원, 선택된 탭 #4ECDC4 강조
- StreakBadge + QuestHistoryList는 탭 외부 유지

### 3. HourlyActivity x축 가독성 개선
- 0~23 모든 레이블 → 4시간 간격(0시, 4시, 8시, 12시, 16시, 20시)만 표시
- 480px 화면에서 레이블 겹침 해소

### 4. 코딩 에디터 모바일 최적화
- 모바일(< 768px)에서 Monaco 옵션 조정: fontSize 13, wordWrap on, lineNumbers off
- 코드 입력 영역 확보 및 줄바꿈 지원

## 검증
- `npx tsc --noEmit` 오류 없음
- `npm run build` ✓ built in 5.06s