### PR TITLE
fix: assert-pr-reviewed application-local.yml API 키 fallback 복원

### DIFF
--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -24,11 +24,18 @@ if [ -f "$CACHE_FILE" ]; then
   exit 0
 fi
 
-# ANTHROPIC_API_KEY 필수 — 셸 프로필에 export 필요
-# 예: ~/.bashrc 또는 ~/.zshrc에 export ANTHROPIC_API_KEY=sk-ant-...
+# ANTHROPIC_API_KEY 확인 — 없으면 application-local.yml에서 자동 추출
+# (로컬 훅 전용, application-local.yml은 .gitignore 등록된 파일)
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  LOCAL_YML="$PROJECT_ROOT/be/core/core-api/src/main/resources/application-local.yml"
+  if [ -f "$LOCAL_YML" ]; then
+    ANTHROPIC_API_KEY=$(grep -A1 "anthropic:" "$LOCAL_YML" | grep "api-key:" | head -1 | sed 's/.*api-key:[[:space:]]*//' | tr -d '[:space:]')
+  fi
+fi
+
 if [ -z "$ANTHROPIC_API_KEY" ]; then
   echo "⛔ PR 사전 리뷰 실패: ANTHROPIC_API_KEY가 설정되지 않았습니다." >&2
-  echo "   ~/.bashrc 또는 ~/.zshrc에 export ANTHROPIC_API_KEY=<your-key> 추가 후 재시도하세요." >&2
+  echo "   be/core/core-api/src/main/resources/application-local.yml에 spring.ai.anthropic.api-key 설정 필요." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

로컬 훅에서 ANTHROPIC_API_KEY 환경변수 없을 때 application-local.yml에서 자동 추출하는 로직 복원.

## Why

- 훅은 로컬 전용 (CI에서 실행 안 됨)
- application-local.yml은 .gitignore 등록 파일로 외부 노출 없음
- 매번 환경변수 수동 설정 불필요