### PR TITLE
feat(coding): 카테고리별 코딩 풀이 레이더 차트 추가

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -54,8 +54,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `feat/coding-rank-radar-chart` |
+| 열린 PR | #160 — 카테고리별 코딩 풀이 레이더 차트 (머지 대기) |
 
 
 
@@ -64,6 +64,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #160 | 카테고리별 코딩 풀이 레이더 차트 (SVG, 9축) | 2026-05-31 |
 | #159 | 코딩 랭크 시스템 — LoL 티어, 난이도별 점수, 스트릭 보너스 | 2026-05-30 |
 | #158 | 코딩 로드맵 해금 기준 — 고유 문제 수(DISTINCT) 기준으로 수정 | 2026-05-30 |
 | #157 | 코딩 문제 로드맵 — 카테고리별 단계적 문제 풀기 (9개 카테고리, 잠금/해금) | 2026-05-29 |

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CodingQuestService.kt
@@ -231,6 +231,10 @@ class CodingQuestService(
         val tier = tierOf(totalScore)
         val (nextTier, nextTierScore) = nextTierInfo(totalScore)
 
+        val categoryStats = ROADMAP_CATEGORIES.associate { (cat, _, _) ->
+            cat to codingRankPort.countSolvedByCategory(userId, cat)
+        }
+
         log.info("코딩 랭크 조회: userId=$userId, score=$totalScore, tier=$tier, streak=$currentStreak")
         return CodingRankResult(
             totalScore = totalScore,
@@ -240,7 +244,8 @@ class CodingQuestService(
             easyCount = easyCount,
             mediumCount = mediumCount,
             hardCount = hardCount,
-            currentStreak = currentStreak
+            currentStreak = currentStreak,
+            categoryStats = categoryStats
         )
     }
 

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CodingQuestServiceTest.kt
@@ -303,6 +303,28 @@ class CodingQuestServiceTest {
     }
 
     @Test
+    fun `getRank - categoryStats에 9개 카테고리별 풀이 수가 포함`() {
+        whenever(codingRankPort.findPassedRecords("user1")).thenReturn(emptyList())
+        whenever(codingRankPort.countSolvedByCategory("user1", "ARRAY")).thenReturn(3)
+        whenever(codingRankPort.countSolvedByCategory("user1", "HASH_MAP")).thenReturn(1)
+        whenever(codingRankPort.countSolvedByCategory("user1", "STACK_QUEUE")).thenReturn(0)
+        whenever(codingRankPort.countSolvedByCategory("user1", "BINARY_SEARCH")).thenReturn(0)
+        whenever(codingRankPort.countSolvedByCategory("user1", "RECURSION")).thenReturn(2)
+        whenever(codingRankPort.countSolvedByCategory("user1", "TREE")).thenReturn(0)
+        whenever(codingRankPort.countSolvedByCategory("user1", "GRAPH")).thenReturn(0)
+        whenever(codingRankPort.countSolvedByCategory("user1", "GREEDY")).thenReturn(0)
+        whenever(codingRankPort.countSolvedByCategory("user1", "DP")).thenReturn(0)
+
+        val result = service.getRank("user1")
+
+        assertThat(result.categoryStats).hasSize(9)
+        assertThat(result.categoryStats["ARRAY"]).isEqualTo(3)
+        assertThat(result.categoryStats["HASH_MAP"]).isEqualTo(1)
+        assertThat(result.categoryStats["RECURSION"]).isEqualTo(2)
+        assertThat(result.categoryStats["DP"]).isEqualTo(0)
+    }
+
+    @Test
     fun `getRank - 챌린저 티어는 nextTier가 null`() {
         val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         // HARD 80문제(고유) = 80 × 50 = 4000점 이상 → 챌린저

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingRankResult.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/coding/CodingRankResult.kt
@@ -8,5 +8,6 @@ data class CodingRankResult(
     val easyCount: Int = 0,
     val mediumCount: Int = 0,
     val hardCount: Int = 0,
-    val currentStreak: Int = 0
+    val currentStreak: Int = 0,
+    val categoryStats: Map<String, Int> = emptyMap()
 )

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CodingRankPort.kt
@@ -4,4 +4,5 @@ import com.devquest.core.domain.model.coding.CodingPassRecord
 
 interface CodingRankPort {
     fun findPassedRecords(userId: String): List<CodingPassRecord>
+    fun countSolvedByCategory(userId: String, category: String): Int
 }

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CodingRankAdapter.kt
@@ -19,4 +19,8 @@ class CodingRankAdapter(
             )
         }
     }
+
+    override fun countSolvedByCategory(userId: String, category: String): Int {
+        return submissionRepository.countDistinctSolvedProblemsByUserAndCategory(userId, category)
+    }
 }

--- a/fe/src/features/coding-quest/components/CategoryRadarChart.tsx
+++ b/fe/src/features/coding-quest/components/CategoryRadarChart.tsx
@@ -1,0 +1,141 @@
+interface CategoryRadarChartProps {
+  categoryStats: Record<string, number>
+  tierColor: string
+}
+
+const AXES = [
+  { key: 'ARRAY',         label: '배열' },
+  { key: 'HASH_MAP',      label: '해시맵' },
+  { key: 'STACK_QUEUE',   label: '스택/큐' },
+  { key: 'BINARY_SEARCH', label: '이진탐색' },
+  { key: 'RECURSION',     label: '재귀' },
+  { key: 'DP',            label: 'DP' },
+  { key: 'GREEDY',        label: '그리디' },
+  { key: 'GRAPH',         label: '그래프' },
+  { key: 'TREE',          label: '트리' },
+]
+
+const CX = 140
+const CY = 120
+const R = 90
+const N = AXES.length
+
+function getPoint(index: number, radius: number): [number, number] {
+  const angle = (index / N) * 2 * Math.PI - Math.PI / 2
+  return [CX + radius * Math.cos(angle), CY + radius * Math.sin(angle)]
+}
+
+function getTextAnchor(x: number): 'end' | 'start' | 'middle' {
+  if (x < CX - 5) return 'end'
+  if (x > CX + 5) return 'start'
+  return 'middle'
+}
+
+function getDominantBaseline(y: number): 'auto' | 'hanging' | 'middle' {
+  if (y < CY - 5) return 'auto'
+  if (y > CY + 5) return 'hanging'
+  return 'middle'
+}
+
+export function CategoryRadarChart({ categoryStats, tierColor }: CategoryRadarChartProps) {
+  const maxVal = Math.max(5, ...Object.values(categoryStats))
+
+  const gridLevels = [0.25, 0.5, 0.75, 1.0]
+
+  function polygonPoints(ratio: number): string {
+    return AXES.map((_, i) => {
+      const [x, y] = getPoint(i, R * ratio)
+      return `${x},${y}`
+    }).join(' ')
+  }
+
+  const dataPoints = AXES.map((axis, i) => {
+    const val = categoryStats[axis.key] ?? 0
+    const ratio = val / maxVal
+    return getPoint(i, R * ratio)
+  })
+
+  const dataPolygon = dataPoints.map(([x, y]) => `${x},${y}`).join(' ')
+
+  return (
+    <svg
+      width="100%"
+      viewBox="0 0 280 240"
+      style={{ display: 'block' }}
+    >
+      {/* 그리드 레벨 */}
+      {gridLevels.map((ratio) => (
+        <polygon
+          key={ratio}
+          points={polygonPoints(ratio)}
+          fill="rgba(255,255,255,0.02)"
+          stroke="rgba(255,255,255,0.06)"
+          strokeWidth={1}
+        />
+      ))}
+
+      {/* 축 선 */}
+      {AXES.map((_, i) => {
+        const [ex, ey] = getPoint(i, R)
+        return (
+          <line
+            key={i}
+            x1={CX}
+            y1={CY}
+            x2={ex}
+            y2={ey}
+            stroke="rgba(255,255,255,0.10)"
+            strokeWidth={1}
+          />
+        )
+      })}
+
+      {/* 데이터 polygon */}
+      <polygon
+        points={dataPolygon}
+        fill={`${tierColor}26`}
+        stroke={tierColor}
+        strokeWidth={1.5}
+        opacity={0.9}
+      />
+
+      {/* 꼭짓점 원 */}
+      {dataPoints.map(([x, y], i) => {
+        const val = categoryStats[AXES[i]?.key ?? ''] ?? 0
+        return (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r={val === 0 ? 2 : 3.5}
+            fill={tierColor}
+            stroke="#0F172A"
+            strokeWidth={1.5}
+            opacity={val === 0 ? 0.4 : 1}
+          />
+        )
+      })}
+
+      {/* 레이블 */}
+      {AXES.map((axis, i) => {
+        const [ex, ey] = getPoint(i, R + 14)
+        return (
+          <text
+            key={i}
+            x={ex}
+            y={ey}
+            textAnchor={getTextAnchor(ex)}
+            dominantBaseline={getDominantBaseline(ey)}
+            style={{
+              fontSize: 10,
+              fill: '#475569',
+              fontFamily: "'Courier New', monospace",
+            }}
+          >
+            {axis.label}
+          </text>
+        )
+      })}
+    </svg>
+  )
+}

--- a/fe/src/features/coding-quest/components/CategoryRadarChart.tsx
+++ b/fe/src/features/coding-quest/components/CategoryRadarChart.tsx
@@ -62,6 +62,8 @@ export function CategoryRadarChart({ categoryStats, tierColor }: CategoryRadarCh
       width="100%"
       viewBox="0 0 280 240"
       style={{ display: 'block' }}
+      role="img"
+      aria-label={`카테고리별 풀이 수: ${AXES.map(({ key, label }) => `${label} ${categoryStats[key] ?? 0}문제`).join(', ')}`}
     >
       {/* 그리드 레벨 */}
       {gridLevels.map((ratio) => (

--- a/fe/src/features/coding-quest/components/CodingRankCard.tsx
+++ b/fe/src/features/coding-quest/components/CodingRankCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { CodingRankResult } from '@/types/api.types'
 import { fetchCodingRank } from '@/lib/apiClient'
+import { CategoryRadarChart } from './CategoryRadarChart'
 
 const TIER_COLORS: Record<string, string> = {
   아이언: '#9CA3AF',
@@ -209,6 +210,14 @@ export function CodingRankCard() {
           🔥 {rank.currentStreak}일 연속 풀이 중
         </div>
       )}
+
+      {/* 카테고리 레이더 차트 */}
+      <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+        <div style={{ fontSize: 11, color: '#475569', fontFamily: "'Courier New', monospace", marginBottom: 4, letterSpacing: '0.05em' }}>
+          CATEGORY
+        </div>
+        <CategoryRadarChart categoryStats={rank.categoryStats} tierColor={tierColor} />
+      </div>
     </div>
   )
 }

--- a/fe/src/features/coding-quest/index.ts
+++ b/fe/src/features/coding-quest/index.ts
@@ -1,3 +1,4 @@
+export { CategoryRadarChart } from './components/CategoryRadarChart'
 export { CodingQuestPage } from './components/CodingQuestPage'
 export { CodingRoadmapPage } from './components/CodingRoadmapPage'
 export { CodingRankCard } from './components/CodingRankCard'

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -207,17 +207,7 @@ export interface CodingRankResult {
   mediumCount: number
   hardCount: number
   currentStreak: number
-  categoryStats: {
-    ARRAY: number
-    HASH_MAP: number
-    STACK_QUEUE: number
-    BINARY_SEARCH: number
-    RECURSION: number
-    TREE: number
-    GRAPH: number
-    GREEDY: number
-    DP: number
-  }
+  categoryStats: Record<string, number>
 }
 
 export interface CodingQuestState {

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -207,6 +207,17 @@ export interface CodingRankResult {
   mediumCount: number
   hardCount: number
   currentStreak: number
+  categoryStats: {
+    ARRAY: number
+    HASH_MAP: number
+    STACK_QUEUE: number
+    BINARY_SEARCH: number
+    RECURSION: number
+    TREE: number
+    GRAPH: number
+    GREEDY: number
+    DP: number
+  }
 }
 
 export interface CodingQuestState {


### PR DESCRIPTION
## 변경 사항

### BE
- `CodingRankResult`에 `categoryStats: Map<String, Int>` 필드 추가 (9개 카테고리별 고유 풀이 수)
- `CodingRankPort`에 `countSolvedByCategory(userId, category)` 메서드 추가
- `CodingRankAdapter`에서 기존 `countDistinctSolvedProblemsByUserAndCategory` 쿼리 활용
- `CodingQuestService.getRank()`에서 ROADMAP_CATEGORIES 9개 순회해 categoryStats 집계

### FE
- `CategoryRadarChart` 컴포넌트 신규 생성 — SVG 순수 구현, 외부 라이브러리 없음
  - 9축 레이더 차트 (ARRAY, HASH_MAP, STACK_QUEUE, BINARY_SEARCH, RECURSION, TREE, GRAPH, GREEDY, DP)
  - 티어 색상 연동 (아이언~챌린저)
  - 동적 스케일 (최소 5, 데이터 최대값 기준)
  - 4단계 그리드, 꼭짓점 원 (0값 반투명 처리)
- `CodingRankCard`에 레이더 차트 섹션 추가 (스트릭 행 하단)
- `CodingRankResult` 타입에 `categoryStats: Record<string, number>` 추가

## 테스트
- BE: `CodingQuestServiceTest` 카테고리 집계 케이스 추가
- FE: `tsc --noEmit` + `vite build` 통과