### PR TITLE
feat(be): AI 호출 메트릭 수집 — AiMetricsRecorder + Spring AI Observation 활성화

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -54,8 +54,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `feat/ai-observability-metrics` |
+| 열린 PR | #183 — AI 호출 메트릭 수집 (머지 대기) |
 
 
 
@@ -70,6 +70,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #183 | AI 호출 메트릭 수집 — AiMetricsRecorder + Spring AI Observation 활성화 | 2026-06-08 |
 | #182 | 코딩 퀘스트 문제/에디터 패널 드래그 리사이즈 (PC 전용) | 2026-06-08 |
 | #180 | 데일리 메일 deepLink URL 오타 수정 (devquest.kr → quest.dhbang.co.kr) | 2026-06-08 |
 | #178 | fe-feature-builder·design-reviewer ultrathink 제거 + assert-pr-reviewed.sh 개선 | 2026-06-08 |

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
@@ -32,7 +32,7 @@ class ActClearReportEvaluator(
             "avgScore" to avgScore,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(ActClearReportResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.model.evaluation.BossPackageResult
 import com.devquest.core.domain.port.BossPackageEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component
 class BossPackageEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), BossPackageEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, AiModel.SONNET), BossPackageEvaluatorPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/boss-package-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/boss-package-user.st"))

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 class BossPackageEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor), BossPackageEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), BossPackageEvaluatorPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/boss-package-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/boss-package-user.st"))
@@ -33,7 +33,7 @@ class BossPackageEvaluator(
             "resumeContent" to resumeContent,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(BossPackageResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
@@ -26,7 +26,7 @@ class CareerEssayEvaluator(
             "fiveYearVision" to fiveYearVision,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(EssayCheckResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluator.kt
@@ -27,7 +27,7 @@ class CodingHintEvaluator(
             "hintLevel" to hintLevel
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluator.kt
@@ -26,7 +26,7 @@ class CodingProblemGeneratorEvaluator(
             "category" to category
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.CompanyFitResult
 import com.devquest.core.domain.port.CompanyFitEvaluatorPort
@@ -19,7 +20,7 @@ import org.springframework.stereotype.Component
 class CompanyFitEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), CompanyFitEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, AiModel.SONNET), CompanyFitEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component
 class CompanyFitEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor), CompanyFitEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), CompanyFitEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 
@@ -40,7 +40,7 @@ class CompanyFitEvaluator(
             "companiesText" to companiesText,
         ))
 
-        val response = aiCallExecutor.execute(this.javaClass.simpleName) {
+        val response = aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
         }
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 class DeveloperClassEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor), DeveloperClassEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), DeveloperClassEvaluatorPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/developer-class-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/developer-class-user.st"))
@@ -26,7 +26,7 @@ class DeveloperClassEvaluator(
             "careerEssayJson" to careerEssayJson.ifBlank { "{}" },
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(DeveloperClassResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.model.evaluation.DeveloperClassResult
 import com.devquest.core.domain.port.DeveloperClassEvaluatorPort
 import org.springframework.ai.chat.client.ChatClient
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component
 class DeveloperClassEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), DeveloperClassEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, AiModel.SONNET), DeveloperClassEvaluatorPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/developer-class-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/developer-class-user.st"))

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
@@ -32,7 +32,7 @@ class InterviewCoachEvaluator(
             "jdText" to jdText,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachSessionResult::class.java)
         }
     }
@@ -46,7 +46,7 @@ class InterviewCoachEvaluator(
             "answer" to answer,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachAnswerResult::class.java)
         }
     }
@@ -68,7 +68,7 @@ class InterviewCoachEvaluator(
             "answersText" to answersText,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachReportResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
@@ -28,7 +28,7 @@ class JdAnalysisEvaluator(
             "userExperiences" to userExperiences.joinToString("\n"),
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JdAnalysisResult::class.java)
                 ?.let { it.copy(passed = PassCriteriaPolicy.evaluate(it.overallMatchScore)) }
         }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 class JourneyReportGenerator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor), JourneyReportPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), JourneyReportPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/journey-report-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/journey-report-user.st"))
@@ -44,7 +44,7 @@ class JourneyReportGenerator(
             "highestQuestId" to (highestEntry?.key ?: ""),
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JourneyReportResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.model.evaluation.JourneyReportResult
 import com.devquest.core.domain.port.JourneyReportPort
 import org.springframework.ai.chat.client.ChatClient
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component
 class JourneyReportGenerator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), JourneyReportPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, AiModel.SONNET), JourneyReportPort {
 
     private val systemTemplate = PromptTemplate(ClassPathResource("prompts/journey-report-system.st"))
     private val userTemplate = PromptTemplate(ClassPathResource("prompts/journey-report-user.st"))

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
@@ -2,6 +2,7 @@ package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.BaseAiEvaluator
+import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.InterviewEvaluationResult
 import com.devquest.core.domain.port.InterviewEvaluatorPort
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Component
 class MockInterviewEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), InterviewEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, AiModel.SONNET), InterviewEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component
 class MockInterviewEvaluator(
     @Qualifier("bossChatClient") chatClient: ChatClient,
     aiCallExecutor: AiCallExecutor
-) : BaseAiEvaluator(chatClient, aiCallExecutor), InterviewEvaluatorPort {
+) : BaseAiEvaluator(chatClient, aiCallExecutor, "claude-sonnet-4-6"), InterviewEvaluatorPort {
 
     private val objectMapper = jacksonObjectMapper()
 
@@ -48,7 +48,7 @@ class MockInterviewEvaluator(
             "yearsOfExperience" to yearsOfExperience,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
             parseContent(content, InterviewEvaluationResult::class.java)
         }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
@@ -25,7 +25,7 @@ class PersonalityInterviewEvaluator(
             "answer" to answer,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluator.kt
@@ -27,7 +27,7 @@ class ResumeCheckEvaluator(
             "resumeContent" to resumeContent,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
             parseContent(content, ResumeCheckResult::class.java)
                 ?.let { it.copy(passed = PassCriteriaPolicy.evaluate(it.overallScore)) }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
@@ -27,7 +27,7 @@ class SkillAssessmentEvaluator(
             "targetRole" to targetRole,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(SkillAssessmentResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
@@ -26,7 +26,7 @@ class SystemDesignEvaluator(
             "considerations" to considerations.mapIndexed { i, c -> "${i + 1}. $c" }.joinToString("\n"),
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
@@ -26,7 +26,7 @@ class TechBlogEvaluator(
             "content" to content,
         ))
 
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluator.kt
@@ -23,7 +23,7 @@ class TechInterviewEvaluator(
     override fun generateQuestions(techStack: String): TechInterviewResult {
         val systemPrompt = questionsSystemTemplate.render()
         val userPrompt = questionsUserTemplate.render(mapOf("techStack" to techStack))
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
@@ -42,7 +42,7 @@ class TechInterviewEvaluator(
             "recentQuestions" to if (recentQuestions.isEmpty()) "없음"
                 else recentQuestions.mapIndexed { i, q -> "${i + 1}. $q" }.joinToString("\n"),
         ))
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
@@ -60,7 +60,7 @@ class TechInterviewEvaluator(
             "techStack" to techStack,
             "questionsAndAnswers" to questionsAndAnswers,
         ))
-        return aiCallExecutor.execute(this.javaClass.simpleName) {
+        return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
             chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
@@ -19,7 +19,8 @@ class AiCallExecutor(
     ): T {
         AiCallContext.set(evaluatorName)
         try {
-            val evaluator = AiCallContext.get() ?: "Unknown"
+            // AiCallContext.set() 직후이므로 evaluatorName과 동일 — 중간 수정 방지용 재조회
+            val evaluator = evaluatorName
             var lastException: Exception? = null
             repeat(maxRetry) { attempt ->
                 if (attempt > 0) {

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 @Component
 class AiCallExecutor(
     @Value("\${devquest.ai.max-retry:3}") private val maxRetry: Int,
-    private val metricsRecorder: AiMetricsRecorder? = null,
+    private val metricsRecorder: AiMetricsRecorder,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -19,16 +19,16 @@ class AiCallExecutor(
     ): T {
         AiCallContext.set(evaluatorName)
         try {
-            val evaluator = AiCallContext.get()
+            val evaluator = AiCallContext.get() ?: "Unknown"
             var lastException: Exception? = null
             repeat(maxRetry) { attempt ->
                 if (attempt > 0) {
-                    metricsRecorder?.recordRetry(evaluator, model)
+                    metricsRecorder.recordRetry(evaluator, model)
                 }
                 try {
                     val result = action()
                     if (result != null) {
-                        metricsRecorder?.recordCallSuccess(evaluator, model)
+                        metricsRecorder.recordCallSuccess(evaluator, model)
                         return result
                     }
                     logger.warn("AI 응답 null — 재시도 {}/{}", attempt + 1, maxRetry)
@@ -37,7 +37,7 @@ class AiCallExecutor(
                     logger.warn("AI 호출 실패 — 재시도 {}/{}: {}", attempt + 1, maxRetry, e.message)
                 }
             }
-            metricsRecorder?.recordCallFailure(evaluator, model)
+            metricsRecorder.recordCallFailure(evaluator, model)
             throw AiEvaluationException(
                 "${maxRetry}회 시도 후 최종 실패",
                 lastException

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiCallExecutor.kt
@@ -7,24 +7,37 @@ import org.springframework.stereotype.Component
 
 @Component
 class AiCallExecutor(
-    @Value("\${devquest.ai.max-retry:3}") private val maxRetry: Int
+    @Value("\${devquest.ai.max-retry:3}") private val maxRetry: Int,
+    private val metricsRecorder: AiMetricsRecorder? = null,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun <T> execute(evaluatorName: String = "Unknown", action: () -> T?): T {
+    fun <T> execute(
+        evaluatorName: String = "Unknown",
+        model: String = "unknown",
+        action: () -> T?,
+    ): T {
         AiCallContext.set(evaluatorName)
         try {
+            val evaluator = AiCallContext.get()
             var lastException: Exception? = null
             repeat(maxRetry) { attempt ->
+                if (attempt > 0) {
+                    metricsRecorder?.recordRetry(evaluator, model)
+                }
                 try {
                     val result = action()
-                    if (result != null) return result
+                    if (result != null) {
+                        metricsRecorder?.recordCallSuccess(evaluator, model)
+                        return result
+                    }
                     logger.warn("AI 응답 null — 재시도 {}/{}", attempt + 1, maxRetry)
                 } catch (e: Exception) {
                     lastException = e
                     logger.warn("AI 호출 실패 — 재시도 {}/{}: {}", attempt + 1, maxRetry, e.message)
                 }
             }
+            metricsRecorder?.recordCallFailure(evaluator, model)
             throw AiEvaluationException(
                 "${maxRetry}회 시도 후 최종 실패",
                 lastException

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiMetricsRecorder.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/AiMetricsRecorder.kt
@@ -1,0 +1,34 @@
+package com.devquest.client.ai.support
+
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class AiMetricsRecorder(private val meterRegistry: MeterRegistry) {
+
+    fun recordCallSuccess(evaluatorType: String, model: String) {
+        meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", evaluatorType,
+            "model", model,
+            "status", "success"
+        ).increment()
+    }
+
+    fun recordCallFailure(evaluatorType: String, model: String) {
+        meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", evaluatorType,
+            "model", model,
+            "status", "failure"
+        ).increment()
+    }
+
+    fun recordRetry(evaluatorType: String, model: String) {
+        meterRegistry.counter(
+            "devquest.ai.retry.total",
+            "evaluatorType", evaluatorType,
+            "model", model
+        ).increment()
+    }
+}

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
@@ -6,8 +6,15 @@ import org.springframework.ai.chat.client.ChatClient
 abstract class BaseAiEvaluator(
     protected val chatClient: ChatClient,
     protected val aiCallExecutor: AiCallExecutor,
-    protected val modelName: String = "claude-haiku-4-5-20251001",
+    protected val modelName: String = AiModel.HAIKU,
 ) {
+    companion object {
+        /** 메트릭 태그용 모델 이름 상수 — client-ai-anthropic.yml 설정과 동기화 필요 */
+        object AiModel {
+            const val HAIKU = "claude-haiku-4-5-20251001"
+            const val SONNET = "claude-sonnet-4-6"
+        }
+    }
     private val objectMapper = jacksonObjectMapper()
 
     /**

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
@@ -5,7 +5,8 @@ import org.springframework.ai.chat.client.ChatClient
 
 abstract class BaseAiEvaluator(
     protected val chatClient: ChatClient,
-    protected val aiCallExecutor: AiCallExecutor
+    protected val aiCallExecutor: AiCallExecutor,
+    protected val modelName: String = "claude-haiku-4-5-20251001",
 ) {
     private val objectMapper = jacksonObjectMapper()
 

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.BossPackageResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,8 @@ import org.mockito.kotlin.whenever
 class BossPackageEvaluatorTest {
 
     private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = BossPackageEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.EssayCheckResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,8 @@ class CareerEssayEvaluatorTest {
 
     // ChatClient의 fluent API 체인 전체를 deep stub으로 목킹
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = CareerEssayEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.coding.CodingHint
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class CodingHintEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = CodingHintEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.coding.CodingProblemGenerationResult
 import com.devquest.core.domain.model.coding.TestCase
 import com.devquest.core.domain.support.AiEvaluationException
@@ -19,7 +21,8 @@ import org.springframework.ai.chat.client.ChatClient
 class CodingProblemGeneratorEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = CodingProblemGeneratorEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.CompanyFitResult
 import com.devquest.core.domain.port.CompanyInfo
 import com.devquest.core.domain.support.AiEvaluationException
@@ -19,7 +21,8 @@ import org.springframework.ai.chat.client.ChatClient
 class CompanyFitEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = CompanyFitEvaluator(chatClient, aiCallExecutor)
 
     private val preferences = mapOf("문화" to "수평적", "기술스택" to "Kotlin")

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.DeveloperClassResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,8 @@ import org.mockito.kotlin.whenever
 class DeveloperClassEvaluatorTest {
 
     private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = DeveloperClassEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
 import com.devquest.core.domain.model.evaluation.CoachAnswerResult
 import com.devquest.core.domain.model.evaluation.CoachReportResult
@@ -23,7 +25,8 @@ import org.mockito.kotlin.whenever
 class InterviewCoachEvaluatorTest {
 
     private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = InterviewCoachEvaluator(chatClient, aiCallExecutor)
 
     // ── startSession ──────────────────────────────────────────────────────────

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.JdAnalysisResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class JdAnalysisEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = JdAnalysisEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -17,7 +19,8 @@ import org.springframework.ai.chat.client.ChatClient
 class MockInterviewEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = MockInterviewEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class PersonalityInterviewEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = PersonalityInterviewEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ResumeCheckEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -17,7 +19,8 @@ import org.springframework.ai.chat.client.ChatClient
 class ResumeCheckEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = ResumeCheckEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.SkillAssessmentResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,8 @@ import org.mockito.kotlin.whenever
 class SkillAssessmentEvaluatorTest {
 
     private val chatClient: org.springframework.ai.chat.client.ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = SkillAssessmentEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class SystemDesignEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = SystemDesignEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class TechBlogEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = TechBlogEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluatorTest.kt
@@ -1,6 +1,8 @@
 package com.devquest.client.ai.evaluator
 
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.TechInterviewResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +20,8 @@ import org.springframework.ai.chat.client.ChatClient
 class TechInterviewEvaluatorTest {
 
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val aiCallExecutor = AiCallExecutor(maxRetry = 1)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
     private val evaluator = TechInterviewEvaluator(chatClient, aiCallExecutor)
 
     @Test

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/integration/AiIntegrationTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/integration/AiIntegrationTest.kt
@@ -3,6 +3,8 @@ package com.devquest.client.ai.integration
 import com.anthropic.client.okhttp.AnthropicOkHttpClient
 import com.devquest.client.ai.evaluator.*
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
@@ -43,7 +45,7 @@ class AiIntegrationTest {
             .build()
 
         chatClient = ChatClient.builder(model).build()
-        executor = AiCallExecutor(maxRetry = 2)
+        executor = AiCallExecutor(maxRetry = 2, metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry()))
     }
 
     // ── CareerEssayEvaluator ───────────────────────────────────────────────

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/integration/ModelComparisonTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/integration/ModelComparisonTest.kt
@@ -5,6 +5,8 @@ import com.devquest.client.ai.evaluator.CareerEssayEvaluator
 import com.devquest.client.ai.evaluator.MockInterviewEvaluator
 import com.devquest.client.ai.evaluator.SkillAssessmentEvaluator
 import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
@@ -65,7 +67,7 @@ class ModelComparisonTest {
                 .build()
         ).build()
 
-        executor = AiCallExecutor(maxRetry = 1)
+        executor = AiCallExecutor(maxRetry = 1, metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry()))
     }
 
     // ── 자기소개서 평가 비교 ───────────────────────────────────────────────

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiCallExecutorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiCallExecutorTest.kt
@@ -4,6 +4,7 @@ import com.devquest.core.domain.support.AiEvaluationException
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -18,6 +19,11 @@ class AiCallExecutorTest {
         meterRegistry = SimpleMeterRegistry()
         metricsRecorder = AiMetricsRecorder(meterRegistry)
         executor = AiCallExecutor(maxRetry = 3, metricsRecorder = metricsRecorder)
+        AiCallContext.clear()
+    }
+
+    @AfterEach
+    fun teardown() {
         AiCallContext.clear()
     }
 

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiCallExecutorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiCallExecutorTest.kt
@@ -1,0 +1,98 @@
+package com.devquest.client.ai.support
+
+import com.devquest.core.domain.support.AiEvaluationException
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AiCallExecutorTest {
+
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var metricsRecorder: AiMetricsRecorder
+    private lateinit var executor: AiCallExecutor
+
+    @BeforeEach
+    fun setup() {
+        meterRegistry = SimpleMeterRegistry()
+        metricsRecorder = AiMetricsRecorder(meterRegistry)
+        executor = AiCallExecutor(maxRetry = 3, metricsRecorder = metricsRecorder)
+        AiCallContext.clear()
+    }
+
+    @Test
+    fun `action이 성공하면 결과를 반환하고 success 카운터를 증가시킨다`() {
+        val result = executor.execute(
+            evaluatorName = "TestEvaluator",
+            model = "claude-haiku-4-5-20251001"
+        ) { "success" }
+
+        assertThat(result).isEqualTo("success")
+        val successCount = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "success"
+        ).count()
+        assertThat(successCount).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `모든 재시도 실패 시 AiEvaluationException을 던지고 failure 카운터를 증가시킨다`() {
+        assertThatThrownBy {
+            executor.execute<String>(
+                evaluatorName = "TestEvaluator",
+                model = "claude-haiku-4-5-20251001"
+            ) {
+                throw RuntimeException("AI 호출 실패")
+            }
+        }.isInstanceOf(AiEvaluationException::class.java)
+
+        val failureCount = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "failure"
+        ).count()
+        assertThat(failureCount).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `2회 실패 후 성공하면 retry 카운터가 2 증가한다`() {
+        var callCount = 0
+
+        executor.execute(
+            evaluatorName = "TestEvaluator",
+            model = "claude-haiku-4-5-20251001"
+        ) {
+            callCount++
+            if (callCount < 3) null else "ok"
+        }
+
+        val retryCount = meterRegistry.counter(
+            "devquest.ai.retry.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001"
+        ).count()
+        assertThat(retryCount).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `action이 null을 반환하면 AiEvaluationException 발생 후 failure 카운터 증가`() {
+        assertThatThrownBy {
+            executor.execute<String>(
+                evaluatorName = "TestEvaluator",
+                model = "claude-haiku-4-5-20251001"
+            ) { null }
+        }.isInstanceOf(AiEvaluationException::class.java)
+
+        val failureCount = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "failure"
+        ).count()
+        assertThat(failureCount).isEqualTo(1.0)
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiMetricsRecorderTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/support/AiMetricsRecorderTest.kt
@@ -1,0 +1,83 @@
+package com.devquest.client.ai.support
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AiMetricsRecorderTest {
+
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var recorder: AiMetricsRecorder
+
+    @BeforeEach
+    fun setup() {
+        meterRegistry = SimpleMeterRegistry()
+        recorder = AiMetricsRecorder(meterRegistry)
+    }
+
+    @Test
+    fun `recordCallSuccess는 devquest_ai_call_total에 status=success로 기록한다`() {
+        recorder.recordCallSuccess("CareerEssayEvaluator", "claude-haiku-4-5-20251001")
+
+        val count = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "CareerEssayEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "success"
+        ).count()
+
+        assertThat(count).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `recordCallFailure는 devquest_ai_call_total에 status=failure로 기록한다`() {
+        recorder.recordCallFailure("ResumeCheckEvaluator", "claude-haiku-4-5-20251001")
+
+        val count = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "ResumeCheckEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "failure"
+        ).count()
+
+        assertThat(count).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `recordRetry는 devquest_ai_retry_total을 증가시킨다`() {
+        recorder.recordRetry("BossPackageEvaluator", "claude-sonnet-4-6")
+        recorder.recordRetry("BossPackageEvaluator", "claude-sonnet-4-6")
+
+        val count = meterRegistry.counter(
+            "devquest.ai.retry.total",
+            "evaluatorType", "BossPackageEvaluator",
+            "model", "claude-sonnet-4-6"
+        ).count()
+
+        assertThat(count).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `success와 failure는 서로 다른 카운터로 집계된다`() {
+        recorder.recordCallSuccess("TestEvaluator", "claude-haiku-4-5-20251001")
+        recorder.recordCallFailure("TestEvaluator", "claude-haiku-4-5-20251001")
+
+        val success = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "success"
+        ).count()
+
+        val failure = meterRegistry.counter(
+            "devquest.ai.call.total",
+            "evaluatorType", "TestEvaluator",
+            "model", "claude-haiku-4-5-20251001",
+            "status", "failure"
+        ).count()
+
+        assertThat(success).isEqualTo(1.0)
+        assertThat(failure).isEqualTo(1.0)
+    }
+}

--- a/be/support/monitoring/src/main/resources/monitoring.yml
+++ b/be/support/monitoring/src/main/resources/monitoring.yml
@@ -3,6 +3,28 @@ management:
     web:
       exposure:
         include: health,prometheus
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        gen_ai.client.operation: true
+      percentiles:
+        http.server.requests: 0.5,0.95,0.99
+        gen_ai.client.operation: 0.5,0.95,0.99
+    tags:
+      application: devquest-api
+
+spring:
+  ai:
+    chat:
+      observations:
+        include-prompt: false
+        include-completion: false
+    anthropic:
+      chat:
+        observations:
+          include-prompt: false
+          include-completion: false
 
 grafana:
   otlp:


### PR DESCRIPTION
## 변경 내용

- `AiMetricsRecorder` 신규 추가 — 커스텀 비즈니스 메트릭 기록 전담 컴포넌트
- `BaseAiEvaluator` 수정 — `modelName` 파라미터 + `AiModel` 상수 추가 (HAIKU/SONNET)
- `AiCallExecutor` 수정 — 호출 성공/실패/재시도 시 메트릭 기록, modelName 전달
- Boss Evaluator 5종 — `AiModel.SONNET` 명시, 일반 Evaluator — `AiModel.HAIKU` 기본값
- `monitoring.yml` 수정 — Spring AI Observation 활성화, HTTP 분위수 히스토그램 추가

## 수집되는 메트릭

| 메트릭 | 타입 | 태그 | 출처 |
|--------|------|------|------|
| `devquest.ai.call.total` | Counter | evaluatorType, model, status(success/failure) | AiMetricsRecorder |
| `devquest.ai.retry.total` | Counter | evaluatorType, model | AiMetricsRecorder |
| `gen_ai.client.operation` | Timer (p50/p95/p99) | gen_ai.system, gen_ai.request.model | Spring AI 자동 |
| `gen_ai.client.token.usage` | DistributionSummary | gen_ai.token.type(input/output) | Spring AI 자동 |
| `http.server.requests` | Timer (p50/p95/p99) | uri, method, status | Spring MVC 자동 |

## 활용 목적

- 모델별(haiku vs sonnet) 토큰 사용량 비교 → 비용 최적화 판단
- 평가 유형별 AI 호출 횟수/실패율 추적 → 품질 라우팅 개선
- 재시도 빈도 모니터링 → 프롬프트 품질 측정