### PR TITLE
fix(be): Spring AI 2.0.0-RC2 업그레이드 — CacheMetricsAdvisor 미동작 수정

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -57,7 +57,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 | 항목 | 내용 |
 |------|------|
 | 브랜치 | `fix/cache-metrics-advisor` |
-| 열린 PR | 진행 중 — CacheMetricsAdvisor 미동작 수정 |
+| 열린 PR | #198 — CacheMetricsAdvisor 미동작 수정 (머지 대기) |
 
 
 
@@ -72,6 +72,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #198 | Spring AI RC2 업그레이드 — CacheMetricsAdvisor 미동작 수정 | 2026-06-12 |
 | #196 | PR 리뷰 훅 Spring 도메인 컨텍스트 주입 + HIGH 기준 강화 | 2026-06-11 |
 | #195 | OtlpMeterRegistry start() 누락 수정 — Grafana 메트릭 미전송 해결 | 2026-06-11 |
 | #194 | 기술면접 평가에 모범 답안(modelAnswer) 추가 | 2026-06-11 |

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `fix/cache-metrics-advisor` |
+| 열린 PR | 진행 중 — CacheMetricsAdvisor 미동작 수정 |
 
 
 

--- a/be/clients/client-ai/build.gradle.kts
+++ b/be/clients/client-ai/build.gradle.kts
@@ -7,6 +7,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-jackson")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // RC2에서 anthropic-java-client-okhttp가 transitive에서 제거됨 — 통합 테스트에서 직접 사용
+    testImplementation("com.anthropic:anthropic-java-client-okhttp:2.35.0")
 }
 
 // 일반 test에서 integration 태그 제외

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/config/AiClientConfig.kt
@@ -1,10 +1,8 @@
 package com.devquest.client.ai.config
 
-import com.anthropic.client.okhttp.AnthropicOkHttpClient
 import com.anthropic.models.messages.Model
 import org.springframework.ai.anthropic.AnthropicCacheOptions
 import org.springframework.ai.anthropic.AnthropicCacheStrategy
-import org.springframework.ai.anthropic.AnthropicChatModel
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.model.ChatModel
@@ -27,14 +25,11 @@ class AiClientConfig {
 
     @Bean("bossChatClient")
     fun bossChatClient(
+        chatModel: ChatModel,
         @Value("\${devquest.ai.boss-model:claude-sonnet-4-6}") bossModel: String,
         @Value("\${devquest.ai.boss-max-tokens:4000}") bossMaxTokens: Int,
-        @Value("\${spring.ai.anthropic.api-key}") apiKey: String,
         cacheMetricsAdvisor: CacheMetricsAdvisor,
     ): ChatClient {
-        val anthropicClient = AnthropicOkHttpClient.builder()
-            .apiKey(apiKey)
-            .build()
         val cacheOptions = AnthropicCacheOptions.builder()
             .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
             .build()
@@ -44,12 +39,9 @@ class AiClientConfig {
             .temperature(0.3)
             .cacheOptions(cacheOptions)
             .build()
-        val model = AnthropicChatModel.builder()
-            .anthropicClient(anthropicClient)
-            .options(options)
-            .build()
-        return ChatClient.builder(model)
+        return ChatClient.builder(chatModel)
             .defaultAdvisors(cacheMetricsAdvisor)
+            .defaultOptions(options.mutate())
             .build()
     }
 }

--- a/be/gradle.properties
+++ b/be/gradle.properties
@@ -11,4 +11,4 @@ javaVersion=21
 ### Spring dependency versions ###
 springBootVersion=4.0.3
 springDependencyManagementVersion=1.1.7
-springAiVersion=2.0.0-M3
+springAiVersion=2.0.0-RC2


### PR DESCRIPTION
## 문제

Grafana 대시보드에서 `ai_tokens_*`, `ai_call_duration_*` 메트릭이 지속적으로 "No data" 표시.

Loki 로그 분석 결과 `CacheMetricsAdvisor.adviseCall()`이 단 한 번도 호출되지 않음을 확인.
`devquest_ai_call_total`(AiMetricsRecorder)은 정상 수집 → AI 호출 자체는 정상, advisor만 누락.

## 원인

Spring AI 2.0.0-M3에서 `CallAdvisor` 체인 invocation 메커니즘 버그로 `adviseCall()`이 호출되지 않음.
RC2에서 해당 버그 수정됨.

추가로 RC2에서 `anthropic-java-client-okhttp`가 transitive 의존성에서 제거되어 `bossChatClient`에서
사용하던 `AnthropicOkHttpClient` 컴파일 오류 발생 → auto-configured `ChatModel` + `defaultOptions()` 방식으로 교체.

## 변경 내용

- `be/gradle.properties`: Spring AI `2.0.0-M3` → `2.0.0-RC2` (Spring Boot 4.0.3 공식 호환 버전)
- `AiClientConfig.kt`: `bossChatClient`에서 `AnthropicOkHttpClient` 제거 → auto-configured `ChatModel` + `defaultOptions(options.mutate())` 방식으로 교체

## 로컬 검증 결과

```
CacheMetricsAdvisor: adviseCall invoked, evaluator=TechInterviewEvaluator
AI cache metrics — evaluator=TechInterviewEvaluator, model=claude-haiku-4-5-20251001, latencyMs=4616, input_tokens=1808, output_tokens=478
```

`adviseCall` 정상 호출 및 AI 토큰 메트릭 DB 기록 확인.