### PR TITLE
chore: QA 마커 강제화 — 커밋 해시 기반 검증 + qa-reviewer 자동 생성

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -263,12 +263,9 @@ Agent(subagent_type: "qa-reviewer", prompt: """
 
 → HIGH 여부 확인
 
-**QA 완료 즉시 마커 파일 생성 (필수 — 없으면 PR 생성 훅이 차단)**:
-```bash
-mkdir -p .claude/qa-cache && echo "QA_PASSED" > ".claude/qa-cache/$(git branch --show-current)"
-```
-
-> **주의**: 마커 생성 후 코드 수정이 추가되면 QA를 재실행해야 한다. 마커는 최종 코드 확정 후 생성할 것.
+> **마커는 qa-reviewer가 자동 생성** — orchestrator가 직접 생성 금지.
+> qa-reviewer가 현재 HEAD SHA를 `.claude/qa-cache/<branch>`에 기록한다.
+> 리뷰 후 커밋이 추가되면 SHA 불일치 → PR 생성 훅이 차단 → qa-reviewer 재실행 필요.
 
 ---
 

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -5,8 +5,8 @@ tools:
   - Read
   - Glob
   - Grep
-permissionMode: plan
-description: 코드 리뷰 + QA 통합 전담 sub-agent. 오케스트레이터로부터 리뷰 대상을 전달받아 코드를 읽기만 하며 아키텍처, 보안, BE↔FE 계약 정합성, 잠재 버그를 검토한다. 코드를 직접 수정하지 않고 보고서를 반환한다.
+  - Bash
+description: 코드 리뷰 + QA 통합 전담 sub-agent. 오케스트레이터로부터 리뷰 대상을 전달받아 코드를 읽기만 하며 아키텍처, 보안, BE↔FE 계약 정합성, 잠재 버그를 검토한다. 코드를 직접 수정하지 않고 보고서를 반환한다. 리뷰 완료 후 QA 마커 파일을 자동 생성한다.
 hooks:
   PostToolUse:
     - matcher: ".*"
@@ -21,11 +21,25 @@ hooks:
 
 | | 허용 | 금지 |
 |--|------|------|
-| 파일 접근 | 모든 파일 **읽기** | **어떤 파일도 수정/생성 금지** — Write, Edit 도구 사용 금지 |
-| 역할 | 검토, 보고서 작성 | 코드 수정, 구현 판단, 수정 방법 제안을 넘어 직접 적용 |
-| 완료 후 | 보고서 반환 | 수정 후 재실행, 에이전트 간 직접 통신 |
+| 파일 접근 | 모든 파일 **읽기**, `.claude/qa-cache/` 마커 **쓰기** | 그 외 파일 수정/생성 금지 — Write, Edit 도구 사용 금지 |
+| 역할 | 검토, 보고서 작성, QA 마커 생성 | 코드 수정, 구현 판단, 수정 방법 제안을 넘어 직접 적용 |
+| 완료 후 | 보고서 반환 + **마커 파일 생성** | 수정 후 재실행, 에이전트 간 직접 통신 |
 
 코드를 고치고 싶다는 판단이 들어도 보고서에 기록만 하고 멈춘다.
+
+## QA 마커 생성 (필수 — 리뷰 완료 후 항상 실행)
+
+HIGH/MEDIUM/LOW 여부와 무관하게 보고서 반환 **직전** 반드시 실행:
+
+```bash
+BRANCH=$(git branch --show-current)
+HEAD_SHA=$(git rev-parse HEAD)
+mkdir -p ".claude/qa-cache/$(dirname "$BRANCH")" 2>/dev/null || true
+echo "$HEAD_SHA" > ".claude/qa-cache/$BRANCH"
+```
+
+> 마커 = "이 커밋에 대해 qa-reviewer가 실행됐다"는 증거.
+> orchestrator는 마커를 직접 생성하지 않는다 — qa-reviewer만 생성한다.
 
 ---
 

--- a/.claude/scripts/assert-qa-run.sh
+++ b/.claude/scripts/assert-qa-run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # gh pr create 전 QA 리뷰 실행 여부 강제 확인
 # chore/, docs/ 브랜치는 면제
+# 마커 파일에 HEAD SHA가 기록되어 있어야 통과 (단순 존재 확인 X)
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
@@ -26,13 +27,21 @@ QA_MARKER="$PROJECT_ROOT/.claude/qa-cache/$BRANCH"
 
 if [ ! -f "$QA_MARKER" ]; then
   echo "⛔ PR 생성 차단: QA 리뷰가 실행되지 않았습니다." >&2
-  echo "   orchestrator 7단계(qa-reviewer)를 먼저 실행하세요." >&2
+  echo "   qa-reviewer 에이전트를 실행하면 마커가 자동 생성됩니다." >&2
   echo "   브랜치: $BRANCH" >&2
-  echo "" >&2
-  echo "   QA 완료 후 orchestrator가 마커를 자동 생성합니다:" >&2
-  echo "   .claude/qa-cache/$BRANCH" >&2
   exit 2
 fi
 
-echo "✅ QA 마커 확인됨 ($BRANCH). PR 생성 진행합니다." >&2
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null)
+MARKER_SHA=$(cat "$QA_MARKER" 2>/dev/null | tr -d '[:space:]')
+
+if [ "$HEAD_SHA" != "$MARKER_SHA" ]; then
+  echo "⛔ PR 생성 차단: QA가 현재 커밋 기준으로 실행되지 않았습니다." >&2
+  echo "   현재 HEAD : $HEAD_SHA" >&2
+  echo "   QA 실행 시점: ${MARKER_SHA:-없음}" >&2
+  echo "   커밋이 추가됐거나 QA를 건너뛴 경우 — qa-reviewer를 재실행하세요." >&2
+  exit 2
+fi
+
+echo "✅ QA 확인됨 (branch=$BRANCH, sha=${HEAD_SHA:0:8}). PR 생성 진행합니다." >&2
 exit 0


### PR DESCRIPTION
## 문제

기존 `assert-qa-run.sh`는 마커 파일 **존재 여부**만 확인 → orchestrator가 qa-reviewer 없이 직접 마커 생성 가능.
지시(instructions)만 바꿔도 우회 가능 → 기계적 강제화 필요.

## 변경 내용

### assert-qa-run.sh
마커 존재 확인 → **마커 내용 == 현재 HEAD SHA** 확인으로 강화.
- qa-reviewer 실행 후 커밋 추가 시 SHA 불일치 → 자동 차단
- 수동으로 마커를 만들려면 HEAD SHA를 정확히 넣어야 함 → 의도적 우회는 명시적 행위

### qa-reviewer.md
- `Bash` 도구 추가, `permissionMode: plan` 제거
- 리뷰 완료 후 HEAD SHA를 마커 파일에 기록하는 지시 추가
- orchestrator가 아닌 qa-reviewer가 마커의 유일한 생성 주체

### orchestrator.md
- 수동 마커 생성 코드(`mkdir -p .claude/qa-cache && echo "QA_PASSED"`) 제거
- "마커는 qa-reviewer가 자동 생성 — orchestrator 직접 생성 금지" 명시

## 동작 흐름

```
orchestrator → qa-reviewer 스폰
  └→ qa-reviewer: 리뷰 완료 후 HEAD SHA 마커 생성
orchestrator → gh pr create
  └→ assert-qa-run.sh: 마커 SHA == HEAD SHA 검증 → 통과
```