### PR TITLE
chore: fe-feature-builder, design-reviewer ultrathink 제거

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -190,8 +190,6 @@ Agent(subagent_type: "be-feature-builder", prompt: """
 
 ```
 Agent(subagent_type: "design-reviewer", prompt: """
-  ultrathink
-
   ## 설계할 기능
   <기능 설명>
 
@@ -221,8 +219,6 @@ Agent(subagent_type: "design-reviewer", prompt: """
 
 ```
 Agent(subagent_type: "fe-feature-builder", prompt: """
-  ultrathink
-
   ## 브랜치
   이미 생성됨: <브랜치명>
   git fetch origin && git checkout <브랜치명>

--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -80,15 +80,20 @@ $DIFF
 ---
 CRITICAL 여부: YES 또는 NO"
 
+# 임시 파일로 JSON body 생성 (인코딩 문제 방지)
+TMPFILE=$(mktemp)
+jq -n \
+  --arg model "claude-haiku-4-5" \
+  --arg content "$PROMPT" \
+  '{"model": $model, "max_tokens": 2000, "messages": [{"role": "user", "content": $content}]}' \
+  > "$TMPFILE"
+
 RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "anthropic-version: 2023-06-01" \
   -H "content-type: application/json" \
-  -d "{
-    \"model\": \"claude-haiku-4-5\",
-    \"max_tokens\": 2000,
-    \"messages\": [{\"role\": \"user\", \"content\": $(echo "$PROMPT" | jq -Rs .)}]
-  }")
+  --data-binary "@$TMPFILE")
+rm -f "$TMPFILE"
 
 REVIEW_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null)
 

--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -24,21 +24,11 @@ if [ -f "$CACHE_FILE" ]; then
   exit 0
 fi
 
-# API 키 추출 시 디버그 출력 방지 (키 노출 차단)
-set +x
-
-# ANTHROPIC_API_KEY 확인 — 없으면 application-local.yml에서 자동 추출
-# application-local.yml은 .gitignore 등록된 로컬 전용 파일 (버전 관리 제외)
-if [ -z "$ANTHROPIC_API_KEY" ]; then
-  LOCAL_YML="$PROJECT_ROOT/be/core/core-api/src/main/resources/application-local.yml"
-  if [ -f "$LOCAL_YML" ]; then
-    ANTHROPIC_API_KEY=$(grep -A1 "anthropic:" "$LOCAL_YML" | grep "api-key:" | head -1 | sed 's/.*api-key:[[:space:]]*//' | tr -d '[:space:]')
-  fi
-fi
-
+# ANTHROPIC_API_KEY 필수 — 셸 프로필에 export 필요
+# 예: ~/.bashrc 또는 ~/.zshrc에 export ANTHROPIC_API_KEY=sk-ant-...
 if [ -z "$ANTHROPIC_API_KEY" ]; then
   echo "⛔ PR 사전 리뷰 실패: ANTHROPIC_API_KEY가 설정되지 않았습니다." >&2
-  echo "   export ANTHROPIC_API_KEY=<your-key> 후 재시도하세요." >&2
+  echo "   ~/.bashrc 또는 ~/.zshrc에 export ANTHROPIC_API_KEY=<your-key> 추가 후 재시도하세요." >&2
   exit 2
 fi
 

--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gh pr create 실행 전 Claude qa-reviewer 사전 검토 강제화
+# gh pr create 실행 전 Claude 사전 검토 강제화
 # CRITICAL 항목 없는 경우만 PR 생성 허용
 
 INPUT=$(cat)
@@ -24,13 +24,15 @@ if [ -f "$CACHE_FILE" ]; then
   exit 0
 fi
 
+# API 키 추출 시 디버그 출력 방지 (키 노출 차단)
+set +x
+
 # ANTHROPIC_API_KEY 확인 — 없으면 application-local.yml에서 자동 추출
-# 보안 참고: application-local.yml은 .gitignore에 등록된 로컬 전용 파일로
-# 버전 관리되지 않음. 키가 외부로 노출될 위험 없음.
+# application-local.yml은 .gitignore 등록된 로컬 전용 파일 (버전 관리 제외)
 if [ -z "$ANTHROPIC_API_KEY" ]; then
   LOCAL_YML="$PROJECT_ROOT/be/core/core-api/src/main/resources/application-local.yml"
   if [ -f "$LOCAL_YML" ]; then
-    ANTHROPIC_API_KEY=$(grep -E "api-key:" "$LOCAL_YML" | grep "sk-ant" | head -1 | sed 's/.*api-key:[[:space:]]*//')
+    ANTHROPIC_API_KEY=$(grep -A1 "anthropic:" "$LOCAL_YML" | grep "api-key:" | head -1 | sed 's/.*api-key:[[:space:]]*//' | tr -d '[:space:]')
   fi
 fi
 
@@ -82,8 +84,10 @@ $DIFF
 ---
 CRITICAL 여부: YES 또는 NO"
 
-# 임시 파일로 JSON body 생성 (인코딩 문제 방지)
+# 임시 파일로 JSON body 생성 (인코딩 문제 방지), 종료 시 자동 정리
 TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
 jq -n \
   --arg model "claude-haiku-4-5" \
   --arg content "$PROMPT" \
@@ -95,7 +99,6 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
   -H "anthropic-version: 2023-06-01" \
   -H "content-type: application/json" \
   --data-binary "@$TMPFILE")
-rm -f "$TMPFILE"
 
 REVIEW_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null)
 

--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -25,6 +25,8 @@ if [ -f "$CACHE_FILE" ]; then
 fi
 
 # ANTHROPIC_API_KEY 확인 — 없으면 application-local.yml에서 자동 추출
+# 보안 참고: application-local.yml은 .gitignore에 등록된 로컬 전용 파일로
+# 버전 관리되지 않음. 키가 외부로 노출될 위험 없음.
 if [ -z "$ANTHROPIC_API_KEY" ]; then
   LOCAL_YML="$PROJECT_ROOT/be/core/core-api/src/main/resources/application-local.yml"
   if [ -f "$LOCAL_YML" ]; then

--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -24,7 +24,14 @@ if [ -f "$CACHE_FILE" ]; then
   exit 0
 fi
 
-# ANTHROPIC_API_KEY 확인
+# ANTHROPIC_API_KEY 확인 — 없으면 application-local.yml에서 자동 추출
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  LOCAL_YML="$PROJECT_ROOT/be/core/core-api/src/main/resources/application-local.yml"
+  if [ -f "$LOCAL_YML" ]; then
+    ANTHROPIC_API_KEY=$(grep -E "api-key:" "$LOCAL_YML" | grep "sk-ant" | head -1 | sed 's/.*api-key:[[:space:]]*//')
+  fi
+fi
+
 if [ -z "$ANTHROPIC_API_KEY" ]; then
   echo "⛔ PR 사전 리뷰 실패: ANTHROPIC_API_KEY가 설정되지 않았습니다." >&2
   echo "   export ANTHROPIC_API_KEY=<your-key> 후 재시도하세요." >&2


### PR DESCRIPTION
## Summary

- `fe-feature-builder`, `design-reviewer` 스폰 프롬프트에서 `ultrathink` 제거
- BE 구현·QA 리뷰와 달리 명확한 스펙을 받아 실행하는 구조라 medium effort로 충분 (Harness Engineering 7편 근거)
- `assert-pr-reviewed.sh` 개선: application-local.yml fallback 제거, set+x, trap, jq 임시파일