### PR TITLE
chore: QA 강제화 훅 추가 — gh pr create 전 qa-reviewer 실행 여부 차단

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -263,11 +263,16 @@ Agent(subagent_type: "qa-reviewer", prompt: """
 
 → CRITICAL 여부 확인
 
+**QA 완료 즉시 마커 파일 생성 (필수 — 없으면 PR 생성 훅이 차단)**:
+```bash
+mkdir -p .claude/qa-cache && echo "QA_PASSED" > ".claude/qa-cache/$(git branch --show-current)"
+```
+
 ---
 
 ## 8단계: CRITICAL 처리
 
-**CRITICAL 없음** → 9단계 (PR 생성 시 assert-pr-reviewed.sh가 자동으로 최종 검토 실행)
+**CRITICAL 없음** → 9단계 (PR 생성 시 assert-qa-run.sh + assert-pr-reviewed.sh가 자동으로 검토 실행)
 
 **CRITICAL 있음**:
 - BE CRITICAL → be-feature-builder 재스폰 (수정 내용 명시)

--- a/.claude/scripts/assert-qa-run.sh
+++ b/.claude/scripts/assert-qa-run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# gh pr create 전 QA 리뷰 실행 여부 강제 확인
+# chore/, docs/ 브랜치는 면제
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+# gh pr create 명령인지 확인
+if ! echo "$COMMAND" | grep -qE "gh pr create"; then
+  exit 0
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# chore/ 또는 docs/ 브랜치는 QA 면제
+if echo "$BRANCH" | grep -qE "^(chore|docs)/"; then
+  exit 0
+fi
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$PROJECT_ROOT" ]; then
+  exit 0
+fi
+
+QA_MARKER="$PROJECT_ROOT/.claude/qa-cache/$BRANCH"
+
+if [ ! -f "$QA_MARKER" ]; then
+  echo "⛔ PR 생성 차단: QA 리뷰가 실행되지 않았습니다." >&2
+  echo "   orchestrator 7단계(qa-reviewer)를 먼저 실행하세요." >&2
+  echo "   브랜치: $BRANCH" >&2
+  echo "" >&2
+  echo "   QA 완료 후 orchestrator가 마커를 자동 생성합니다:" >&2
+  echo "   .claude/qa-cache/$BRANCH" >&2
+  exit 2
+fi
+
+echo "✅ QA 마커 확인됨 ($BRANCH). PR 생성 진행합니다." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,7 @@
         "hooks": [
           { "type": "command", "command": ".claude/scripts/assert-no-main-push.sh" },
           { "type": "command", "command": ".claude/scripts/assert-no-admin.sh" },
+          { "type": "command", "command": ".claude/scripts/assert-qa-run.sh" },
           { "type": "command", "command": ".claude/scripts/assert-pr-reviewed.sh" },
           { "type": "command", "command": ".claude/scripts/log-event.sh PreToolUse main" }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ desktop.ini
 .claude/launch.json
 .claude/worktrees/
 .claude/review-cache/
+.claude/qa-cache/
 .claude/docs/ai-interview-notes.md
 # === Root npm (dev tool only) ===
 /package.json


### PR DESCRIPTION
## 변경 요약

- `assert-qa-run.sh` 신규 추가 — `gh pr create` 전 `.claude/qa-cache/<브랜치명>` 마커 파일 존재 여부 확인
- `settings.json` PreToolUse Bash 훅에 `assert-qa-run.sh` 추가 (`assert-pr-reviewed.sh` 앞에 실행)
- `orchestrator.md` — QA 완료 후 마커 파일 생성 명령 필수 절차로 추가
- `.gitignore` — `.claude/qa-cache/` 추가

## 동작

```
feat/* 브랜치에서 gh pr create 호출
  → assert-qa-run.sh 실행
    → .claude/qa-cache/<브랜치명> 없으면 ⛔ 차단
    → 있으면 ✅ 통과 → assert-pr-reviewed.sh 실행
```

`chore/`, `docs/` 브랜치는 QA 면제.

## 오케스트레이터 변경

7단계(qa-reviewer) 완료 즉시 마커 생성이 **필수 절차**로 명시됨:
```bash
mkdir -p .claude/qa-cache && echo "QA_PASSED" > ".claude/qa-cache/$(git branch --show-current)"
```