### PR TITLE
fix(be): CacheMetricsAdvisor nativeUsage null 처리 — Grafana 메트릭 No data 수정

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `fix/cache-metrics-null-native-usage` |
+| 열린 PR | #192 — CacheMetricsAdvisor nativeUsage null 처리 (머지 대기) |
 
 
 
@@ -72,6 +72,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #192 | CacheMetricsAdvisor nativeUsage null 처리 — Grafana 메트릭 No data 수정 | 2026-06-11 |
 | #191 | qa-reviewer + orchestrator severity HIGH/MEDIUM/LOW 기준 통일 | 2026-06-10 |
 | #190 | 기술면접 비로그인 체험 + IP rate limiting (Bucket4j, 하루 2회, 자정 reset) | 2026-06-10 |
 | #189 | PR 리뷰 훅 개선 — HIGH/MEDIUM/LOW 3단계 + 차단 기준 명확화 | 2026-06-10 |

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -31,15 +31,39 @@ class CacheMetricsAdvisor(
         val latencyMs = System.currentTimeMillis() - startMs
 
         runCatching {
-            val nativeUsage = response.chatResponse()?.metadata?.usage?.nativeUsage
-            val usage = nativeUsage as? Usage ?: return@runCatching
+            val chatResponse = response.chatResponse() ?: return@runCatching
+            val springUsage = chatResponse.metadata?.usage ?: run {
+                log.warn("CacheMetricsAdvisor: usage is null in response metadata")
+                return@runCatching
+            }
 
-            val cacheRead = usage.cacheReadInputTokens().orElse(0L)
-            val cacheCreation = usage.cacheCreationInputTokens().orElse(0L)
-            val inputTokens = usage.inputTokens()
-            val outputTokens = usage.outputTokens()
             val evaluatorName = AiCallContext.get()
-            val modelName = response.chatResponse()?.metadata?.model ?: "unknown"
+            val modelName = chatResponse.metadata?.model ?: "unknown"
+
+            val nativeUsage = springUsage.nativeUsage
+            val anthropicUsage = nativeUsage as? Usage
+
+            if (anthropicUsage == null) {
+                log.warn(
+                    "CacheMetricsAdvisor: nativeUsage cast failed — type={}, evaluator={}. Recording basic token metrics only.",
+                    nativeUsage?.javaClass?.name ?: "null",
+                    evaluatorName,
+                )
+                // nativeUsage unavailable — record basic token metrics via Spring AI Usage interface
+                val inputTokens = springUsage.promptTokens?.toLong() ?: 0L
+                val outputTokens = springUsage.completionTokens?.toLong() ?: 0L
+                meterRegistry.timer("ai.call.duration", "evaluatorType", evaluatorName, "model", modelName).record(latencyMs, TimeUnit.MILLISECONDS)
+                meterRegistry.counter("ai.tokens.input", "evaluatorType", evaluatorName, "model", modelName).increment(inputTokens.toDouble())
+                meterRegistry.counter("ai.tokens.output", "evaluatorType", evaluatorName, "model", modelName).increment(outputTokens.toDouble())
+                meterRegistry.counter("ai.tokens.cache_read", "evaluatorType", evaluatorName, "model", modelName).increment(0.0)
+                meterRegistry.counter("ai.tokens.cache_creation", "evaluatorType", evaluatorName, "model", modelName).increment(0.0)
+                return@runCatching
+            }
+
+            val cacheRead = anthropicUsage.cacheReadInputTokens().orElse(0L)
+            val cacheCreation = anthropicUsage.cacheCreationInputTokens().orElse(0L)
+            val inputTokens = anthropicUsage.inputTokens()
+            val outputTokens = anthropicUsage.outputTokens()
 
             log.info(
                 "AI cache metrics — evaluator={}, model={}, latencyMs={}, cacheHit={}, cache_read_input_tokens={}, cache_creation_input_tokens={}, input_tokens={}, output_tokens={}",
@@ -84,7 +108,7 @@ class CacheMetricsAdvisor(
             meterRegistry.counter("ai.tokens.cache_creation", "evaluatorType", evaluatorName, "model", modelName).increment(cacheCreation.toDouble())
 
         }.onFailure { e ->
-            log.debug("Failed to extract cache metrics", e)
+            log.warn("CacheMetricsAdvisor: unexpected error extracting metrics", e)
         }
 
         return response


### PR DESCRIPTION
## 문제

Grafana 대시보드에서 `ai.tokens.cache_read`, `ai.tokens.cache_creation`, `ai.call.duration` 등의 메트릭이 **No data**로 표시되는 현상.

## 근본 원인

Spring AI `UsageCalculator.getCumulativeUsage()`가 내부적으로 3-arg `DefaultUsage` 생성자를 호출해 `nativeUsage = null`을 반환하는 경우, 기존 코드가 아무 로그 없이 조용히 종료되고 있었음.

```kotlin
// 기존 코드 — null이면 debug 로그도 없이 탈출
val usage = nativeUsage as? Usage ?: return@runCatching
```

`log.debug` 레벨이라 prod에서 확인 불가.

## 수정 내용

1. **nativeUsage null / 타입 불일치 시** `log.warn` 승격 + 실제 타입명 출력
2. **cast 실패 시 fallback**: Spring AI `Usage` 인터페이스(`promptTokens` / `completionTokens`)로 기본 토큰 메트릭 기록 — `cache_read` / `cache_creation`은 0으로 기록해 시리즈 자체는 생성
3. **외부 `onFailure`** 로그도 debug → warn 승격

## 효과

- nativeUsage가 null이더라도 `ai.tokens.input` 등 기본 메트릭 시리즈가 Prometheus에 생성됨 → Grafana No data 방지
- cast 실패 시 warn 로그로 prod에서 원인 파악 가능