### PR TITLE
fix: Grafana 대시보드 개선 — Latency histogram 활성화 + Loki 로그 패널 추가

### DIFF
--- a/be/support/monitoring/src/main/resources/monitoring.yml
+++ b/be/support/monitoring/src/main/resources/monitoring.yml
@@ -8,9 +8,11 @@ management:
       percentiles-histogram:
         http.server.requests: true
         gen_ai.client.operation: true
+        ai.call.duration: true
       percentiles:
         http.server.requests: 0.5,0.95,0.99
         gen_ai.client.operation: 0.5,0.95,0.99
+        ai.call.duration: 0.5,0.95,0.99
     tags:
       application: devquest-api
 

--- a/grafana/ai-metrics-dashboard.json
+++ b/grafana/ai-metrics-dashboard.json
@@ -7,14 +7,24 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "Grafana Cloud Loki datasource",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
     }
   ],
   "__requires": [
     { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
     { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "datasource", "id": "loki", "name": "Loki", "version": "1.0.0" },
     { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
     { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
-    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+    { "type": "panel", "id": "table", "name": "Table", "version": "" },
+    { "type": "panel", "id": "logs", "name": "Logs", "version": "" }
   ],
   "annotations": { "list": [] },
   "editable": true,
@@ -450,6 +460,63 @@
           }
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 },
+      "id": 50,
+      "title": "Application Logs",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 44 },
+      "id": 51,
+      "title": "Recent Logs",
+      "type": "logs",
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "{app=\"devquest-api\"}",
+          "maxLines": 200,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 56 },
+      "id": 52,
+      "title": "Error / Warn Logs",
+      "type": "logs",
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "{app=\"devquest-api\"} | json | level =~ `ERROR|WARN`",
+          "maxLines": 100,
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "1m",
@@ -467,6 +534,17 @@
         "refresh": 1,
         "type": "datasource",
         "label": "Prometheus Datasource"
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "DS_LOKI",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Loki Datasource"
       }
     ]
   },


### PR DESCRIPTION
## 문제

1. **Latency 패널 No data**: `monitoring.yml`에 `ai.call.duration` histogram 미설정 → `ai_call_duration_seconds_bucket` OTLP 미전송
2. **로그 확인 불편**: 로그 보려면 Grafana Explore → Loki 별도 이동 필요

## 변경 내용

### monitoring.yml
`ai.call.duration` percentiles-histogram 및 percentiles(P50/P95/P99) 활성화

### ai-metrics-dashboard.json
- `DS_LOKI` datasource 변수 추가 (`__inputs`, `templating`)
- **Application Logs** 섹션 추가 (하단):
  - Recent Logs: `{app="devquest-api"}` 전체 로그, 최신순
  - Error/Warn Logs: `{app="devquest-api"} | json | level =~ ERROR|WARN` 필터