### PR TITLE
fix(be): CacheMetricsAdvisor chatResponse null 진단 로그 추가

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -26,6 +26,7 @@ class CacheMetricsAdvisor(
     override fun getOrder(): Int = Ordered.LOWEST_PRECEDENCE
 
     override fun adviseCall(request: ChatClientRequest, chain: CallAdvisorChain): ChatClientResponse {
+        log.info("CacheMetricsAdvisor: adviseCall invoked, evaluator={}", AiCallContext.get())
         val startMs = System.currentTimeMillis()
         val response = chain.nextCall(request)
         val latencyMs = System.currentTimeMillis() - startMs

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/CacheMetricsAdvisor.kt
@@ -31,7 +31,15 @@ class CacheMetricsAdvisor(
         val latencyMs = System.currentTimeMillis() - startMs
 
         runCatching {
-            val chatResponse = response.chatResponse() ?: return@runCatching
+            val chatResponse = response.chatResponse()
+            if (chatResponse == null) {
+                log.warn(
+                    "CacheMetricsAdvisor: chatResponse() is null — response type={}, evaluator={}",
+                    response.javaClass.name,
+                    AiCallContext.get(),
+                )
+                return@runCatching
+            }
             val springUsage = chatResponse.metadata?.usage ?: run {
                 log.warn("CacheMetricsAdvisor: usage is null in response metadata")
                 return@runCatching


### PR DESCRIPTION
## 배경

prod 로그에서 `CacheMetricsAdvisor` 관련 로그가 전혀 없음.
`response.chatResponse() ?: return@runCatching` 첫 줄에서 조용히 종료되고 있을 가능성 높음.
`.entity(Class)` 호출 시 Spring AI 2.0.0-M3에서 `chatResponse()`가 null을 반환하는지 확인 필요.

## 변경

`chatResponse()` null 시 response 타입과 evaluator 정보를 WARN 로그로 출력.
로그 확인 후 근본 원인 파악 → 다음 PR에서 실제 수정.