### PR TITLE
feat: 코딩 랭크 시스템 — 난이도별 점수 및 LoL 티어 제도

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -55,7 +55,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 | 항목 | 내용 |
 |------|------|
 | 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 열린 PR | #159 — 코딩 랭크 시스템 (머지 대기) |
 
 
 

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/CodingQuestController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/CodingQuestController.kt
@@ -89,6 +89,12 @@ class CodingQuestController(
         return ApiResponse.success(mapOf("level" to level))
     }
 
+    @GetMapping("/rank")
+    fun getRank(@AuthenticationPrincipal userId: String): ApiResponse<*> {
+        val rank = codingQuestService.getRank(userId)
+        return ApiResponse.success(rank)
+    }
+
     @PostMapping("/hint")
     fun getHint(
         @AuthenticationPrincipal _userId: String,

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
@@ -15,6 +15,7 @@ import com.devquest.core.domain.port.CodingSubmissionPort
 import com.devquest.core.domain.port.Judge0Port
 import com.devquest.core.domain.port.UserCodingLevelPort
 import java.time.LocalDate
+import java.time.ZoneId
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -245,7 +246,7 @@ class CodingQuestService(
 
     private fun calculateStreak(solvedDates: Set<LocalDate>): Int {
         if (solvedDates.isEmpty()) return 0
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         // 오늘 또는 어제부터 역산
         val startDate = if (solvedDates.contains(today)) today else today.minusDays(1)
         if (!solvedDates.contains(startDate)) return 0

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
@@ -3,15 +3,18 @@ package com.devquest.core.domain
 import com.devquest.core.domain.model.coding.CategoryProgressResult
 import com.devquest.core.domain.model.coding.CodingHint
 import com.devquest.core.domain.model.coding.CodingProblem
+import com.devquest.core.domain.model.coding.CodingRankResult
 import com.devquest.core.domain.model.coding.CodingSubmissionResult
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.port.CodingHintPort
 import com.devquest.core.domain.port.CodingProblemGeneratorPort
 import com.devquest.core.domain.port.CodingProblemPort
+import com.devquest.core.domain.port.CodingRankPort
 import com.devquest.core.domain.port.CodingRoadmapProgressPort
 import com.devquest.core.domain.port.CodingSubmissionPort
 import com.devquest.core.domain.port.Judge0Port
 import com.devquest.core.domain.port.UserCodingLevelPort
+import java.time.LocalDate
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,7 +27,8 @@ class CodingQuestService(
     private val codingSubmissionPort: CodingSubmissionPort,
     private val judge0Port: Judge0Port,
     private val codingHintPort: CodingHintPort,
-    private val codingRoadmapProgressPort: CodingRoadmapProgressPort
+    private val codingRoadmapProgressPort: CodingRoadmapProgressPort,
+    private val codingRankPort: CodingRankPort
 ) {
     private val objectMapper = com.fasterxml.jackson.databind.ObjectMapper()
     private val log = LoggerFactory.getLogger(javaClass)
@@ -35,6 +39,30 @@ class CodingQuestService(
         private const val MAX_RETRY = 2
         private const val LEVEL_UP_INTERVAL = 3
         private const val ROADMAP_UNLOCK_THRESHOLD = 3
+
+        private val TIER_THRESHOLDS = listOf(
+            0 to "아이언",
+            100 to "브론즈",
+            300 to "실버",
+            600 to "골드",
+            1000 to "플래티넘",
+            1500 to "다이아",
+            2500 to "마스터",
+            4000 to "챌린저"
+        )
+
+        fun tierOf(score: Int): String =
+            TIER_THRESHOLDS.lastOrNull { score >= it.first }?.second ?: "아이언"
+
+        fun nextTierInfo(score: Int): Pair<String?, Int?> {
+            val idx = TIER_THRESHOLDS.indexOfLast { score >= it.first }
+            return if (idx < TIER_THRESHOLDS.size - 1) {
+                val next = TIER_THRESHOLDS[idx + 1]
+                next.second to next.first
+            } else {
+                null to null
+            }
+        }
 
         fun difficultyForLevel(level: Int): String = when {
             level <= 3 -> "EASY"
@@ -169,6 +197,66 @@ class CodingQuestService(
 
     fun getLevel(userId: String): Int {
         return userCodingLevelPort.getLevel(userId)
+    }
+
+    fun getRank(userId: String): CodingRankResult {
+        val records = codingRankPort.findPassedRecords(userId)
+
+        // 고유 문제별 첫 통과 날짜로 집계
+        val uniqueByProblem = records
+            .groupBy { it.problemId }
+            .mapValues { (_, list) -> list.minBy { it.passedDate } }
+            .values.toList()
+
+        val easyCount = uniqueByProblem.count { it.difficulty == "EASY" }
+        val mediumCount = uniqueByProblem.count { it.difficulty == "MEDIUM" }
+        val hardCount = uniqueByProblem.count { it.difficulty == "HARD" }
+
+        // 난이도별 기본 점수
+        val baseScore = easyCount * 10 + mediumCount * 25 + hardCount * 50
+
+        // 날짜별 그룹화 → 각 날 첫 문제에 +5점 일일 보너스
+        val dailyBonus = uniqueByProblem
+            .groupBy { it.passedDate }
+            .size * 5
+
+        // 연속 스트릭 계산
+        val solvedDates = uniqueByProblem.map { it.passedDate }.toSortedSet()
+        val currentStreak = calculateStreak(solvedDates)
+
+        val streakBonus = currentStreak * 2
+        val totalScore = baseScore + dailyBonus + streakBonus
+
+        val tier = tierOf(totalScore)
+        val (nextTier, nextTierScore) = nextTierInfo(totalScore)
+
+        log.info("코딩 랭크 조회: userId=$userId, score=$totalScore, tier=$tier, streak=$currentStreak")
+        return CodingRankResult(
+            totalScore = totalScore,
+            tier = tier,
+            nextTier = nextTier,
+            nextTierScore = nextTierScore,
+            easyCount = easyCount,
+            mediumCount = mediumCount,
+            hardCount = hardCount,
+            currentStreak = currentStreak
+        )
+    }
+
+    private fun calculateStreak(solvedDates: Set<LocalDate>): Int {
+        if (solvedDates.isEmpty()) return 0
+        val today = LocalDate.now()
+        // 오늘 또는 어제부터 역산
+        val startDate = if (solvedDates.contains(today)) today else today.minusDays(1)
+        if (!solvedDates.contains(startDate)) return 0
+
+        var streak = 0
+        var current = startDate
+        while (solvedDates.contains(current)) {
+            streak++
+            current = current.minusDays(1)
+        }
+        return streak
     }
 
     fun getHint(problemId: Long, title: String, description: String, hintLevel: Int): CodingHint {

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
@@ -206,7 +206,7 @@ class CodingQuestService(
         // 고유 문제별 첫 통과 날짜로 집계
         val uniqueByProblem = records
             .groupBy { it.problemId }
-            .mapValues { (_, list) -> list.minBy { it.passedDate } }
+            .mapValues { (_, list) -> list.minByOrNull { it.passedDate } ?: list.first() }
             .values.toList()
 
         val easyCount = uniqueByProblem.count { it.difficulty == "EASY" }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
@@ -5,13 +5,16 @@ import com.devquest.core.domain.model.coding.CodingProblem
 import com.devquest.core.domain.model.coding.CodingProblemGenerationResult
 import com.devquest.core.domain.model.coding.TestCase
 import com.devquest.core.domain.port.CodingHintPort
+import com.devquest.core.domain.port.CodingPassRecord
 import com.devquest.core.domain.port.CodingProblemGeneratorPort
 import com.devquest.core.domain.port.CodingProblemPort
+import com.devquest.core.domain.port.CodingRankPort
 import com.devquest.core.domain.port.CodingRoadmapProgressPort
 import com.devquest.core.domain.port.CodingSubmissionPort
 import com.devquest.core.domain.port.Judge0Port
 import com.devquest.core.domain.port.Judge0Result
 import com.devquest.core.domain.port.UserCodingLevelPort
+import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -34,6 +37,7 @@ class CodingQuestServiceTest {
     @Mock lateinit var judge0Port: Judge0Port
     @Mock lateinit var codingHintPort: CodingHintPort
     @Mock lateinit var codingRoadmapProgressPort: CodingRoadmapProgressPort
+    @Mock lateinit var codingRankPort: CodingRankPort
 
     @InjectMocks
     private lateinit var service: CodingQuestService
@@ -189,6 +193,127 @@ class CodingQuestServiceTest {
         org.assertj.core.api.Assertions.assertThatThrownBy {
             service.getHint(1L, "제목", "설명", 4)
         }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ===== getRank 테스트 =====
+
+    @Test
+    fun `getRank - 통과 기록이 없으면 totalScore=0, tier=아이언 반환`() {
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(emptyList())
+
+        val result = service.getRank("user1")
+
+        assertThat(result.totalScore).isEqualTo(0)
+        assertThat(result.tier).isEqualTo("아이언")
+        assertThat(result.easyCount).isEqualTo(0)
+        assertThat(result.mediumCount).isEqualTo(0)
+        assertThat(result.hardCount).isEqualTo(0)
+        assertThat(result.currentStreak).isEqualTo(0)
+    }
+
+    @Test
+    fun `getRank - EASY 1문제 통과 시 기본 점수 10점`() {
+        val today = LocalDate.now()
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
+            listOf(CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = today))
+        )
+
+        val result = service.getRank("user1")
+
+        // EASY 10점 + 일일 보너스 5점 + 스트릭 1일 × 2점 = 17점
+        assertThat(result.totalScore).isEqualTo(17)
+        assertThat(result.easyCount).isEqualTo(1)
+        assertThat(result.tier).isEqualTo("아이언")
+    }
+
+    @Test
+    fun `getRank - 같은 문제 여러 번 통과해도 1회만 계산`() {
+        val today = LocalDate.now()
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
+            listOf(
+                CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = today),
+                CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = today)
+            )
+        )
+
+        val result = service.getRank("user1")
+
+        assertThat(result.easyCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `getRank - 100점 이상이면 브론즈 티어`() {
+        val today = LocalDate.now()
+        // MEDIUM 4문제(고유) = 4 × 25 = 100점 + 일일 보너스 5점 + 스트릭 1일 × 2점 = 107점
+        val records = (1L..4L).map {
+            CodingPassRecord(problemId = it, difficulty = "MEDIUM", passedDate = today)
+        }
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(records)
+
+        val result = service.getRank("user1")
+
+        assertThat(result.tier).isEqualTo("브론즈")
+        assertThat(result.mediumCount).isEqualTo(4)
+    }
+
+    @Test
+    fun `getRank - 연속 2일 풀이 시 스트릭=2, 보너스 4점 추가`() {
+        val today = LocalDate.now()
+        val yesterday = today.minusDays(1)
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
+            listOf(
+                CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = yesterday),
+                CodingPassRecord(problemId = 2L, difficulty = "EASY", passedDate = today)
+            )
+        )
+
+        val result = service.getRank("user1")
+
+        assertThat(result.currentStreak).isEqualTo(2)
+        // EASY 2문제 × 10 = 20점 + 일일 보너스 2일 × 5 = 10점 + 스트릭 2 × 2 = 4점 = 34점
+        assertThat(result.totalScore).isEqualTo(34)
+    }
+
+    @Test
+    fun `getRank - 오늘 풀이가 없고 어제까지 연속 풀었으면 스트릭 유지`() {
+        val yesterday = LocalDate.now().minusDays(1)
+        val dayBefore = LocalDate.now().minusDays(2)
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
+            listOf(
+                CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = dayBefore),
+                CodingPassRecord(problemId = 2L, difficulty = "EASY", passedDate = yesterday)
+            )
+        )
+
+        val result = service.getRank("user1")
+
+        assertThat(result.currentStreak).isEqualTo(2)
+    }
+
+    @Test
+    fun `getRank - nextTier와 nextTierScore가 올바르게 반환`() {
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(emptyList())
+
+        val result = service.getRank("user1")
+
+        assertThat(result.nextTier).isEqualTo("브론즈")
+        assertThat(result.nextTierScore).isEqualTo(100)
+    }
+
+    @Test
+    fun `getRank - 챌린저 티어는 nextTier가 null`() {
+        val today = LocalDate.now()
+        // HARD 80문제(고유) = 80 × 50 = 4000점 이상 → 챌린저
+        val records = (1L..80L).map {
+            CodingPassRecord(problemId = it, difficulty = "HARD", passedDate = today)
+        }
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(records)
+
+        val result = service.getRank("user1")
+
+        assertThat(result.tier).isEqualTo("챌린저")
+        assertThat(result.nextTier).isNull()
+        assertThat(result.nextTierScore).isNull()
     }
 
     @Test

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
@@ -5,7 +5,7 @@ import com.devquest.core.domain.model.coding.CodingProblem
 import com.devquest.core.domain.model.coding.CodingProblemGenerationResult
 import com.devquest.core.domain.model.coding.TestCase
 import com.devquest.core.domain.port.CodingHintPort
-import com.devquest.core.domain.port.CodingPassRecord
+import com.devquest.core.domain.model.coding.CodingPassRecord
 import com.devquest.core.domain.port.CodingProblemGeneratorPort
 import com.devquest.core.domain.port.CodingProblemPort
 import com.devquest.core.domain.port.CodingRankPort
@@ -15,6 +15,7 @@ import com.devquest.core.domain.port.Judge0Port
 import com.devquest.core.domain.port.Judge0Result
 import com.devquest.core.domain.port.UserCodingLevelPort
 import java.time.LocalDate
+import java.time.ZoneId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -213,7 +214,7 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - EASY 1문제 통과 시 기본 점수 10점`() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
             listOf(CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = today))
         )
@@ -228,7 +229,7 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - 같은 문제 여러 번 통과해도 1회만 계산`() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
             listOf(
                 CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = today),
@@ -243,7 +244,7 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - 100점 이상이면 브론즈 티어`() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         // MEDIUM 4문제(고유) = 4 × 25 = 100점 + 일일 보너스 5점 + 스트릭 1일 × 2점 = 107점
         val records = (1L..4L).map {
             CodingPassRecord(problemId = it, difficulty = "MEDIUM", passedDate = today)
@@ -258,7 +259,7 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - 연속 2일 풀이 시 스트릭=2, 보너스 4점 추가`() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         val yesterday = today.minusDays(1)
         whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
             listOf(
@@ -276,8 +277,9 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - 오늘 풀이가 없고 어제까지 연속 풀었으면 스트릭 유지`() {
-        val yesterday = LocalDate.now().minusDays(1)
-        val dayBefore = LocalDate.now().minusDays(2)
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val yesterday = today.minusDays(1)
+        val dayBefore = today.minusDays(2)
         whenever(codingRankPort.findPassedRecords("user1")).thenReturn(
             listOf(
                 CodingPassRecord(problemId = 1L, difficulty = "EASY", passedDate = dayBefore),
@@ -302,7 +304,7 @@ class CodingQuestServiceTest {
 
     @Test
     fun `getRank - 챌린저 티어는 nextTier가 null`() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         // HARD 80문제(고유) = 80 × 50 = 4000점 이상 → 챌린저
         val records = (1L..80L).map {
             CodingPassRecord(problemId = it, difficulty = "HARD", passedDate = today)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingPassRecord.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingPassRecord.kt
@@ -1,0 +1,9 @@
+package com.devquest.core.domain.model.coding
+
+import java.time.LocalDate
+
+data class CodingPassRecord(
+    val problemId: Long,
+    val difficulty: String,
+    val passedDate: LocalDate
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingRankResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingRankResult.kt
@@ -1,0 +1,12 @@
+package com.devquest.core.domain.model.coding
+
+data class CodingRankResult(
+    val totalScore: Int = 0,
+    val tier: String = "아이언",
+    val nextTier: String? = "브론즈",
+    val nextTierScore: Int? = 100,
+    val easyCount: Int = 0,
+    val mediumCount: Int = 0,
+    val hardCount: Int = 0,
+    val currentStreak: Int = 0
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
@@ -1,12 +1,6 @@
 package com.devquest.core.domain.port
 
-import java.time.LocalDate
-
-data class CodingPassRecord(
-    val problemId: Long,
-    val difficulty: String,
-    val passedDate: LocalDate
-)
+import com.devquest.core.domain.model.coding.CodingPassRecord
 
 interface CodingRankPort {
     fun findPassedRecords(userId: String): List<CodingPassRecord>

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
@@ -1,0 +1,13 @@
+package com.devquest.core.domain.port
+
+import java.time.LocalDate
+
+data class CodingPassRecord(
+    val problemId: Long,
+    val difficulty: String,
+    val passedDate: LocalDate
+)
+
+interface CodingRankPort {
+    fun findPassedRecords(userId: String): List<CodingPassRecord>
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingPassRecordRow.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingPassRecordRow.kt
@@ -1,0 +1,9 @@
+package com.devquest.storage.db.core
+
+import java.time.LocalDateTime
+
+data class CodingPassRecordRow(
+    val problemId: Long,
+    val difficulty: String,
+    val createdAt: LocalDateTime
+)

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
@@ -8,4 +8,12 @@ interface CodingSubmissionRepository : JpaRepository<CodingSubmissionEntity, Lon
 
     @Query("SELECT COUNT(DISTINCT s.problemId) FROM CodingSubmissionEntity s WHERE s.userId = :userId AND s.category = :category AND s.passed = true")
     fun countDistinctSolvedProblemsByUserAndCategory(userId: String, category: String): Int
+
+    @Query("""
+        SELECT s.problemId, p.difficulty, s.createdAt
+        FROM CodingSubmissionEntity s
+        JOIN CodingProblemEntity p ON s.problemId = p.id
+        WHERE s.userId = :userId AND s.passed = true
+    """)
+    fun findPassedRecordsWithDifficulty(userId: String): List<Array<Any>>
 }

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CodingSubmissionRepository.kt
@@ -10,10 +10,10 @@ interface CodingSubmissionRepository : JpaRepository<CodingSubmissionEntity, Lon
     fun countDistinctSolvedProblemsByUserAndCategory(userId: String, category: String): Int
 
     @Query("""
-        SELECT s.problemId, p.difficulty, s.createdAt
+        SELECT new com.devquest.storage.db.core.CodingPassRecordRow(s.problemId, p.difficulty, s.createdAt)
         FROM CodingSubmissionEntity s
         JOIN CodingProblemEntity p ON s.problemId = p.id
         WHERE s.userId = :userId AND s.passed = true
     """)
-    fun findPassedRecordsWithDifficulty(userId: String): List<Array<Any>>
+    fun findPassedRecordsWithDifficulty(userId: String): List<CodingPassRecordRow>
 }

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
@@ -1,0 +1,26 @@
+package com.devquest.storage.db.core.adapter
+
+import com.devquest.core.domain.port.CodingPassRecord
+import com.devquest.core.domain.port.CodingRankPort
+import com.devquest.storage.db.core.CodingSubmissionRepository
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class CodingRankAdapter(
+    private val submissionRepository: CodingSubmissionRepository
+) : CodingRankPort {
+
+    override fun findPassedRecords(userId: String): List<CodingPassRecord> {
+        return submissionRepository.findPassedRecordsWithDifficulty(userId).map { row ->
+            val problemId = (row[0] as Number).toLong()
+            val difficulty = row[1] as String
+            val createdAt = row[2] as LocalDateTime
+            CodingPassRecord(
+                problemId = problemId,
+                difficulty = difficulty,
+                passedDate = createdAt.toLocalDate()
+            )
+        }
+    }
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
@@ -1,10 +1,9 @@
 package com.devquest.storage.db.core.adapter
 
-import com.devquest.core.domain.port.CodingPassRecord
+import com.devquest.core.domain.model.coding.CodingPassRecord
 import com.devquest.core.domain.port.CodingRankPort
 import com.devquest.storage.db.core.CodingSubmissionRepository
 import org.springframework.stereotype.Component
-import java.time.LocalDateTime
 
 @Component
 class CodingRankAdapter(
@@ -13,17 +12,10 @@ class CodingRankAdapter(
 
     override fun findPassedRecords(userId: String): List<CodingPassRecord> {
         return submissionRepository.findPassedRecordsWithDifficulty(userId).map { row ->
-            val problemId = (row[0] as Number).toLong()
-            val difficulty = row[1] as String
-            val createdAt = when (val raw = row[2]) {
-                is LocalDateTime -> raw
-                is java.sql.Timestamp -> raw.toLocalDateTime()
-                else -> LocalDateTime.parse(raw.toString())
-            }
             CodingPassRecord(
-                problemId = problemId,
-                difficulty = difficulty,
-                passedDate = createdAt.toLocalDate()
+                problemId = row.problemId,
+                difficulty = row.difficulty,
+                passedDate = row.createdAt.toLocalDate()
             )
         }
     }

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
@@ -15,7 +15,11 @@ class CodingRankAdapter(
         return submissionRepository.findPassedRecordsWithDifficulty(userId).map { row ->
             val problemId = (row[0] as Number).toLong()
             val difficulty = row[1] as String
-            val createdAt = row[2] as LocalDateTime
+            val createdAt = when (val raw = row[2]) {
+                is LocalDateTime -> raw
+                is java.sql.Timestamp -> raw.toLocalDateTime()
+                else -> LocalDateTime.parse(raw.toString())
+            }
             CodingPassRecord(
                 problemId = problemId,
                 difficulty = difficulty,

--- a/fe/src/features/coding-quest/components/CodingRankCard.tsx
+++ b/fe/src/features/coding-quest/components/CodingRankCard.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect } from 'react'
+import type { CodingRankResult } from '@/types/api.types'
+import { fetchCodingRank } from '@/lib/apiClient'
+
+const TIER_COLORS: Record<string, string> = {
+  아이언: '#9CA3AF',
+  브론즈: '#CD7F32',
+  실버: '#94A3B8',
+  골드: '#F59E0B',
+  플래티넘: '#06B6D4',
+  다이아: '#60A5FA',
+  마스터: '#A78BFA',
+  챌린저: '#4ECDC4',
+}
+
+function getTierColor(tier: string): string {
+  return TIER_COLORS[tier] ?? '#94A3B8'
+}
+
+export function CodingRankCard() {
+  const [rank, setRank] = useState<CodingRankResult | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchCodingRank()
+      .then((data) => {
+        setRank(data)
+        setLoading(false)
+      })
+      .catch(() => {
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 12,
+          padding: '16px 20px',
+          marginBottom: 16,
+          fontFamily: "'Courier New', monospace",
+          color: '#475569',
+          fontSize: 13,
+          textAlign: 'center',
+        }}
+      >
+        랭크 정보 불러오는 중...
+      </div>
+    )
+  }
+
+  if (rank == null) return null
+
+  const tierColor = getTierColor(rank.tier)
+  const isChallenger = rank.nextTier == null
+  const progressPct = isChallenger
+    ? 100
+    : rank.nextTierScore != null && rank.nextTierScore > 0
+      ? Math.min(Math.round((rank.totalScore / rank.nextTierScore) * 100), 100)
+      : 0
+
+  return (
+    <div
+      style={{
+        background: '#0F172A',
+        border: `1px solid ${tierColor}40`,
+        borderRadius: 12,
+        padding: '16px 20px',
+        marginBottom: 16,
+        fontFamily: "'Courier New', monospace",
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* 좌측 티어 색상 바 */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: 3,
+          background: tierColor,
+          borderRadius: '12px 0 0 12px',
+        }}
+      />
+
+      {/* 상단: 티어 + 점수 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 10,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 16 }}>🏆</span>
+          <span
+            style={{
+              fontSize: 16,
+              fontWeight: 700,
+              color: tierColor,
+              fontFamily: "'Courier New', monospace",
+            }}
+          >
+            {rank.tier}
+          </span>
+        </div>
+        <span
+          style={{
+            fontSize: 18,
+            fontWeight: 700,
+            color: '#F8FAFC',
+            fontFamily: "'Courier New', monospace",
+          }}
+        >
+          {rank.totalScore}점
+        </span>
+      </div>
+
+      {/* 진행도 바 */}
+      <div style={{ marginBottom: 6 }}>
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.08)',
+            borderRadius: 4,
+            height: 6,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${progressPct}%`,
+              height: '100%',
+              background: tierColor,
+              borderRadius: 4,
+              transition: 'width 0.4s ease',
+            }}
+          />
+        </div>
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 11,
+            color: '#475569',
+            fontFamily: "'Courier New', monospace",
+            textAlign: 'right',
+          }}
+        >
+          {isChallenger
+            ? '최고 티어 달성!'
+            : `${rank.nextTier}까지 ${(rank.nextTierScore ?? 0) - rank.totalScore}점`}
+        </div>
+      </div>
+
+      {/* 문제 수 행 */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 16,
+          marginTop: 12,
+          paddingTop: 12,
+          borderTop: '1px solid rgba(255,255,255,0.06)',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12,
+            fontFamily: "'Courier New', monospace",
+            color: '#10B981',
+          }}
+        >
+          EASY ×{rank.easyCount}
+        </span>
+        <span
+          style={{
+            fontSize: 12,
+            fontFamily: "'Courier New', monospace",
+            color: '#F59E0B',
+          }}
+        >
+          MEDIUM ×{rank.mediumCount}
+        </span>
+        <span
+          style={{
+            fontSize: 12,
+            fontFamily: "'Courier New', monospace",
+            color: '#EF4444',
+          }}
+        >
+          HARD ×{rank.hardCount}
+        </span>
+      </div>
+
+      {/* 스트릭 행 (0이면 숨김) */}
+      {rank.currentStreak > 0 && (
+        <div
+          style={{
+            marginTop: 10,
+            fontSize: 12,
+            fontFamily: "'Courier New', monospace",
+            color: '#F59E0B',
+          }}
+        >
+          🔥 {rank.currentStreak}일 연속 풀이 중
+        </div>
+      )}
+    </div>
+  )
+}

--- a/fe/src/features/coding-quest/components/CodingRoadmapPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingRoadmapPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import type { CategoryProgress } from '@/types/api.types'
 import { fetchCodingRoadmap } from '@/lib/apiClient'
 import { ProgressBar } from '@/components/ui/ProgressBar'
+import { CodingRankCard } from './CodingRankCard'
 
 export interface CodingRoadmapPageProps {
   onBack: () => void
@@ -219,6 +220,7 @@ export function CodingRoadmapPage({ onBack, onSelectCategory }: CodingRoadmapPag
             gap: 10,
           }}
         >
+          <CodingRankCard />
           {loading ? (
             <p
               style={{

--- a/fe/src/features/coding-quest/index.ts
+++ b/fe/src/features/coding-quest/index.ts
@@ -1,5 +1,6 @@
 export { CodingQuestPage } from './components/CodingQuestPage'
 export { CodingRoadmapPage } from './components/CodingRoadmapPage'
+export { CodingRankCard } from './components/CodingRankCard'
 export { HintSection } from './components/HintSection'
 export { fetchHint } from './api/fetchHint'
 export type { HintResult } from './api/fetchHint'

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult, CategoryProgress } from '@/types/api.types'
+import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult, CategoryProgress, CodingRankResult } from '@/types/api.types'
 import { getToken, clearToken } from '@/hooks/useAuth'
 import { STORAGE_KEYS } from '@/lib/storageKeys'
 
@@ -149,6 +149,14 @@ export async function submitCode(problemId: number, language: string, userCode: 
   assertOk(res)
   const json: ApiResponse<CodingSubmissionResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코드 제출 실패')
+  return json.data
+}
+
+export async function fetchCodingRank(): Promise<CodingRankResult> {
+  const res = await fetch(`${API_BASE}/coding/rank`, { headers: authHeaders() })
+  assertOk(res)
+  const json: ApiResponse<CodingRankResult> = await res.json()
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('코딩 랭크 조회 실패')
   return json.data
 }
 

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -198,6 +198,17 @@ export interface CodingLevelResult {
   level: number
 }
 
+export interface CodingRankResult {
+  totalScore: number
+  tier: string
+  nextTier: string | null
+  nextTierScore: number | null
+  easyCount: number
+  mediumCount: number
+  hardCount: number
+  currentStreak: number
+}
+
 export interface CodingQuestState {
   language: 'JAVA' | 'KOTLIN'
   problem: CodingProblem | null


### PR DESCRIPTION
## 기능

코딩 연습 로드맵에 LoL 티어 기반 랭크 시스템 추가.

## 점수 체계

| 난이도 | 점수 |
|--------|------|
| EASY | 10점 |
| MEDIUM | 25점 |
| HARD | 50점 |

- 일일 첫 풀이 보너스: +5점
- 연속 풀이 스트릭 보너스: 스트릭 일수 × 2점

## 티어

아이언 → 브론즈 → 실버 → 골드 → 플래티넘 → 다이아 → 마스터 → 챌린저

## 변경 내역

**BE**
- `GET /api/v1/coding/rank` 엔드포인트 추가
- `CodingRankResult` 도메인 모델 및 `CodingRankPort` 추가
- `CodingRankAdapter` — JPQL JOIN으로 difficulty 조회
- `CodingQuestService.getRank()` — 서비스 레이어 점수 계산 (KST 타임존 고정)
- 테스트 9케이스 추가

**FE**
- `CodingRankCard` 컴포넌트 신규 추가
- `CodingRoadmapPage` 상단에 랭크 카드 삽입
- `fetchCodingRank()` API 클라이언트 추가