### PR TITLE
fix(be): Grafana instance ID 수정

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ server:
 grafana:
   otlp:
     enabled: true
-    instance-id: "3284556"
+    instance-id: "1680166"
 
 storage:
   datasource:


### PR DESCRIPTION
## 변경 사항

`application-prod.yml`의 Grafana instance ID 오타 수정.

- 기존: `3284556` (잘못된 값)
- 수정: `1680166` (실제 spryspinach2629 스택 ID)

## 원인

OTLP push 시 `Authorization: Basic base64(instanceId:apiKey)` 구성에서
instance ID가 틀려 401 발생. API 키 자체는 유효했음.

## 테스트

배포 후 `fly logs -a devquest-api | grep -i otlp` 로 확인.
`Failed to publish` 사라지면 정상.