### PR TITLE
feat(fe): 코딩 퀘스트 문제/에디터 패널 드래그 리사이즈 (PC 전용)

### DIFF
--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -49,8 +49,18 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
   const [problemWidth, setProblemWidth] = useState(38)
+  const [dividerHovered, setDividerHovered] = useState(false)
   const isDragging = useRef(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const cleanupDragRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    return () => {
+      cleanupDragRef.current?.()
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [])
 
   const handleDividerMouseDown = (e: React.MouseEvent) => {
     isDragging.current = true
@@ -65,10 +75,17 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
 
     const onMouseUp = () => {
       isDragging.current = false
+      cleanupDragRef.current = null
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+    }
+
+    cleanupDragRef.current = () => {
+      isDragging.current = false
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
     }
 
     document.body.style.cursor = 'col-resize'
@@ -631,15 +648,15 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
           {problemPanel}
           <div
             onMouseDown={handleDividerMouseDown}
+            onMouseEnter={() => setDividerHovered(true)}
+            onMouseLeave={() => setDividerHovered(false)}
             style={{
               width: 5,
               cursor: 'col-resize',
-              background: 'rgba(255,255,255,0.08)',
+              background: dividerHovered ? 'rgba(99,102,241,0.6)' : 'rgba(255,255,255,0.08)',
               flexShrink: 0,
               transition: 'background 0.15s',
             }}
-            onMouseEnter={e => (e.currentTarget.style.background = 'rgba(99,102,241,0.6)')}
-            onMouseLeave={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.08)')}
           />
           {editorPanel}
         </div>

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import Editor from '@monaco-editor/react'
 import CodeMirror from '@uiw/react-codemirror'
 import { java } from '@codemirror/lang-java'
@@ -84,12 +84,12 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
     }
   }, [])
 
-  const handleDividerMouseDown = (e: React.MouseEvent) => {
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     dragStartXRef.current = e.clientX
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
-  }
+  }, [])
 
   const notifyStateChange = (patch: Partial<CodingQuestState>) => {
     if (!onStateChange) return

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -21,6 +21,7 @@ const KOTLIN_TEMPLATE = `fun main() {
 
 const MIN_PROBLEM_WIDTH = 20
 const MAX_PROBLEM_WIDTH = 60
+const INITIAL_PROBLEM_WIDTH = 38
 
 type Language = 'JAVA' | 'KOTLIN'
 type MobileTab = 'problem' | 'code'
@@ -51,11 +52,10 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
   const [hints, setHints] = useState<string[]>(savedState?.hints ?? [])
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
-  const [problemWidth, setProblemWidth] = useState(38)
+  const [problemWidth, setProblemWidth] = useState(INITIAL_PROBLEM_WIDTH)
   const [dividerHovered, setDividerHovered] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const dragStartXRef = useRef<number | null>(null)
-  const dragStartWidthRef = useRef<number>(38)
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -80,13 +80,13 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
       document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
+      dragStartXRef.current = null
     }
   }, [])
 
   const handleDividerMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
     dragStartXRef.current = e.clientX
-    dragStartWidthRef.current = problemWidth
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
   }

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import Editor from '@monaco-editor/react'
 import CodeMirror from '@uiw/react-codemirror'
 import { java } from '@codemirror/lang-java'
@@ -48,6 +48,34 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
   const [hints, setHints] = useState<string[]>(savedState?.hints ?? [])
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
+  const [problemWidth, setProblemWidth] = useState(38)
+  const isDragging = useRef(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleDividerMouseDown = (e: React.MouseEvent) => {
+    isDragging.current = true
+    e.preventDefault()
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current || !containerRef.current) return
+      const rect = containerRef.current.getBoundingClientRect()
+      const newWidth = ((e.clientX - rect.left) / rect.width) * 100
+      setProblemWidth(Math.min(60, Math.max(20, newWidth)))
+    }
+
+    const onMouseUp = () => {
+      isDragging.current = false
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }
 
   const notifyStateChange = (patch: Partial<CodingQuestState>) => {
     if (!onStateChange) return
@@ -174,7 +202,7 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
         overflowY: 'auto',
         padding: 24,
         minHeight: 0,
-        ...(isMobile ? { flex: 1 } : { width: '38%', flexShrink: 0, borderRight: '1px solid rgba(255,255,255,0.08)' }),
+        ...(isMobile ? { flex: 1 } : { width: `${problemWidth}%`, flexShrink: 0 }),
       }}
     >
       {/* 모바일에서만 제목/난이도/레벨 표시 */}
@@ -599,8 +627,20 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
           </div>
         </div>
       ) : (
-        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <div ref={containerRef} style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
           {problemPanel}
+          <div
+            onMouseDown={handleDividerMouseDown}
+            style={{
+              width: 5,
+              cursor: 'col-resize',
+              background: 'rgba(255,255,255,0.08)',
+              flexShrink: 0,
+              transition: 'background 0.15s',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'rgba(99,102,241,0.6)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.08)')}
+          />
           {editorPanel}
         </div>
       )}

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -54,11 +54,30 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
   const [problemWidth, setProblemWidth] = useState(38)
   const [dividerHovered, setDividerHovered] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const abortControllerRef = useRef<AbortController | null>(null)
+  const dragStartXRef = useRef<number | null>(null)
+  const dragStartWidthRef = useRef<number>(38)
 
   useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (dragStartXRef.current === null || !containerRef.current) return
+      const rect = containerRef.current.getBoundingClientRect()
+      const newWidth = ((e.clientX - rect.left) / rect.width) * 100
+      setProblemWidth(Math.min(MAX_PROBLEM_WIDTH, Math.max(MIN_PROBLEM_WIDTH, newWidth)))
+    }
+
+    const handleMouseUp = () => {
+      if (dragStartXRef.current === null) return
+      dragStartXRef.current = null
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
     return () => {
-      abortControllerRef.current?.abort()
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
@@ -66,27 +85,10 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
 
   const handleDividerMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
-    abortControllerRef.current?.abort()
-    const controller = new AbortController()
-    abortControllerRef.current = controller
-    const { signal } = controller
-
+    dragStartXRef.current = e.clientX
+    dragStartWidthRef.current = problemWidth
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
-
-    document.addEventListener('mousemove', (e: MouseEvent) => {
-      if (!containerRef.current) return
-      const rect = containerRef.current.getBoundingClientRect()
-      const newWidth = ((e.clientX - rect.left) / rect.width) * 100
-      setProblemWidth(Math.min(MAX_PROBLEM_WIDTH, Math.max(MIN_PROBLEM_WIDTH, newWidth)))
-    }, { signal })
-
-    document.addEventListener('mouseup', () => {
-      controller.abort()
-      abortControllerRef.current = null
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }, { signal })
   }
 
   const notifyStateChange = (patch: Partial<CodingQuestState>) => {

--- a/fe/src/features/coding-quest/components/CodingQuestPage.tsx
+++ b/fe/src/features/coding-quest/components/CodingQuestPage.tsx
@@ -19,6 +19,9 @@ const KOTLIN_TEMPLATE = `fun main() {
     // 여기에 코드를 작성하세요
 }`
 
+const MIN_PROBLEM_WIDTH = 20
+const MAX_PROBLEM_WIDTH = 60
+
 type Language = 'JAVA' | 'KOTLIN'
 type MobileTab = 'problem' | 'code'
 
@@ -50,48 +53,40 @@ export function CodingQuestPage({ onBack, savedState, onStateChange, category }:
   const [mobileTab, setMobileTab] = useState<MobileTab>('problem')
   const [problemWidth, setProblemWidth] = useState(38)
   const [dividerHovered, setDividerHovered] = useState(false)
-  const isDragging = useRef(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const cleanupDragRef = useRef<(() => void) | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     return () => {
-      cleanupDragRef.current?.()
+      abortControllerRef.current?.abort()
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
   }, [])
 
   const handleDividerMouseDown = (e: React.MouseEvent) => {
-    isDragging.current = true
     e.preventDefault()
-
-    const onMouseMove = (e: MouseEvent) => {
-      if (!isDragging.current || !containerRef.current) return
-      const rect = containerRef.current.getBoundingClientRect()
-      const newWidth = ((e.clientX - rect.left) / rect.width) * 100
-      setProblemWidth(Math.min(60, Math.max(20, newWidth)))
-    }
-
-    const onMouseUp = () => {
-      isDragging.current = false
-      cleanupDragRef.current = null
-      document.removeEventListener('mousemove', onMouseMove)
-      document.removeEventListener('mouseup', onMouseUp)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-    }
-
-    cleanupDragRef.current = () => {
-      isDragging.current = false
-      document.removeEventListener('mousemove', onMouseMove)
-      document.removeEventListener('mouseup', onMouseUp)
-    }
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+    const { signal } = controller
 
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
-    document.addEventListener('mousemove', onMouseMove)
-    document.addEventListener('mouseup', onMouseUp)
+
+    document.addEventListener('mousemove', (e: MouseEvent) => {
+      if (!containerRef.current) return
+      const rect = containerRef.current.getBoundingClientRect()
+      const newWidth = ((e.clientX - rect.left) / rect.width) * 100
+      setProblemWidth(Math.min(MAX_PROBLEM_WIDTH, Math.max(MIN_PROBLEM_WIDTH, newWidth)))
+    }, { signal })
+
+    document.addEventListener('mouseup', () => {
+      controller.abort()
+      abortControllerRef.current = null
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }, { signal })
   }
 
   const notifyStateChange = (patch: Partial<CodingQuestState>) => {


### PR DESCRIPTION
## Summary
- 코딩 연습 문제 패널과 에디터 패널 사이에 드래그로 너비 조절 가능한 핸들 추가 (PC 전용)
- useEffect 명시적 removeEventListener + useCallback 패턴으로 안전한 이벤트 관리

## Why
문제 패널 38% 고정 비율이 사용자에 따라 불편할 수 있어 자유롭게 조절 가능하도록 개선.

## Test plan
- [x] 구분선 hover 시 인디고색으로 강조 + col-resize 커서 확인
- [x] 드래그로 20~60% 범위 내 너비 조절 확인
- [x] 드래그 중 텍스트 선택 방지 확인
- [x] 컴포넌트 언마운트 시 이벤트 리스너 + 상태 완전 정리
- [x] 모바일 뷰 영향 없음 확인
- [x] FE 빌드 성공