### PR TITLE
fix: Alloy scrape HTTPS + TLS skip — flycast force_https 대응

### DIFF
--- a/monitoring/config.alloy
+++ b/monitoring/config.alloy
@@ -1,11 +1,19 @@
 // Grafana Alloy 설정
 // devquest-api.flycast/actuator/prometheus 스크랩 → Grafana Cloud push
 // .flycast = Fly 내부 proxy 경유 → suspended machine도 auto-start 가능
+// scheme=https + insecure_skip_verify: force_https=true 설정 대응
+//   (flycast는 내부 전용이라 인증서 검증 불필요)
 
 prometheus.scrape "devquest" {
   targets = [{"__address__" = "devquest-api.flycast"}]
   metrics_path = "/actuator/prometheus"
   scrape_interval = "60s"
+  scheme = "https"
+
+  tls_config {
+    insecure_skip_verify = true
+  }
+
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
 

--- a/monitoring/config.alloy
+++ b/monitoring/config.alloy
@@ -2,7 +2,10 @@
 // devquest-api.flycast/actuator/prometheus 스크랩 → Grafana Cloud push
 // .flycast = Fly 내부 proxy 경유 → suspended machine도 auto-start 가능
 // scheme=https + insecure_skip_verify: force_https=true 설정 대응
-//   (flycast는 내부 전용이라 인증서 검증 불필요)
+//   flycast는 Fly.io 사설 네트워크 내부 전용 — 외부에서 접근 불가
+//   TLS 인증서가 devquest-api.fly.dev용이라 flycast 호스트명으로 검증 실패
+//   → insecure_skip_verify=true로 인증서 검증만 건너뜀
+//   개선 방향: Fly.io 내부 CA(또는 자체 서명 인증서)로 전환하면 이 옵션 제거 가능
 
 prometheus.scrape "devquest" {
   targets = [{"__address__" = "devquest-api.flycast"}]


### PR DESCRIPTION
## 요약

- `force_https = true` 설정으로 인해 flycast HTTP(80) 요청이 HTTPS로 redirect → scrape 실패(`up=0`)
- Alloy 스크랩 설정에 `scheme = "https"` + `tls_config.insecure_skip_verify = true` 추가
  - flycast 내부 전용이라 인증서 검증 불필요

## 변경 파일

- `monitoring/config.alloy`

## 검증

배포 후 Grafana Cloud에서 `up{job="devquest"}` = 1 확인 예정