### PR TITLE
feat(be+fe): 기술면접 비로그인 체험 + IP rate limiting

### DIFF
--- a/.claude/qa-cache/feat/tech-interview-demo
+++ b/.claude/qa-cache/feat/tech-interview-demo
@@ -1,0 +1,1 @@
+QA_PASSED

--- a/be/core/core-api/build.gradle.kts
+++ b/be/core/core-api/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/config/WebMvcConfig.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/config/WebMvcConfig.kt
@@ -1,0 +1,17 @@
+package com.devquest.core.api.config
+
+import com.devquest.core.api.support.TechInterviewRateLimitInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val techInterviewRateLimitInterceptor: TechInterviewRateLimitInterceptor,
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(techInterviewRateLimitInterceptor)
+            .addPathPatterns("/api/v1/tech-interview/**")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/TechInterviewController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/TechInterviewController.kt
@@ -17,7 +17,7 @@ class TechInterviewController(
 
     @GetMapping("/question")
     fun generateQuestion(
-        @AuthenticationPrincipal userId: String,
+        @AuthenticationPrincipal(errorOnInvalidType = false) userId: String?,
         @RequestParam(defaultValue = "Java") techStack: String,
     ): ApiResponse<*> {
         return ApiResponse.success(techInterviewService.generateQuestion(userId, techStack))
@@ -25,7 +25,7 @@ class TechInterviewController(
 
     @PostMapping("/evaluate")
     fun evaluate(
-        @AuthenticationPrincipal userId: String,
+        @AuthenticationPrincipal(errorOnInvalidType = false) userId: String?,
         @Valid @RequestBody request: TechInterviewEvaluateRequestDto,
     ): ApiResponse<*> {
         return ApiResponse.success(

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/RateLimitResetScheduler.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/RateLimitResetScheduler.kt
@@ -1,0 +1,19 @@
+package com.devquest.core.api.support
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class RateLimitResetScheduler(
+    private val rateLimitBucketStore: RateLimitBucketStore,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    fun resetDailyLimits() {
+        rateLimitBucketStore.clear()
+        log.info("Rate limit buckets cleared (daily reset)")
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -39,18 +39,21 @@ class TechInterviewRateLimitInterceptor : HandlerInterceptor {
             response.status = HttpStatus.TOO_MANY_REQUESTS.value()
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.characterEncoding = "UTF-8"
-            response.writer.write(
-                objectMapper.writeValueAsString(
-                    mapOf(
-                        "result" to "ERROR",
-                        "data" to null,
-                        "error" to mapOf(
-                            "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
-                            "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
+            response.writer.apply {
+                write(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "result" to "ERROR",
+                            "data" to null,
+                            "error" to mapOf(
+                                "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
+                                "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
+                            )
                         )
                     )
                 )
-            )
+                flush()
+            }
             false
         }
     }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -8,23 +8,21 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import java.time.Duration
-import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 
 @Component
 class TechInterviewRateLimitInterceptor : HandlerInterceptor {
 
     private val objectMapper = ObjectMapper()
-    private val buckets: MutableMap<String, Bucket> = Collections.synchronizedMap(
-        object : LinkedHashMap<String, Bucket>(16, 0.75f, true) {
-            override fun removeEldestEntry(eldest: Map.Entry<String, Bucket>) = size > MAX_IP_COUNT
-        }
-    )
+    private val buckets = ConcurrentHashMap<String, Bucket>()
 
-    companion object {
-        private const val MAX_IP_COUNT = 5000
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    fun clearBuckets() {
+        buckets.clear()
     }
 
     override fun preHandle(
@@ -33,7 +31,7 @@ class TechInterviewRateLimitInterceptor : HandlerInterceptor {
         handler: Any,
     ): Boolean {
         val ip = request.getHeader("Fly-Client-IP") ?: request.remoteAddr
-        val bucket = buckets.getOrPut(ip) { newBucket() }
+        val bucket = buckets.computeIfAbsent(ip) { newBucket() }
 
         return if (bucket.tryConsume(1)) {
             true

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -6,8 +6,10 @@ import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import java.time.Duration
@@ -17,6 +19,19 @@ import java.util.concurrent.ConcurrentHashMap
 class TechInterviewRateLimitInterceptor(
     private val rateLimitBucketStore: RateLimitBucketStore,
 ) : HandlerInterceptor {
+
+    private val rateLimitResponseJson: String by lazy {
+        ObjectMapper().writeValueAsString(
+            mapOf(
+                "result" to "ERROR",
+                "data" to null,
+                "error" to mapOf(
+                    "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
+                    "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
+                )
+            )
+        )
+    }
 
     override fun preHandle(
         request: HttpServletRequest,
@@ -33,7 +48,7 @@ class TechInterviewRateLimitInterceptor(
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.characterEncoding = "UTF-8"
             response.writer.apply {
-                write(RATE_LIMIT_RESPONSE_JSON)
+                write(rateLimitResponseJson)
                 flush()
             }
             false
@@ -46,23 +61,13 @@ class TechInterviewRateLimitInterceptor(
             ?: request.getHeader("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
             ?: request.remoteAddr
     }
-
-    companion object {
-        private val RATE_LIMIT_RESPONSE_JSON: String = ObjectMapper().writeValueAsString(
-            mapOf(
-                "result" to "ERROR",
-                "data" to null,
-                "error" to mapOf(
-                    "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
-                    "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
-                )
-            )
-        )
-    }
 }
 
 @Component
-class RateLimitBucketStore {
+class RateLimitBucketStore(
+    @Value("\${devquest.rate-limit.tech-interview.capacity:2}") private val capacity: Long,
+    @Value("\${devquest.rate-limit.tech-interview.refill-days:1}") private val refillDays: Long,
+) {
 
     private val buckets = ConcurrentHashMap<String, Bucket>()
 
@@ -73,8 +78,8 @@ class RateLimitBucketStore {
     private fun newBucket(): Bucket = Bucket.builder()
         .addLimit(
             Bandwidth.builder()
-                .capacity(2)
-                .refillIntervally(2, Duration.ofDays(1))
+                .capacity(capacity)
+                .refillIntervally(capacity, Duration.ofDays(refillDays))
                 .build()
         )
         .build()

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -52,8 +52,8 @@ class TechInterviewRateLimitInterceptor : HandlerInterceptor {
     private fun newBucket(): Bucket = Bucket.builder()
         .addLimit(
             Bandwidth.builder()
-                .capacity(1)
-                .refillIntervally(1, Duration.ofDays(1))
+                .capacity(2)
+                .refillIntervally(2, Duration.ofDays(1))
                 .build()
         )
         .build()

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -11,13 +11,21 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import java.time.Duration
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
 
 @Component
 class TechInterviewRateLimitInterceptor : HandlerInterceptor {
 
     private val objectMapper = ObjectMapper()
-    private val buckets = ConcurrentHashMap<String, Bucket>()
+    private val buckets: MutableMap<String, Bucket> = Collections.synchronizedMap(
+        object : LinkedHashMap<String, Bucket>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, Bucket>) = size > MAX_IP_COUNT
+        }
+    )
+
+    companion object {
+        private const val MAX_IP_COUNT = 5000
+    }
 
     override fun preHandle(
         request: HttpServletRequest,
@@ -36,7 +44,7 @@ class TechInterviewRateLimitInterceptor : HandlerInterceptor {
             response.writer.write(
                 objectMapper.writeValueAsString(
                     mapOf(
-                        "result" to "FAIL",
+                        "result" to "ERROR",
                         "data" to null,
                         "error" to mapOf(
                             "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -1,0 +1,60 @@
+package com.devquest.core.api.support
+
+import com.devquest.core.support.error.ErrorCode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class TechInterviewRateLimitInterceptor : HandlerInterceptor {
+
+    private val objectMapper = ObjectMapper()
+    private val buckets = ConcurrentHashMap<String, Bucket>()
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        val ip = request.getHeader("Fly-Client-IP") ?: request.remoteAddr
+        val bucket = buckets.getOrPut(ip) { newBucket() }
+
+        return if (bucket.tryConsume(1)) {
+            true
+        } else {
+            response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+            response.writer.write(
+                objectMapper.writeValueAsString(
+                    mapOf(
+                        "result" to "FAIL",
+                        "data" to null,
+                        "error" to mapOf(
+                            "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
+                            "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
+                        )
+                    )
+                )
+            )
+            false
+        }
+    }
+
+    private fun newBucket(): Bucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(1)
+                .refillIntervally(1, Duration.ofDays(1))
+                .build()
+        )
+        .build()
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptor.kt
@@ -8,30 +8,23 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 @Component
-class TechInterviewRateLimitInterceptor : HandlerInterceptor {
-
-    private val objectMapper = ObjectMapper()
-    private val buckets = ConcurrentHashMap<String, Bucket>()
-
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    fun clearBuckets() {
-        buckets.clear()
-    }
+class TechInterviewRateLimitInterceptor(
+    private val rateLimitBucketStore: RateLimitBucketStore,
+) : HandlerInterceptor {
 
     override fun preHandle(
         request: HttpServletRequest,
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
-        val ip = request.getHeader("Fly-Client-IP") ?: request.remoteAddr
-        val bucket = buckets.computeIfAbsent(ip) { newBucket() }
+        val ip = resolveClientIp(request)
+        val bucket = rateLimitBucketStore.getOrCreate(ip)
 
         return if (bucket.tryConsume(1)) {
             true
@@ -40,23 +33,42 @@ class TechInterviewRateLimitInterceptor : HandlerInterceptor {
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.characterEncoding = "UTF-8"
             response.writer.apply {
-                write(
-                    objectMapper.writeValueAsString(
-                        mapOf(
-                            "result" to "ERROR",
-                            "data" to null,
-                            "error" to mapOf(
-                                "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
-                                "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
-                            )
-                        )
-                    )
-                )
+                write(RATE_LIMIT_RESPONSE_JSON)
                 flush()
             }
             false
         }
     }
+
+    private fun resolveClientIp(request: HttpServletRequest): String {
+        // Fly.io 전용 헤더 → X-Forwarded-For 첫 번째 IP → remoteAddr 순으로 폴백
+        return request.getHeader("Fly-Client-IP")
+            ?: request.getHeader("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
+            ?: request.remoteAddr
+    }
+
+    companion object {
+        private val RATE_LIMIT_RESPONSE_JSON: String = ObjectMapper().writeValueAsString(
+            mapOf(
+                "result" to "ERROR",
+                "data" to null,
+                "error" to mapOf(
+                    "code" to ErrorCode.RATE_LIMIT_EXCEEDED.name,
+                    "message" to ErrorCode.RATE_LIMIT_EXCEEDED.message,
+                )
+            )
+        )
+    }
+}
+
+@Component
+class RateLimitBucketStore {
+
+    private val buckets = ConcurrentHashMap<String, Bucket>()
+
+    fun getOrCreate(ip: String): Bucket = buckets.computeIfAbsent(ip) { newBucket() }
+
+    fun clear() = buckets.clear()
 
     private fun newBucket(): Bucket = Bucket.builder()
         .addLimit(

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/TechInterviewService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/TechInterviewService.kt
@@ -13,16 +13,18 @@ class TechInterviewService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun generateQuestion(userId: String, techStack: String): TechInterviewResult {
+    fun generateQuestion(userId: String?, techStack: String): TechInterviewResult {
         log.info("기술 면접 질문 생성: userId=$userId, techStack=$techStack")
         return techInterviewPort.generateQuestions(techStack)
     }
 
     @Transactional
-    fun evaluate(userId: String, techStack: String, questions: List<String>, answers: List<String>): TechInterviewResult {
+    fun evaluate(userId: String?, techStack: String, questions: List<String>, answers: List<String>): TechInterviewResult {
         val result = techInterviewPort.evaluate(techStack, questions, answers)
-        val xp = QuestXpPolicy.calculate(QuestConstants.TECH_INTERVIEW, result.passed)
-        questProgressRecorder.record(userId, QuestConstants.TECH_INTERVIEW, 1, result.overallScore, result.passed, xp)
+        if (userId != null) {
+            val xp = QuestXpPolicy.calculate(QuestConstants.TECH_INTERVIEW, result.passed)
+            questProgressRecorder.record(userId, QuestConstants.TECH_INTERVIEW, 1, result.overallScore, result.passed, xp)
+        }
         log.info("기술 면접 평가 완료: userId=$userId, score=${result.overallScore}, passed=${result.passed}")
         return result
     }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/TechInterviewService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/TechInterviewService.kt
@@ -14,18 +14,20 @@ class TechInterviewService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun generateQuestion(userId: String?, techStack: String): TechInterviewResult {
-        log.info("기술 면접 질문 생성: userId=$userId, techStack=$techStack")
+        val userLabel = userId ?: "guest"
+        log.info("기술 면접 질문 생성: userId={}, techStack={}", userLabel, techStack)
         return techInterviewPort.generateQuestions(techStack)
     }
 
     @Transactional
     fun evaluate(userId: String?, techStack: String, questions: List<String>, answers: List<String>): TechInterviewResult {
         val result = techInterviewPort.evaluate(techStack, questions, answers)
+        val userLabel = userId ?: "guest"
         if (userId != null) {
             val xp = QuestXpPolicy.calculate(QuestConstants.TECH_INTERVIEW, result.passed)
             questProgressRecorder.record(userId, QuestConstants.TECH_INTERVIEW, 1, result.overallScore, result.passed, xp)
         }
-        log.info("기술 면접 평가 완료: userId=$userId, score=${result.overallScore}, passed=${result.passed}")
+        log.info("기술 면접 평가 완료: userId={}, score={}, passed={}", userLabel, result.overallScore, result.passed)
         return result
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/security/SecurityConfig.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/security/SecurityConfig.kt
@@ -28,6 +28,7 @@ class SecurityConfig(
             .cors { it.configurationSource(corsConfigurationSource()) }
             .authorizeHttpRequests {
                 it.requestMatchers("/api/v1/auth/**", "/health", "/actuator/health").permitAll()
+                it.requestMatchers("/api/v1/tech-interview/**").permitAll()
                 it.requestMatchers("/actuator/**").access(
                     WebExpressionAuthorizationManager(
                         "hasIpAddress('127.0.0.1') or hasIpAddress('::1') or hasIpAddress('fdaa::/16')"

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/support/error/ErrorCode.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/support/error/ErrorCode.kt
@@ -4,5 +4,6 @@ enum class ErrorCode(val message: String) {
     DEFAULT("알 수 없는 오류가 발생했습니다"),
     AI_EVALUATION_FAILED("AI 평가 중 오류가 발생했습니다"),
     INVALID_REQUEST("유효하지 않은 요청입니다"),
-    QUEST_NOT_FOUND("퀘스트를 찾을 수 없습니다")
+    QUEST_NOT_FOUND("퀘스트를 찾을 수 없습니다"),
+    RATE_LIMIT_EXCEEDED("오늘 체험 횟수를 초과했습니다. 내일 다시 시도해주세요.")
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/support/error/ErrorType.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/support/error/ErrorType.kt
@@ -6,5 +6,6 @@ enum class ErrorType(val status: HttpStatus, val code: ErrorCode, val message: S
     DEFAULT(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.DEFAULT, ErrorCode.DEFAULT.message),
     AI_EVALUATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.AI_EVALUATION_FAILED, ErrorCode.AI_EVALUATION_FAILED.message),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_REQUEST, ErrorCode.INVALID_REQUEST.message),
-    QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.QUEST_NOT_FOUND, ErrorCode.QUEST_NOT_FOUND.message)
+    QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.QUEST_NOT_FOUND, ErrorCode.QUEST_NOT_FOUND.message),
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, ErrorCode.RATE_LIMIT_EXCEEDED, ErrorCode.RATE_LIMIT_EXCEEDED.message)
 }

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -59,3 +59,7 @@ devquest:
     from: noreply@dhbang.co.kr
     enabled: ${MAIL_ENABLED:false}
 
+  rate-limit:
+    tech-interview:
+      capacity: 2
+      refill-days: 1

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
@@ -17,7 +17,7 @@ class TechInterviewRateLimitInterceptorTest {
 
     @BeforeEach
     fun setUp() {
-        store = RateLimitBucketStore()
+        store = RateLimitBucketStore(capacity = 2, refillDays = 1)
         interceptor = TechInterviewRateLimitInterceptor(store)
     }
 

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
@@ -40,8 +40,17 @@ class TechInterviewRateLimitInterceptorTest {
     }
 
     @Test
-    fun `같은 IP에서 두 번째 요청은 차단된다`() {
+    fun `같은 IP에서 두 번째 요청(평가)도 통과한다`() {
         val request = mockRequest("1.2.3.4")
+        interceptor.preHandle(request, mockResponse(), Any())
+        val result = interceptor.preHandle(request, mockResponse(), Any())
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `같은 IP에서 세 번째 요청은 차단된다`() {
+        val request = mockRequest("1.2.3.4")
+        interceptor.preHandle(request, mockResponse(), Any())
         interceptor.preHandle(request, mockResponse(), Any())
         val result = interceptor.preHandle(request, mockResponse(), Any())
         assertThat(result).isFalse()

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
@@ -12,24 +12,27 @@ import java.io.StringWriter
 
 class TechInterviewRateLimitInterceptorTest {
 
+    private lateinit var store: RateLimitBucketStore
     private lateinit var interceptor: TechInterviewRateLimitInterceptor
 
     @BeforeEach
     fun setUp() {
-        interceptor = TechInterviewRateLimitInterceptor()
+        store = RateLimitBucketStore()
+        interceptor = TechInterviewRateLimitInterceptor(store)
     }
 
-    private fun mockRequest(ip: String): HttpServletRequest {
+    private fun mockRequest(ip: String, flyClientIp: String? = null): HttpServletRequest {
         val request = mock<HttpServletRequest>()
-        whenever(request.getHeader("Fly-Client-IP")).thenReturn(null)
+        whenever(request.getHeader("Fly-Client-IP")).thenReturn(flyClientIp)
+        whenever(request.getHeader("X-Forwarded-For")).thenReturn(null)
         whenever(request.remoteAddr).thenReturn(ip)
         return request
     }
 
     private fun mockResponse(): HttpServletResponse {
         val response = mock<HttpServletResponse>()
-        val writer = StringWriter()
-        whenever(response.writer).thenReturn(PrintWriter(writer))
+        val writer = PrintWriter(StringWriter())
+        whenever(response.writer).thenReturn(writer)
         return response
     }
 
@@ -58,8 +61,27 @@ class TechInterviewRateLimitInterceptorTest {
 
     @Test
     fun `다른 IP는 독립적으로 카운트된다`() {
-        interceptor.preHandle(mockRequest("1.2.3.4"), mockResponse(), Any())  // IP-A 소진
-        val result = interceptor.preHandle(mockRequest("5.6.7.8"), mockResponse(), Any())  // IP-B 첫 시도
+        interceptor.preHandle(mockRequest("1.2.3.4"), mockResponse(), Any())
+        val result = interceptor.preHandle(mockRequest("5.6.7.8"), mockResponse(), Any())
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `Fly-Client-IP 헤더가 있으면 해당 IP로 식별된다`() {
+        // remoteAddr이 다르더라도 Fly-Client-IP 기준으로 동일 IP 취급
+        interceptor.preHandle(mockRequest("10.0.0.1", flyClientIp = "1.2.3.4"), mockResponse(), Any())
+        interceptor.preHandle(mockRequest("10.0.0.2", flyClientIp = "1.2.3.4"), mockResponse(), Any())
+        val result = interceptor.preHandle(mockRequest("10.0.0.3", flyClientIp = "1.2.3.4"), mockResponse(), Any())
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `store clear 후에는 다시 2회 허용된다`() {
+        val request = mockRequest("1.2.3.4")
+        interceptor.preHandle(request, mockResponse(), Any())
+        interceptor.preHandle(request, mockResponse(), Any())
+        store.clear()
+        val result = interceptor.preHandle(request, mockResponse(), Any())
         assertThat(result).isTrue()
     }
 }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/support/TechInterviewRateLimitInterceptorTest.kt
@@ -1,0 +1,56 @@
+package com.devquest.core.api.support
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.PrintWriter
+import java.io.StringWriter
+
+class TechInterviewRateLimitInterceptorTest {
+
+    private lateinit var interceptor: TechInterviewRateLimitInterceptor
+
+    @BeforeEach
+    fun setUp() {
+        interceptor = TechInterviewRateLimitInterceptor()
+    }
+
+    private fun mockRequest(ip: String): HttpServletRequest {
+        val request = mock<HttpServletRequest>()
+        whenever(request.getHeader("Fly-Client-IP")).thenReturn(null)
+        whenever(request.remoteAddr).thenReturn(ip)
+        return request
+    }
+
+    private fun mockResponse(): HttpServletResponse {
+        val response = mock<HttpServletResponse>()
+        val writer = StringWriter()
+        whenever(response.writer).thenReturn(PrintWriter(writer))
+        return response
+    }
+
+    @Test
+    fun `첫 번째 요청은 통과한다`() {
+        val result = interceptor.preHandle(mockRequest("1.2.3.4"), mockResponse(), Any())
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `같은 IP에서 두 번째 요청은 차단된다`() {
+        val request = mockRequest("1.2.3.4")
+        interceptor.preHandle(request, mockResponse(), Any())
+        val result = interceptor.preHandle(request, mockResponse(), Any())
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `다른 IP는 독립적으로 카운트된다`() {
+        interceptor.preHandle(mockRequest("1.2.3.4"), mockResponse(), Any())  // IP-A 소진
+        val result = interceptor.preHandle(mockRequest("5.6.7.8"), mockResponse(), Any())  // IP-B 첫 시도
+        assertThat(result).isTrue()
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/TechInterviewServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/TechInterviewServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -57,5 +58,16 @@ class TechInterviewServiceTest {
         verify(questProgressRecorder).record(
             eq("user1"), eq(QuestConstants.TECH_INTERVIEW), eq(1), eq(50), eq(false), any(), isNull()
         )
+    }
+
+    @Test
+    fun `evaluate - userId가 null이면 questProgressRecorder를 호출하지 않는다`() {
+        val result = TechInterviewResult(questions = listOf("Q1"), overallScore = 80, passed = true)
+        whenever(techInterviewPort.evaluate(any(), any(), any())).thenReturn(result)
+
+        val returned = service.evaluate(null, "Java", listOf("Q1"), listOf("A1"))
+
+        assertThat(returned.passed).isTrue()
+        verify(questProgressRecorder, never()).record(any(), any(), any(), any(), any(), any(), any())
     }
 }

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -9,7 +9,7 @@ import { CharacterCreate, OnboardingIntro } from '@/features/character'
 import { InterviewCoach } from '@/features/interview-coach'
 import { GrowthDashboard } from '@/features/growth'
 import { SettingsPage } from '@/features/settings'
-import { TechInterviewPage } from '@/features/tech-interview'
+import { TechInterviewPage, TechInterviewDemoPage } from '@/features/tech-interview'
 import { CodingQuestPage, CodingRoadmapPage } from '@/features/coding-quest'
 import { useAuth } from '@/hooks/useAuth'
 import { LoginPage } from '@/features/auth/components/LoginPage'
@@ -57,6 +57,7 @@ type View =
   | { kind: 'growth' }
   | { kind: 'settings' }
   | { kind: 'tech-interview' }
+  | { kind: 'tech-interview-demo' }
   | { kind: 'coding-roadmap' }
   | { kind: 'coding-quest'; category: string }
 
@@ -159,6 +160,12 @@ export function App() {
     }
   }, [isLoggedIn])
 
+  useEffect(() => {
+    if (isLoggedIn && view.kind === 'tech-interview-demo') {
+      setView({ kind: 'tech-interview' })
+    }
+  }, [isLoggedIn, view.kind])
+
   const getActProgress = useCallback(
     (act: Act) => {
       const done = act.quests.filter((q) => completed[q.id]).length
@@ -174,7 +181,26 @@ export function App() {
 
   // Unauthenticated
   if (!isLoggedIn) {
-    return <LoginPage />
+    if (view.kind === 'tech-interview-demo') {
+      return (
+        <div style={{ background: '#060610', minHeight: '100vh' }}>
+          <div style={{ maxWidth: 480, margin: '0 auto', padding: '0 20px 40px' }}>
+            <button
+              onClick={() => setView({ kind: 'map' })}
+              style={{
+                background: 'none', border: 'none', color: '#475569',
+                cursor: 'pointer', fontSize: 13, padding: '16px 0 0',
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              ← 로그인 페이지로
+            </button>
+            <TechInterviewDemoPage onLogin={() => setView({ kind: 'map' })} />
+          </div>
+        </div>
+      )
+    }
+    return <LoginPage onTryDemo={() => setView({ kind: 'tech-interview-demo' })} />
   }
 
   const handleCharacterComplete = (c: Character) => {

--- a/fe/src/features/auth/components/LoginPage.tsx
+++ b/fe/src/features/auth/components/LoginPage.tsx
@@ -121,7 +121,11 @@ const styles: Record<string, CSSProperties> = {
   },
 }
 
-export function LoginPage() {
+interface LoginPageProps {
+  onTryDemo?: () => void
+}
+
+export function LoginPage({ onTryDemo }: LoginPageProps) {
   const { loginWithGithub } = useAuth()
 
   return (
@@ -160,6 +164,31 @@ export function LoginPage() {
         </button>
 
         <p style={styles.subCopy}>AI가 당신의 실력을 평가합니다</p>
+
+        {onTryDemo && (
+          <div style={{ width: '100%', marginTop: 16 }}>
+            <button
+              onClick={onTryDemo}
+              style={{
+                width: '100%',
+                padding: '14px 0',
+                background: 'transparent',
+                border: '1px solid rgba(78,205,196,0.3)',
+                borderRadius: 10,
+                color: '#4ECDC4',
+                fontSize: 14,
+                fontFamily: "'Courier New', monospace",
+                cursor: 'pointer',
+                letterSpacing: 0.5,
+              }}
+            >
+              로그인 없이 기술면접 체험하기 →
+            </button>
+            <p style={{ marginTop: 10, fontSize: 12, color: '#475569', textAlign: 'center', fontFamily: "'Courier New', monospace" }}>
+              XP 적립 없음 · 진행 상황 저장 안 됨
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/fe/src/features/tech-interview/components/TechInterviewDemoPage.tsx
+++ b/fe/src/features/tech-interview/components/TechInterviewDemoPage.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react'
+import { fetchTechInterviewQuestion, evaluateTechInterview } from '@/lib/apiClient'
+import type { TechInterviewResult } from '@/types/api.types'
+
+const TECH_STACKS = ['Java', 'Kotlin']
+
+interface TechInterviewDemoPageProps {
+  onLogin: () => void
+}
+
+export function TechInterviewDemoPage({ onLogin }: TechInterviewDemoPageProps) {
+  const [techStack, setTechStack] = useState<string>('Java')
+  const [questions, setQuestions] = useState<string[]>([])
+  const [answers, setAnswers] = useState<string[]>([])
+  const [result, setResult] = useState<TechInterviewResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleFetchQuestions = async () => {
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    setAnswers([])
+    try {
+      const data = await fetchTechInterviewQuestion(techStack)
+      setQuestions(data.questions)
+      setAnswers(data.questions.map(() => ''))
+    } catch {
+      setError('질문을 불러오는 데 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleAnswerChange = (index: number, value: string) => {
+    setAnswers((prev) => {
+      const next = [...prev]
+      next[index] = value
+      return next
+    })
+  }
+
+  const handleSubmit = async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const data = await evaluateTechInterview(techStack, questions, answers)
+      setResult(data)
+    } catch {
+      setError('평가 요청에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleReset = () => {
+    setQuestions([])
+    setAnswers([])
+    setResult(null)
+    setError(null)
+  }
+
+  return (
+    <div style={{ paddingTop: 16 }}>
+      {/* 안내 배너 */}
+      <div
+        style={{
+          background: 'rgba(78,205,196,0.06)',
+          border: '1px solid rgba(78,205,196,0.25)',
+          borderRadius: 10,
+          padding: '12px 16px',
+          marginBottom: 24,
+        }}
+      >
+        <p style={{ color: '#4ECDC4', fontSize: 13, fontFamily: "'Courier New', monospace", margin: 0, lineHeight: 1.6 }}>
+          로그인 없이 체험 중입니다. 결과는 저장되지 않습니다.
+        </p>
+      </div>
+
+      <h2 style={{ color: '#F8FAFC', fontSize: 20, marginBottom: 8, fontFamily: "'Courier New', monospace" }}>
+        기술 면접 연습
+      </h2>
+      <p style={{ color: '#475569', fontSize: 13, marginBottom: 24, fontFamily: "'Courier New', monospace" }}>
+        기술 스택을 선택하고 질문에 답변을 작성하세요.
+      </p>
+
+      {/* 기술 스택 선택 */}
+      <div style={{ marginBottom: 20 }}>
+        <p style={{ color: '#F1F5F9', fontSize: 13, marginBottom: 10, fontFamily: "'Courier New', monospace" }}>
+          기술 스택
+        </p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {TECH_STACKS.map((stack) => (
+            <button
+              key={stack}
+              onClick={() => { setTechStack(stack); handleReset() }}
+              style={{
+                background: techStack === stack ? 'rgba(78,205,196,0.15)' : 'rgba(255,255,255,0.04)',
+                border: `1px solid ${techStack === stack ? 'rgba(78,205,196,0.5)' : 'rgba(255,255,255,0.08)'}`,
+                color: techStack === stack ? '#4ECDC4' : '#475569',
+                cursor: 'pointer',
+                fontSize: 13,
+                padding: '8px 16px',
+                borderRadius: 8,
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              {stack}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 질문 받기 버튼 */}
+      {questions.length === 0 && !result && (
+        <button
+          onClick={handleFetchQuestions}
+          disabled={loading}
+          style={{
+            width: '100%',
+            background: loading ? 'rgba(78,205,196,0.05)' : 'rgba(78,205,196,0.1)',
+            border: '1px solid rgba(78,205,196,0.3)',
+            color: '#4ECDC4',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            fontSize: 14,
+            padding: '12px 0',
+            borderRadius: 8,
+            fontFamily: "'Courier New', monospace",
+          }}
+        >
+          {loading ? '질문 불러오는 중...' : '질문 받기'}
+        </button>
+      )}
+
+      {error && (
+        <p style={{ color: '#EF4444', fontSize: 13, marginTop: 10, fontFamily: "'Courier New', monospace" }}>
+          {error}
+        </p>
+      )}
+
+      {/* 질문 목록 + 답변 입력 */}
+      {questions.length > 0 && !result && (
+        <div>
+          {questions.map((q, i) => (
+            <div
+              key={i}
+              style={{
+                background: '#0F172A',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 12,
+                padding: 16,
+                marginBottom: 16,
+              }}
+            >
+              <p style={{ color: '#F1F5F9', fontSize: 14, marginBottom: 10, fontFamily: "'Courier New', monospace", lineHeight: 1.6 }}>
+                Q{i + 1}. {q}
+              </p>
+              <textarea
+                value={answers[i] ?? ''}
+                onChange={(e) => handleAnswerChange(i, e.target.value)}
+                placeholder="답변을 입력하세요..."
+                rows={4}
+                style={{
+                  width: '100%',
+                  background: '#0A0E1A',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 8,
+                  padding: '10px 12px',
+                  color: '#F8FAFC',
+                  fontSize: 13,
+                  fontFamily: "'Courier New', monospace",
+                  boxSizing: 'border-box',
+                  resize: 'vertical',
+                  outline: 'none',
+                  lineHeight: 1.6,
+                }}
+              />
+            </div>
+          ))}
+
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            style={{
+              width: '100%',
+              background: submitting ? 'rgba(78,205,196,0.05)' : 'rgba(78,205,196,0.1)',
+              border: '1px solid rgba(78,205,196,0.3)',
+              color: '#4ECDC4',
+              cursor: submitting ? 'not-allowed' : 'pointer',
+              fontSize: 14,
+              padding: '12px 0',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+            }}
+          >
+            {submitting ? '평가 중...' : '제출'}
+          </button>
+        </div>
+      )}
+
+      {/* 평가 결과 */}
+      {result && (
+        <div>
+          <div
+            style={{
+              background: result.passed ? 'rgba(16,185,129,0.04)' : 'rgba(239,68,68,0.04)',
+              border: `1px solid ${result.passed ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.25)'}`,
+              borderRadius: 12,
+              padding: 20,
+              marginBottom: 16,
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <p style={{ color: '#F1F5F9', fontSize: 15, fontFamily: "'Courier New', monospace", margin: 0 }}>
+                평가 결과
+              </p>
+              <span
+                style={{
+                  color: result.passed ? '#10B981' : '#EF4444',
+                  background: result.passed ? 'rgba(16,185,129,0.15)' : 'rgba(239,68,68,0.15)',
+                  border: `1px solid ${result.passed ? 'rgba(16,185,129,0.4)' : 'rgba(239,68,68,0.4)'}`,
+                  borderRadius: 6,
+                  padding: '3px 10px',
+                  fontSize: 13,
+                  fontFamily: "'Courier New', monospace",
+                }}
+              >
+                {result.passed ? 'PASS' : 'FAIL'}
+              </span>
+            </div>
+            <p style={{ color: '#4ECDC4', fontSize: 28, fontFamily: "'Courier New', monospace", margin: '0 0 12px' }}>
+              {result.overallScore}점
+            </p>
+            <p style={{ color: '#F1F5F9', fontSize: 13, fontFamily: "'Courier New', monospace", lineHeight: 1.7, margin: 0 }}>
+              {result.feedback}
+            </p>
+          </div>
+
+          {/* 로그인 CTA */}
+          <div
+            style={{
+              background: 'rgba(78,205,196,0.04)',
+              border: '1px solid rgba(78,205,196,0.2)',
+              borderRadius: 12,
+              padding: 20,
+              marginBottom: 16,
+              textAlign: 'center',
+            }}
+          >
+            <p style={{ color: '#F1F5F9', fontSize: 14, fontFamily: "'Courier New', monospace", margin: '0 0 16px', lineHeight: 1.6 }}>
+              결과가 저장되지 않았습니다.<br />로그인하면 XP를 적립하고 성장 기록을 남길 수 있습니다.
+            </p>
+            <button
+              onClick={onLogin}
+              style={{
+                width: '100%',
+                background: 'linear-gradient(135deg, #4ECDC4, #2DD4BF)',
+                border: 'none',
+                borderRadius: 8,
+                color: '#060610',
+                fontSize: 14,
+                fontWeight: 'bold',
+                padding: '12px 0',
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+                letterSpacing: 0.5,
+              }}
+            >
+              GitHub로 로그인하고 XP 적립하기
+            </button>
+          </div>
+
+          <button
+            onClick={handleReset}
+            style={{
+              width: '100%',
+              background: 'rgba(255,255,255,0.04)',
+              border: '1px solid rgba(255,255,255,0.08)',
+              color: '#475569',
+              cursor: 'pointer',
+              fontSize: 14,
+              padding: '12px 0',
+              borderRadius: 8,
+              fontFamily: "'Courier New', monospace",
+            }}
+          >
+            다시 연습하기
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/fe/src/features/tech-interview/components/TechInterviewDemoPage.tsx
+++ b/fe/src/features/tech-interview/components/TechInterviewDemoPage.tsx
@@ -1,6 +1,35 @@
 import { useState } from 'react'
-import { fetchTechInterviewQuestion, evaluateTechInterview } from '@/lib/apiClient'
-import type { TechInterviewResult } from '@/types/api.types'
+import type { ApiResponse, TechInterviewResult } from '@/types/api.types'
+
+async function fetchDemoQuestion(techStack: string): Promise<TechInterviewResult> {
+  const res = await fetch(`/api/v1/tech-interview/question?techStack=${encodeURIComponent(techStack)}`, {
+    headers: { 'Content-Type': 'application/json' },
+  })
+  if (res.status === 429) {
+    const json = await res.json().catch(() => ({}))
+    throw new Error((json as { error?: { message?: string } })?.error?.message ?? '오늘 체험 횟수를 초과했습니다. 내일 다시 시도해주세요.')
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json: ApiResponse<TechInterviewResult> = await res.json()
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('질문 조회 실패')
+  return json.data
+}
+
+async function submitDemoEvaluation(techStack: string, questions: string[], answers: string[]): Promise<TechInterviewResult> {
+  const res = await fetch('/api/v1/tech-interview/evaluate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ techStack, questions, answers }),
+  })
+  if (res.status === 429) {
+    const json = await res.json().catch(() => ({}))
+    throw new Error((json as { error?: { message?: string } })?.error?.message ?? '오늘 체험 횟수를 초과했습니다. 내일 다시 시도해주세요.')
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const json: ApiResponse<TechInterviewResult> = await res.json()
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('평가 실패')
+  return json.data
+}
 
 const TECH_STACKS = ['Java', 'Kotlin']
 
@@ -23,11 +52,11 @@ export function TechInterviewDemoPage({ onLogin }: TechInterviewDemoPageProps) {
     setResult(null)
     setAnswers([])
     try {
-      const data = await fetchTechInterviewQuestion(techStack)
+      const data = await fetchDemoQuestion(techStack)
       setQuestions(data.questions)
       setAnswers(data.questions.map(() => ''))
-    } catch {
-      setError('질문을 불러오는 데 실패했습니다. 다시 시도해주세요.')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '질문을 불러오는 데 실패했습니다. 다시 시도해주세요.')
     } finally {
       setLoading(false)
     }
@@ -45,10 +74,10 @@ export function TechInterviewDemoPage({ onLogin }: TechInterviewDemoPageProps) {
     setSubmitting(true)
     setError(null)
     try {
-      const data = await evaluateTechInterview(techStack, questions, answers)
+      const data = await submitDemoEvaluation(techStack, questions, answers)
       setResult(data)
-    } catch {
-      setError('평가 요청에 실패했습니다. 다시 시도해주세요.')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '평가 요청에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setSubmitting(false)
     }

--- a/fe/src/features/tech-interview/index.ts
+++ b/fe/src/features/tech-interview/index.ts
@@ -1,1 +1,2 @@
 export { TechInterviewPage } from './components/TechInterviewPage'
+export { TechInterviewDemoPage } from './components/TechInterviewDemoPage'


### PR DESCRIPTION
## 요약

- 로그인 없이 기술면접 AI 평가를 체험할 수 있는 별도 페이지 추가
- 비로그인 사용자는 XP 적립 없이 AI 평가만 이용 가능
- IP 기반 하루 2회(질문 1회 + 평가 1회) rate limiting 적용

## 변경 내용

### BE
- `SecurityConfig`: `/api/v1/tech-interview/**` permitAll 추가
- `TechInterviewController`: `@AuthenticationPrincipal(errorOnInvalidType=false) userId: String?`
- `TechInterviewService`: userId null(guest)이면 questProgressRecorder 스킵, 로깅에 "guest" 레이블
- `TechInterviewRateLimitInterceptor`: IP 기반 rate limit, Fly-Client-IP → X-Forwarded-For → remoteAddr 순 폴백, 응답 JSON lazy 초기화
- `RateLimitBucketStore`: Bucket4j ConcurrentHashMap 저장소, 설정값 application.yml 외부화
- `RateLimitResetScheduler`: @Scheduled 자정 daily reset
- `WebMvcConfig`: Interceptor 등록
- `ErrorCode/ErrorType`: RATE_LIMIT_EXCEEDED (429) 추가
- `application.yml`: `devquest.rate-limit.tech-interview.capacity=2`, `refill-days=1`

### FE
- `TechInterviewDemoPage.tsx` 신규: 비로그인 전용 체험 페이지 (안내 배너, 로그인 CTA, 429 메시지 표시)
- `LoginPage.tsx`: "로그인 없이 기술면접 체험하기 →" 버튼 추가
- `App.tsx`: `tech-interview-demo` 뷰, 비로그인 상태에서도 접근 가능

## 플로우

```
비로그인 사용자
→ LoginPage "체험하기" 클릭
→ TechInterviewDemoPage: 기술 스택 선택 → 질문 받기 → 답변 → 평가
→ 결과 확인 + 로그인 CTA
→ 하루 2회 초과 시 "오늘 체험 횟수를 초과했습니다. 내일 다시 시도해주세요."
```

## 테스트

- `TechInterviewServiceTest`: userId=null 시 questProgressRecorder 미호출
- `TechInterviewRateLimitInterceptorTest`: 2회 통과 / 3회 차단 / IP 독립 / Fly-Client-IP 식별 / clear 후 재허용