### PR TITLE
fix(fe): 모바일 코딩 에디터 스크롤·코드 잘림·키보드 미표시 수정

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -54,8 +54,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `fix/mobile-coding-editor-ux` |
+| 열린 PR | #163 — fix(fe): 모바일 코딩 에디터 스크롤·코드 잘림·키보드 미표시 수정 (머지 대기) |
 
 
 
@@ -64,6 +64,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #163 | 모바일 코딩 에디터 스크롤·코드 잘림·키보드 미표시 수정 | 2026-06-02 |
 | #162 | 메일 HTML 템플릿 개선 + dhbang.co.kr 도메인 인증 + AI 질문 프롬프트 강화 | 2026-06-01 |
 | #161 | 데일리 메일 AI 질문 생성 + 발송 이력 중복 방지 | 2026-05-31 |
 | #160 | 카테고리별 코딩 풀이 레이더 차트 (SVG, 9축) | 2026-05-31 |

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -295,6 +295,7 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
+            aria-label="코드 입력"
             style={{
               width: '100%',
               height: '100%',

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -162,6 +162,7 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
         background: '#0F172A',
         overflowY: 'auto',
         padding: 24,
+        minHeight: 0,
         ...(isMobile ? { flex: 1 } : { width: '38%', flexShrink: 0, borderRight: '1px solid rgba(255,255,255,0.08)' }),
       }}
     >
@@ -235,11 +236,11 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
                     fontSize: 13,
                   }}
                 >
-                  <div style={{ color: '#475569', marginBottom: 4 }}>
-                    입력: <span style={{ color: '#F1F5F9', fontFamily: 'monospace' }}>{tc.input}</span>
+                  <div style={{ color: '#475569', marginBottom: 4, overflowX: 'auto' }}>
+                    입력: <span style={{ color: '#F1F5F9', fontFamily: 'monospace', display: 'inline-block', wordBreak: 'break-all' }}>{tc.input}</span>
                   </div>
-                  <div style={{ color: '#475569' }}>
-                    출력: <span style={{ color: '#4ECDC4', fontFamily: 'monospace' }}>{tc.expectedOutput}</span>
+                  <div style={{ color: '#475569', overflowX: 'auto' }}>
+                    출력: <span style={{ color: '#4ECDC4', fontFamily: 'monospace', display: 'inline-block', wordBreak: 'break-all' }}>{tc.expectedOutput}</span>
                   </div>
                 </div>
               ))}
@@ -284,20 +285,45 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
         </div>
       )}
 
-      {/* Monaco Editor */}
+      {/* Monaco Editor (데스크탑) / Textarea (모바일) */}
       <div style={{ flex: 1, overflow: 'hidden' }}>
-        <Editor
-          height="100%"
-          language={monacoLang}
-          value={code}
-          onChange={(val) => handleCodeChange(val ?? '')}
-          theme="vs-dark"
-          options={{
-            ...editorOptions,
-            fontFamily: 'Consolas, "Courier New", monospace',
-            automaticLayout: true,
-          }}
-        />
+        {isMobile ? (
+          <textarea
+            value={code}
+            onChange={(e) => handleCodeChange(e.target.value)}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            style={{
+              width: '100%',
+              height: '100%',
+              background: '#1E293B',
+              color: '#F1F5F9',
+              fontFamily: 'Consolas, "Courier New", monospace',
+              fontSize: 13,
+              border: 'none',
+              outline: 'none',
+              padding: 12,
+              resize: 'none',
+              boxSizing: 'border-box',
+              lineHeight: 1.6,
+            }}
+          />
+        ) : (
+          <Editor
+            height="100%"
+            language={monacoLang}
+            value={code}
+            onChange={(val) => handleCodeChange(val ?? '')}
+            theme="vs-dark"
+            options={{
+              ...editorOptions,
+              fontFamily: 'Consolas, "Courier New", monospace',
+              automaticLayout: true,
+            }}
+          />
+        )}
       </div>
 
       {/* 결과 패널 */}
@@ -554,11 +580,11 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
 
       {/* 본문 영역 */}
       {isMobile ? (
-        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'problem' ? 'flex' : 'none', flexDirection: 'column' }}>
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'problem' ? 'flex' : 'none', flexDirection: 'column', minHeight: 0 }}>
             {problemPanel}
           </div>
-          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'code' ? 'flex' : 'none', flexDirection: 'column' }}>
+          <div style={{ flex: 1, overflow: 'hidden', display: mobileTab === 'code' ? 'flex' : 'none', flexDirection: 'column', minHeight: 0 }}>
             {editorPanel}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 모바일 문제 탭 스크롤 미작동 수정 (flex 컨테이너 `minHeight: 0` 추가)
- 테스트케이스 입출력 코드 가로 잘림 수정 (`wordBreak: 'break-all'` + `overflowX: 'auto'`)
- 모바일에서 Monaco Editor 대신 `<textarea>` 렌더링하여 가상 키보드 활성화

## Why
- flex item의 기본 `min-height: auto`로 인해 `overflowY: 'auto'`가 작동하지 않아 스크롤 불가
- Monaco Editor는 모바일 네이티브 가상 키보드를 트리거하지 못하는 구조적 한계

## Test plan
- [x] FE tsc 타입 체크 통과
- [x] FE 빌드 성공