### PR TITLE
feat(be): AI 캐시 토큰 메트릭 추가 + Grafana 대시보드

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `feat/ai-token-metrics-dashboard` |
+| 열린 PR | #187 — AI 캐시 토큰 메트릭 + Grafana 대시보드 (머지 대기) |
 
 
 
@@ -72,6 +72,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #187 | AI 캐시 토큰 메트릭 추가 + Grafana 대시보드 (cache_read/creation 카운터, 5개 섹션 대시보드) | 2026-06-09 |
 | #186 | Better Stack 제거 — Grafana Cloud Loki 전환 (loki4j 1.6.0) | 2026-06-09 |
 | #185 | QA 강제화 훅 — gh pr create 전 qa-reviewer 실행 여부 차단 | 2026-06-09 |
 | #184 | 모의면접 Java/인프라 카테고리 추가 및 질문 다양성 강화 + 모범 답안 상세화 | 2026-06-09 |

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -81,6 +81,8 @@ class CacheMetricsAdvisor(
             meterRegistry.timer("ai.call.duration", "evaluator", evaluatorName, "model", modelName).record(latencyMs, TimeUnit.MILLISECONDS)
             meterRegistry.counter("ai.tokens.input", "evaluator", evaluatorName, "model", modelName).increment(inputTokens.toDouble())
             meterRegistry.counter("ai.tokens.output", "evaluator", evaluatorName, "model", modelName).increment(outputTokens.toDouble())
+            meterRegistry.counter("ai.tokens.cache_read", "evaluator", evaluatorName, "model", modelName).increment(cacheRead.toDouble())
+            meterRegistry.counter("ai.tokens.cache_creation", "evaluator", evaluatorName, "model", modelName).increment(cacheCreation.toDouble())
 
         }.onFailure { e ->
             log.debug("Failed to extract cache metrics", e)

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -77,12 +77,11 @@ class CacheMetricsAdvisor(
                 log.warn("AI 메트릭 DB 저장 실패", e)
             }
 
-            meterRegistry.counter("ai.call.total", "evaluator", evaluatorName, "model", modelName).increment()
-            meterRegistry.timer("ai.call.duration", "evaluator", evaluatorName, "model", modelName).record(latencyMs, TimeUnit.MILLISECONDS)
-            meterRegistry.counter("ai.tokens.input", "evaluator", evaluatorName, "model", modelName).increment(inputTokens.toDouble())
-            meterRegistry.counter("ai.tokens.output", "evaluator", evaluatorName, "model", modelName).increment(outputTokens.toDouble())
-            meterRegistry.counter("ai.tokens.cache_read", "evaluator", evaluatorName, "model", modelName).increment(cacheRead.toDouble())
-            meterRegistry.counter("ai.tokens.cache_creation", "evaluator", evaluatorName, "model", modelName).increment(cacheCreation.toDouble())
+            meterRegistry.timer("ai.call.duration", "evaluatorType", evaluatorName, "model", modelName).record(latencyMs, TimeUnit.MILLISECONDS)
+            meterRegistry.counter("ai.tokens.input", "evaluatorType", evaluatorName, "model", modelName).increment(inputTokens.toDouble())
+            meterRegistry.counter("ai.tokens.output", "evaluatorType", evaluatorName, "model", modelName).increment(outputTokens.toDouble())
+            meterRegistry.counter("ai.tokens.cache_read", "evaluatorType", evaluatorName, "model", modelName).increment(cacheRead.toDouble())
+            meterRegistry.counter("ai.tokens.cache_creation", "evaluatorType", evaluatorName, "model", modelName).increment(cacheCreation.toDouble())
 
         }.onFailure { e ->
             log.debug("Failed to extract cache metrics", e)

--- a/grafana/ai-metrics-dashboard.json
+++ b/grafana/ai-metrics-dashboard.json
@@ -1,0 +1,490 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Grafana Cloud Prometheus (Mimir) datasource",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "호출 현황",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
+      "title": "총 AI 호출 (1h)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(devquest_ai_call_total[1h]))",
+          "legendFormat": "총 호출",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.95 },
+              { "color": "green", "value": 0.99 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "title": "성공률 (1h)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(devquest_ai_call_total{status=\"success\"}[1h])) / sum(increase(devquest_ai_call_total[1h]))",
+          "legendFormat": "성공률",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.3 },
+              { "color": "green", "value": 0.6 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "title": "캐시 히트율 (5m)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_cache_read_total[5m])) / (sum(rate(ai_tokens_cache_read_total[5m])) + sum(rate(ai_tokens_input_total[5m])) + 0.0001)",
+          "legendFormat": "캐시 히트율",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5000 },
+              { "color": "red", "value": 10000 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "title": "P95 레이턴시 (5m)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "P95",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
+      "title": "재시도 횟수 (1h)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(devquest_ai_retry_total[1h]))",
+          "legendFormat": "재시도",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "title": "토큰 사용량",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 10,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "입력 토큰 / 출력 토큰 (evaluator별)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_input_total[5m])) by (evaluator)",
+          "legendFormat": "input · {{evaluator}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_output_total[5m])) by (evaluator)",
+          "legendFormat": "output · {{evaluator}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 20 },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "cache_read" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "cache_creation" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 11,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "캐시 토큰 (cache_read vs cache_creation)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_cache_read_total[5m]))",
+          "legendFormat": "cache_read",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_cache_creation_total[5m]))",
+          "legendFormat": "cache_creation",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "title": "캐시 효율",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 20,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "캐시 히트율 추이 (evaluator별)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(ai_tokens_cache_read_total[5m])) by (evaluator) / (sum(rate(ai_tokens_cache_read_total[5m])) by (evaluator) + sum(rate(ai_tokens_input_total[5m])) by (evaluator) + 0.0001)",
+          "legendFormat": "{{evaluator}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 21,
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "캐시 절약 토큰 (cache_read 누적)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator)",
+          "legendFormat": "절약 · {{evaluator}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "title": "레이턴시",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 5 },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 30,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "AI 호출 레이턴시 P50 / P95 / P99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 5 },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 31,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "title": "Evaluator별 P95 레이턴시",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le, evaluator)) * 1000",
+          "legendFormat": "{{evaluator}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 104,
+      "title": "Evaluator 요약",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "custom": { "align": "auto", "displayMode": "auto" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "캐시 히트율" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "custom.displayMode", "value": "color-background" },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.3 }, { "color": "green", "value": 0.6 }] } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "성공률" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "custom.displayMode", "value": "color-background" },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.9 }, { "color": "green", "value": 0.99 }] } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 33 },
+      "id": 40,
+      "options": { "footer": { "show": false }, "showHeader": true, "sortBy": [{ "displayName": "호출 수", "desc": true }] },
+      "title": "Evaluator별 종합 현황 (1h)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(devquest_ai_call_total[1h])) by (evaluatorType)",
+          "legendFormat": "{{evaluatorType}}",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(devquest_ai_call_total{status=\"success\"}[1h])) by (evaluatorType) / sum(increase(devquest_ai_call_total[1h])) by (evaluatorType)",
+          "legendFormat": "{{evaluatorType}}",
+          "refId": "B",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator) / (sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator) + sum(increase(ai_tokens_input_total[1h])) by (evaluator) + 0.0001)",
+          "legendFormat": "{{evaluator}}",
+          "refId": "C",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "호출 수",
+              "Value #B": "성공률",
+              "Value #C": "캐시 히트율"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "tags": ["devquest", "ai", "metrics"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus Datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "DevQuest — AI 메트릭",
+  "uid": "devquest-ai-metrics",
+  "version": 1
+}

--- a/grafana/ai-metrics-dashboard.json
+++ b/grafana/ai-metrics-dashboard.json
@@ -28,7 +28,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "id": 100,
-      "title": "호출 현황",
+      "title": "?�출 ?�황",
       "type": "row"
     },
     {
@@ -49,13 +49,13 @@
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
       "id": 1,
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "총 AI 호출 (1h)",
+      "title": "�?AI ?�출 (1h)",
       "type": "stat",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "expr": "sum(increase(devquest_ai_call_total[1h]))",
-          "legendFormat": "총 호출",
+          "legendFormat": "�??�출",
           "refId": "A"
         }
       ]
@@ -82,13 +82,13 @@
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "id": 2,
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "성공률 (1h)",
+      "title": "?�공�?(1h)",
       "type": "stat",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "expr": "sum(increase(devquest_ai_call_total{status=\"success\"}[1h])) / sum(increase(devquest_ai_call_total[1h]))",
-          "legendFormat": "성공률",
+          "legendFormat": "?�공�?,
           "refId": "A"
         }
       ]
@@ -115,13 +115,13 @@
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
       "id": 3,
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "캐시 히트율 (5m)",
+      "title": "캐시 ?�트??(5m)",
       "type": "stat",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "expr": "sum(rate(ai_tokens_cache_read_total[5m])) / (sum(rate(ai_tokens_cache_read_total[5m])) + sum(rate(ai_tokens_input_total[5m])) + 0.0001)",
-          "legendFormat": "캐시 히트율",
+          "legendFormat": "캐시 ?�트??,
           "refId": "A"
         }
       ]
@@ -146,7 +146,7 @@
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
       "id": 4,
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "P95 레이턴시 (5m)",
+      "title": "P95 ?�이?�시 (5m)",
       "type": "stat",
       "targets": [
         {
@@ -175,13 +175,13 @@
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "id": 5,
       "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "재시도 횟수 (1h)",
+      "title": "?�시???�수 (1h)",
       "type": "stat",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "expr": "sum(increase(devquest_ai_retry_total[1h]))",
-          "legendFormat": "재시도",
+          "legendFormat": "?�시??,
           "refId": "A"
         }
       ]
@@ -190,7 +190,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
       "id": 101,
-      "title": "토큰 사용량",
+      "title": "?�큰 ?�용??,
       "type": "row"
     },
     {
@@ -206,19 +206,19 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
       "id": 10,
       "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "입력 토큰 / 출력 토큰 (evaluator별)",
+      "title": "?�력 ?�큰 / 출력 ?�큰 (evaluator�?",
       "type": "timeseries",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(ai_tokens_input_total[5m])) by (evaluator)",
-          "legendFormat": "input · {{evaluator}}",
+          "expr": "sum(rate(ai_tokens_input_total[5m])) by (evaluatorType)",
+          "legendFormat": "input · {{evaluatorType}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(ai_tokens_output_total[5m])) by (evaluator)",
-          "legendFormat": "output · {{evaluator}}",
+          "expr": "sum(rate(ai_tokens_output_total[5m])) by (evaluatorType)",
+          "legendFormat": "output · {{evaluatorType}}",
           "refId": "B"
         }
       ]
@@ -245,7 +245,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
       "id": 11,
       "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "캐시 토큰 (cache_read vs cache_creation)",
+      "title": "캐시 ?�큰 (cache_read vs cache_creation)",
       "type": "timeseries",
       "targets": [
         {
@@ -266,7 +266,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
       "id": 102,
-      "title": "캐시 효율",
+      "title": "캐시 ?�율",
       "type": "row"
     },
     {
@@ -284,13 +284,13 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
       "id": 20,
       "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "캐시 히트율 추이 (evaluator별)",
+      "title": "캐시 ?�트??추이 (evaluator�?",
       "type": "timeseries",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(ai_tokens_cache_read_total[5m])) by (evaluator) / (sum(rate(ai_tokens_cache_read_total[5m])) by (evaluator) + sum(rate(ai_tokens_input_total[5m])) by (evaluator) + 0.0001)",
-          "legendFormat": "{{evaluator}}",
+          "expr": "sum(rate(ai_tokens_cache_read_total[5m])) by (evaluatorType) / (sum(rate(ai_tokens_cache_read_total[5m])) by (evaluatorType) + sum(rate(ai_tokens_input_total[5m])) by (evaluatorType) + 0.0001)",
+          "legendFormat": "{{evaluatorType}}",
           "refId": "A"
         }
       ]
@@ -308,13 +308,13 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
       "id": 21,
       "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "캐시 절약 토큰 (cache_read 누적)",
+      "title": "캐시 ?�약 ?�큰 (cache_read ?�적)",
       "type": "timeseries",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator)",
-          "legendFormat": "절약 · {{evaluator}}",
+          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluatorType)",
+          "legendFormat": "?�약 · {{evaluatorType}}",
           "refId": "A"
         }
       ]
@@ -323,7 +323,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
       "id": 103,
-      "title": "레이턴시",
+      "title": "?�이?�시",
       "type": "row"
     },
     {
@@ -339,7 +339,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
       "id": 30,
       "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "AI 호출 레이턴시 P50 / P95 / P99",
+      "title": "AI ?�출 ?�이?�시 P50 / P95 / P99",
       "type": "timeseries",
       "targets": [
         {
@@ -375,13 +375,13 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
       "id": 31,
       "options": { "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "Evaluator별 P95 레이턴시",
+      "title": "Evaluator�?P95 ?�이?�시",
       "type": "timeseries",
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "histogram_quantile(0.95, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le, evaluator)) * 1000",
-          "legendFormat": "{{evaluator}}",
+          "expr": "histogram_quantile(0.95, sum(rate(ai_call_duration_seconds_bucket[5m])) by (le, evaluatorType)) * 1000",
+          "legendFormat": "{{evaluatorType}}",
           "refId": "A"
         }
       ]
@@ -390,7 +390,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
       "id": 104,
-      "title": "Evaluator 요약",
+      "title": "Evaluator ?�약",
       "type": "row"
     },
     {
@@ -403,7 +403,7 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "캐시 히트율" },
+            "matcher": { "id": "byName", "options": "캐시 ?�트?? },
             "properties": [
               { "id": "unit", "value": "percentunit" },
               { "id": "custom.displayMode", "value": "color-background" },
@@ -411,7 +411,7 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "성공률" },
+            "matcher": { "id": "byName", "options": "?�공�? },
             "properties": [
               { "id": "unit", "value": "percentunit" },
               { "id": "custom.displayMode", "value": "color-background" },
@@ -422,8 +422,8 @@
       },
       "gridPos": { "h": 10, "w": 24, "x": 0, "y": 33 },
       "id": 40,
-      "options": { "footer": { "show": false }, "showHeader": true, "sortBy": [{ "displayName": "호출 수", "desc": true }] },
-      "title": "Evaluator별 종합 현황 (1h)",
+      "options": { "footer": { "show": false }, "showHeader": true, "sortBy": [{ "displayName": "?�출 ??, "desc": true }] },
+      "title": "Evaluator�?종합 ?�황 (1h)",
       "type": "table",
       "targets": [
         {
@@ -442,8 +442,8 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator) / (sum(increase(ai_tokens_cache_read_total[1h])) by (evaluator) + sum(increase(ai_tokens_input_total[1h])) by (evaluator) + 0.0001)",
-          "legendFormat": "{{evaluator}}",
+          "expr": "sum(increase(ai_tokens_cache_read_total[1h])) by (evaluatorType) / (sum(increase(ai_tokens_cache_read_total[1h])) by (evaluatorType) + sum(increase(ai_tokens_input_total[1h])) by (evaluatorType) + 0.0001)",
+          "legendFormat": "{{evaluatorType}}",
           "refId": "C",
           "instant": true
         }
@@ -454,9 +454,9 @@
           "id": "organize",
           "options": {
             "renameByName": {
-              "Value #A": "호출 수",
-              "Value #B": "성공률",
-              "Value #C": "캐시 히트율"
+              "Value #A": "?�출 ??,
+              "Value #B": "?�공�?,
+              "Value #C": "캐시 ?�트??
             }
           }
         }
@@ -484,7 +484,7 @@
   "time": { "from": "now-3h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "DevQuest — AI 메트릭",
+  "title": "DevQuest ??AI 메트�?,
   "uid": "devquest-ai-metrics",
   "version": 1
 }


### PR DESCRIPTION
## 요약

- `CacheMetricsAdvisor`에 캐시 토큰 Micrometer 카운터 2개 추가
- Grafana Cloud 대시보드 JSON 추가 — import 한 번으로 주요 지표 고정

## 변경 사항

### BE
| 추가 메트릭 | 설명 |
|------------|------|
| `ai.tokens.cache_read{evaluatorType, model}` | 캐시 히트 시 절약된 토큰 수 |
| `ai.tokens.cache_creation{evaluatorType, model}` | 캐시 생성 토큰 수 |

기존 `ai.call.total` 중복 카운터 제거, 태그명 `evaluator` -> `evaluatorType` 통일

### Grafana 대시보드 (`grafana/ai-metrics-dashboard.json`)

| 섹션 | 패널 |
|------|------|
| Overview | 총 호출 수 / 성공률 / 캐시 히트율 / P95 레이턴시 / 재시도 횟수 |
| Token Usage | Evaluator별 input/output 토큰, cache_read vs cache_creation |
| Cache Efficiency | Evaluator별 캐시 히트율 추이, 캐시 절약 토큰 누적 |
| Latency | 전체 P50/P95/P99, Evaluator별 P95 |
| Evaluator Summary | 호출수 / 성공률 / 캐시 히트율 테이블 |

## 대시보드 import 방법

Grafana Cloud > Dashboards > Import > JSON 파일 업로드 -> `grafana/ai-metrics-dashboard.json` 선택