### PR TITLE
fix(be): 코딩 로드맵 해금 기준을 고유 문제 수 기준으로 수정

### DIFF
--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
@@ -1,7 +1,11 @@
 package com.devquest.storage.db.core
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface CodingSubmissionRepository : JpaRepository<CodingSubmissionEntity, Long> {
     fun countByUserIdAndCategoryAndPassed(userId: String, category: String, passed: Boolean): Int
+
+    @Query("SELECT COUNT(DISTINCT s.problemId) FROM CodingSubmissionEntity s WHERE s.userId = :userId AND s.category = :category AND s.passed = true")
+    fun countDistinctSolvedProblemsByUserAndCategory(userId: String, category: String): Int
 }

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRoadmapProgressAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRoadmapProgressAdapter.kt
@@ -10,5 +10,5 @@ class CodingRoadmapProgressAdapter(
 ) : CodingRoadmapProgressPort {
 
     override fun countSolvedByUserAndCategory(userId: String, category: String): Int =
-        codingSubmissionRepository.countByUserIdAndCategoryAndPassed(userId, category, true)
+        codingSubmissionRepository.countDistinctSolvedProblemsByUserAndCategory(userId, category)
 }


### PR DESCRIPTION
## 문제

카테고리 해금 조건 카운트가 제출 횟수 기준이라 같은 문제를 여러 번 통과해도 카운트가 쌓였음.

## 수정

`countByUserIdAndCategoryAndPassed` → `COUNT(DISTINCT problemId)` JPQL 쿼리로 교체.

같은 문제를 몇 번 통과해도 1개로 집계. 카테고리당 서로 다른 3문제를 풀어야 다음 카테고리 해금.

## 변경 파일

- `CodingSubmissionRepository.kt` — `@Query` distinct count 메서드 추가
- `CodingRoadmapProgressAdapter.kt` — 신규 메서드 사용으로 전환