### PR TITLE
chore: qa-reviewer + orchestrator severity HIGH/MEDIUM/LOW 기준 통일

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -261,27 +261,31 @@ Agent(subagent_type: "qa-reviewer", prompt: """
 """)
 ```
 
-→ CRITICAL 여부 확인
+→ HIGH 여부 확인
 
 **QA 완료 즉시 마커 파일 생성 (필수 — 없으면 PR 생성 훅이 차단)**:
 ```bash
 mkdir -p .claude/qa-cache && echo "QA_PASSED" > ".claude/qa-cache/$(git branch --show-current)"
 ```
 
+> **주의**: 마커 생성 후 코드 수정이 추가되면 QA를 재실행해야 한다. 마커는 최종 코드 확정 후 생성할 것.
+
 ---
 
-## 8단계: CRITICAL 처리
+## 8단계: HIGH 처리
 
-**CRITICAL 없음** → 9단계 (PR 생성 시 assert-qa-run.sh + assert-pr-reviewed.sh가 자동으로 검토 실행)
+**HIGH 없음** → 9단계 (PR 생성 시 assert-qa-run.sh + assert-pr-reviewed.sh가 자동으로 검토 실행)
 
-**CRITICAL 있음**:
-- BE CRITICAL → be-feature-builder 재스폰 (수정 내용 명시)
-- FE CRITICAL → fe-feature-builder 재스폰
+**HIGH 있음**:
+- BE HIGH → be-feature-builder 재스폰 (수정 내용 명시)
+- FE HIGH → fe-feature-builder 재스폰
 - 수정 후 qa-reviewer 재실행
 - 최대 2회 재시도. 실패 시 사용자에게 원인과 함께 보고
 
+**MEDIUM / LOW**: 오케스트레이터가 타당성 판단 후 처리 여부 결정. PR 생성 차단 안 함.
+
 > **강제 장치**: `gh pr create` 실행 시 PreToolUse 훅이 Anthropic API로 diff를 재검토한다.
-> CRITICAL 있으면 PR 생성 차단 → 반드시 수정 후 재시도.
+> HIGH 있으면 PR 생성 차단 → 반드시 수정 후 재시도.
 
 ---
 
@@ -296,7 +300,7 @@ gh pr create \
   --body-file .github/pull_request_template.md
 ```
 
-> PR 생성 시 PreToolUse 훅이 자동으로 사전 리뷰를 실행한다. CRITICAL 없으면 PR 생성 진행.
+> PR 생성 시 PreToolUse 훅이 자동으로 사전 리뷰를 실행한다. HIGH 없으면 PR 생성 진행.
 
 > **PR body는 한국어로 작성한다.** (title의 type/scope/message는 영어 컨벤션 유지)
 > **"🤖 Generated with Claude Code" 문구는 PR body에 포함하지 않는다.**
@@ -334,8 +338,9 @@ git push
 - FE: [변경 요약]
 
 ### QA
-- CRITICAL: 없음
-- WARNING: N건 — [항목]
+- HIGH: 없음
+- MEDIUM: N건 — [항목]
+- LOW: N건 — [항목]
 
 ### PR: #[번호]
 ```

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -127,7 +127,7 @@ FE apiClient → 에러 메시지 파싱 → 사용자 노출
 | 체크 | 기준 |
 |------|------|
 | 신규 Service 메서드 | 대응 테스트 케이스 존재 여부 |
-| 생성자 변경 | `@Mock` 목록에 새 의존성 추가 여부 (누락 시 CI 파괴 — **CRITICAL**) |
+| 생성자 변경 | `@Mock` 목록에 새 의존성 추가 여부 (누락 시 CI 파괴 — **HIGH**) |
 | AI 응답 `passed` 처리 | `overallScore`/`fitScore` 등 복합 점수 Result(Resume, DeveloperClass, BossPackage 등)에 한해 `PassCriteriaPolicy.evaluate*()` 정규화 여부 확인. 단순 `result.passed` 사용은 정상 패턴 |
 | `aiEvaluationJson` 보존 | `record()` null 전달 시 기존 JSON이 null로 덮어쓰이지 않는지 |
 | Evaluator 단위 테스트 | 새 `*Evaluator` 구현 시 `*EvaluatorTest.kt` 존재 여부 |
@@ -135,7 +135,20 @@ FE apiClient → 에러 메시지 파싱 → 사용자 노출
 | Controller 테스트 패턴 | `standaloneSetup` + `AuthenticationPrincipalArgumentResolver` 사용 여부 |
 | Evaluator 테스트 패턴 | `@Mock`/`@InjectMocks` 사용 금지 — `RETURNS_DEEP_STUBS` 패턴 사용 여부 |
 
-테스트 없음 → **WARNING** 처리 (CRITICAL 아님, tech-debt로 분류)
+테스트 없음 → **MEDIUM** 처리 (HIGH 아님, tech-debt로 분류)
+
+## Severity 기준
+
+| 등급 | 정의 | 오케스트레이터 처리 |
+|------|------|-------------------|
+| **HIGH** | 아키텍처 규칙 위반 / 시크릿 하드코딩 / 런타임 크래시 확실히 유발 / 즉각적 보안 취약점(SQL Injection·XSS) / BE↔FE 계약 불일치 | **수정 후 재QA 필수** |
+| **MEDIUM** | 명백한 로직 버그(즉각 크래시 아님) / 성능 anti-pattern / 테스트 커버리지 부족으로 회귀 위험 | 권장 수정, 오케스트레이터 판단 |
+| **LOW** | 코드 스타일·가독성 / 설정 외부화 권장 / "더 좋은 방법" / 확장성 고려 | tech-debt, 선택적 |
+
+**판단 원칙**:
+- "분산 환경 고려", "추후 확장성", "초기화 안전성 우려", "더 좋은 패턴 존재" → HIGH 금지
+- 실제로 현재 코드에서 피해가 발생하는지 확인 후에만 HIGH 판정
+- 같은 유형의 지적은 한 번만 (중복 나열 금지)
 
 ## 보고서 형식
 
@@ -143,10 +156,13 @@ FE apiClient → 에러 메시지 파싱 → 사용자 노출
 ## QA 리뷰 결과: [기능명]
 
 ### BE 리뷰
-**CRITICAL (즉시 수정 필요)**
+**HIGH (수정 필수)**
 - [내용] (file:line)
 
-**WARNING (권장 수정)**
+**MEDIUM (권장 수정)**
+- [내용] (file:line)
+
+**LOW (선택적 개선)**
 - [내용] (file:line)
 
 **이상 없음**: [체크한 항목 목록]
@@ -154,10 +170,13 @@ FE apiClient → 에러 메시지 파싱 → 사용자 노출
 ---
 
 ### FE 리뷰
-**CRITICAL**
+**HIGH**
 - [내용]
 
-**WARNING**
+**MEDIUM**
+- [내용]
+
+**LOW**
 - [내용]
 
 **이상 없음**: [체크한 항목 목록]
@@ -173,13 +192,9 @@ FE apiClient → 에러 메시지 파싱 → 사용자 노출
 ---
 
 ### 종합 판정
-- [ ] 머지 가능 (CRITICAL 없음)
-- [ ] 수정 후 재검토 필요 (CRITICAL N건)
+- [ ] 머지 가능 (HIGH 없음)
+- [ ] 수정 후 재검토 필요 (HIGH N건)
 ```
-
-심각도 기준:
-- **CRITICAL**: 런타임 오류, 아키텍처 위반, 보안 이슈, BE↔FE 불일치
-- **WARNING**: 잠재적 버그, 스타일 위반, 개선 권장
 
 > 보고서 작성 후 전체 검토 과정을 재현하지 않는다. 위 형식 그대로 반환하고 끝낸다.
 


### PR DESCRIPTION
## 요약

`assert-pr-reviewed.sh` (#189)에서 HIGH/MEDIUM/LOW 3단계로 개선한 기준을 `qa-reviewer.md`와 `orchestrator.md`에도 동일하게 적용.

## 변경 내용

### qa-reviewer.md
- 보고서 형식: CRITICAL/WARNING → HIGH/MEDIUM/LOW 3단계
- Severity 기준 표 추가 (HIGH: 수정 필수 / MEDIUM: 권장 / LOW: 선택적)
- 판단 원칙 추가: "분산 환경 고려" 등 → HIGH 금지 명시
- 테스트 없음 → WARNING → MEDIUM으로 변경

### orchestrator.md
- 8단계 "CRITICAL 처리" → "HIGH 처리"
- MEDIUM/LOW 처리 방침 명시 (차단 없음, 오케스트레이터 판단)
- QA 마커 생성 후 코드 추가 시 재실행 필요 주의 추가
- 완료 보고 형식 갱신