### PR TITLE
fix(be): OtlpMeterRegistry start() 누락 수정 — Grafana 메트릭 미전송 해결

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `fix/otlp-registry-start` |
+| 열린 PR | #195 — OtlpMeterRegistry start() 누락 수정 (머지 대기) |
 
 
 
@@ -72,6 +72,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #195 | OtlpMeterRegistry start() 누락 수정 — Grafana 메트릭 미전송 해결 | 2026-06-11 |
 | #194 | 기술면접 평가에 모범 답안(modelAnswer) 추가 | 2026-06-11 |
 | #193 | 데일리 질문 답변 페이지 — 로그인 없이 AI 피드백 (/daily-question) | 2026-06-11 |
 | #192 | CacheMetricsAdvisor nativeUsage null 처리 — Grafana 메트릭 No data 수정 | 2026-06-11 |

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.Base64
+import java.util.concurrent.Executors
 
 @Configuration
 @ConditionalOnProperty("grafana.otlp.enabled", havingValue = "true")
@@ -32,6 +33,8 @@ class OtlpMetricsConfig(
             override fun headers(): Map<String, String> =
                 mapOf("Authorization" to "Basic $encoded")
         }
-        return OtlpMeterRegistry(config, clock)
+        val registry = OtlpMeterRegistry(config, clock)
+        registry.start(Executors.defaultThreadFactory())
+        return registry
     }
 }

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -17,7 +17,7 @@ class OtlpMetricsConfig(
     @Value("\${GRAFANA_API_KEY}") private val apiKey: String,
 ) {
 
-    @Bean
+    @Bean(destroyMethod = "stop")
     fun otlpMeterRegistry(clock: Clock): OtlpMeterRegistry {
         require(instanceId.isNotBlank()) { "grafana.otlp.instance-id must not be blank" }
         require(apiKey.isNotBlank()) { "GRAFANA_API_KEY must not be blank" }
@@ -33,8 +33,16 @@ class OtlpMetricsConfig(
             override fun headers(): Map<String, String> =
                 mapOf("Authorization" to "Basic $encoded")
         }
+        val threadFactory = Executors.defaultThreadFactory().let { base ->
+            java.util.concurrent.ThreadFactory { runnable ->
+                base.newThread(runnable).apply {
+                    name = "otlp-metrics-exporter"
+                    isDaemon = true
+                }
+            }
+        }
         val registry = OtlpMeterRegistry(config, clock)
-        registry.start(Executors.defaultThreadFactory())
+        registry.start(threadFactory)
         return registry
     }
 }

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -21,6 +21,7 @@ class OtlpMetricsConfig(
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
+    @Volatile
     private var registry: OtlpMeterRegistry? = null
 
     @Bean

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -45,11 +45,11 @@ class OtlpMetricsConfig(
                 isDaemon = true
             }
         }
-        registry = OtlpMeterRegistry(config, clock).also {
-            it.start(threadFactory)
+        return OtlpMeterRegistry(config, clock).also { created ->
+            created.start(threadFactory)
+            registry = created
             log.info("OtlpMeterRegistry started — pushing to Grafana Cloud every 60s")
         }
-        return registry!!
     }
 
     @PreDestroy

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -3,12 +3,15 @@ package com.devquest.monitoring
 import io.micrometer.core.instrument.Clock
 import io.micrometer.registry.otlp.OtlpConfig
 import io.micrometer.registry.otlp.OtlpMeterRegistry
+import jakarta.annotation.PreDestroy
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.Base64
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
 @Configuration
 @ConditionalOnProperty("grafana.otlp.enabled", havingValue = "true")
@@ -17,7 +20,10 @@ class OtlpMetricsConfig(
     @Value("\${GRAFANA_API_KEY}") private val apiKey: String,
 ) {
 
-    @Bean(destroyMethod = "stop")
+    private val log = LoggerFactory.getLogger(javaClass)
+    private var registry: OtlpMeterRegistry? = null
+
+    @Bean
     fun otlpMeterRegistry(clock: Clock): OtlpMeterRegistry {
         require(instanceId.isNotBlank()) { "grafana.otlp.instance-id must not be blank" }
         require(apiKey.isNotBlank()) { "GRAFANA_API_KEY must not be blank" }
@@ -33,16 +39,23 @@ class OtlpMetricsConfig(
             override fun headers(): Map<String, String> =
                 mapOf("Authorization" to "Basic $encoded")
         }
-        val threadFactory = Executors.defaultThreadFactory().let { base ->
-            java.util.concurrent.ThreadFactory { runnable ->
-                base.newThread(runnable).apply {
-                    name = "otlp-metrics-exporter"
-                    isDaemon = true
-                }
+        val threadFactory = ThreadFactory { runnable ->
+            Executors.defaultThreadFactory().newThread(runnable).apply {
+                name = "otlp-metrics-exporter"
+                isDaemon = true
             }
         }
-        val registry = OtlpMeterRegistry(config, clock)
-        registry.start(threadFactory)
-        return registry
+        registry = OtlpMeterRegistry(config, clock).also {
+            it.start(threadFactory)
+            log.info("OtlpMeterRegistry started — pushing to Grafana Cloud every 60s")
+        }
+        return registry!!
+    }
+
+    @PreDestroy
+    fun stopRegistry() {
+        runCatching { registry?.stop() }
+            .onSuccess { log.info("OtlpMeterRegistry stopped") }
+            .onFailure { log.warn("OtlpMeterRegistry stop failed", it) }
     }
 }


### PR DESCRIPTION
## 원인

`OtlpMeterRegistry`(`PushMeterRegistry` 상속)는 `start(ThreadFactory)` 호출이 있어야 내부 push 스레드가 시작됩니다.

Spring Boot의 `MeterRegistryPostProcessor`는 빈을 `CompositeMeterRegistry`에 추가만 할 뿐 `start()`를 호출하지 않습니다. 반면 Spring Boot 공식 `OtlpMetricsExportAutoConfiguration`은 내부적으로 `start()`를 처리합니다.

기존 코드는 수동 `@Bean`으로 생성하면서 `start()` 호출이 없어 push 스레드가 시작되지 않았고, 60초마다 Grafana Cloud로 전송해야 할 메트릭이 실제로는 전송되지 않았습니다.

## 변경

- `registry.start(threadFactory)` 호출 추가 → push 스레드 시작
- 스레드명 `otlp-metrics-exporter` + `isDaemon = true` → 앱 종료 블로킹 방지
- `@PreDestroy stopRegistry()` 추가 → 컨텍스트 종료 시 graceful shutdown (예외 안전)
- `@Volatile` 추가 → 멀티스레드 가시성 보장
- 시작/종료 로그 추가

## 검증

- `./gradlew :support:monitoring:compileKotlin` 통과
- prod 배포 후 AI 평가 1회 호출 → 최대 60초(step: PT60S) 후 Grafana 대시보드 확인