### PR TITLE
fix(be): auto_stop_machines=false — 모니터링 scrape 위해 항상 기동 유지

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -65,7 +65,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
-| #169 | Alloy scrape HTTPS+TLS skip 수정 — flycast force_https 대응으로 up=0 버그 수정 | 2026-06-05 |
+| #170 | Alloy .internal:8080 직접 연결 + devquest-api min_machines=1 항상 기동 (up=0 근본 수정) | 2026-06-05 |
+| #169 | Alloy scrape HTTPS+TLS skip 수정 시도 (flycast 자체 미동작 확인) | 2026-06-05 |
 | #168 | Prometheus 엔드포인트 IP 화이트리스트(fdaa::/16) + Grafana Alloy → Grafana Cloud 시각화 | 2026-06-05 |
 | #166 | AI 호출 메트릭 수집 — DB 저장(ai_call_log) + Prometheus (evaluator·모델·토큰·latency) | 2026-06-04 |
 | #165 | 모바일 코딩 에디터 CodeMirror 6 교체 (문법 강조·괄호 자동 닫기·Tab 들여쓰기) + orchestrator 훅 절대경로 수정 | 2026-06-04 |

--- a/be/fly.toml
+++ b/be/fly.toml
@@ -14,7 +14,7 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'suspend'
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
 


### PR DESCRIPTION
## 요약

- `min_machines_running = 1`에도 `auto_stop_machines = 'suspend'`가 우선 적용되어 suspend 발생
- `.internal` 연결은 suspended machine을 자동 기동 못 함 → scrape 지속 실패
- `auto_stop_machines = false`로 변경하여 항상 1대 기동 유지

## 변경 파일

- `be/fly.toml`: `auto_stop_machines = 'suspend'` → `false`

## 비용 영향

- shared-cpu-1x 512MB 24시간 기동 → 약 $2/월 (Fly.io 무료 플랜 포함)