### PR TITLE
fix(be): 전체 Evaluator .entity() → parseContent() 마이그레이션 — Spring AI RC2 호환성 수정

### DIFF
--- a/.claude/scripts/assert-pr-reviewed.sh
+++ b/.claude/scripts/assert-pr-reviewed.sh
@@ -137,11 +137,14 @@ HIGH 여부: YES 또는 NO"
 
 # 임시 파일로 JSON body 생성 (인코딩 문제 방지), 종료 시 자동 정리
 TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
+PROMPTFILE=$(mktemp)
+trap 'rm -f "$TMPFILE" "$PROMPTFILE"' EXIT
 
+# PROMPT를 파일로 저장 후 --rawfile로 읽기 — "Argument list too long" 방지
+printf '%s' "$PROMPT" > "$PROMPTFILE"
 jq -n \
   --arg model "claude-haiku-4-5" \
-  --arg content "$PROMPT" \
+  --rawfile content "$PROMPTFILE" \
   '{"model": $model, "max_tokens": 2000, "messages": [{"role": "user", "content": $content}]}' \
   > "$TMPFILE"
 

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluator.kt
@@ -33,7 +33,8 @@ class ActClearReportEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(ActClearReportResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, ActClearReportResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluator.kt
@@ -35,7 +35,8 @@ class BossPackageEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(BossPackageResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, BossPackageResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluator.kt
@@ -27,7 +27,8 @@ class CareerEssayEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(EssayCheckResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, EssayCheckResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluator.kt
@@ -28,11 +28,8 @@ class CodingHintEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt()
-                .system(systemPrompt)
-                .user(userPrompt)
-                .call()
-                .entity(CodingHint::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, CodingHint::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluator.kt
@@ -27,11 +27,8 @@ class CodingProblemGeneratorEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt()
-                .system(systemPrompt)
-                .user(userPrompt)
-                .call()
-                .entity(CodingProblemGenerationResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, CodingProblemGenerationResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluator.kt
@@ -28,7 +28,8 @@ class DeveloperClassEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(DeveloperClassResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, DeveloperClassResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluator.kt
@@ -33,7 +33,8 @@ class InterviewCoachEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachSessionResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, CoachSessionResult::class.java)
         }
     }
 
@@ -47,7 +48,8 @@ class InterviewCoachEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachAnswerResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, CoachAnswerResult::class.java)
         }
     }
 
@@ -69,7 +71,8 @@ class InterviewCoachEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(CoachReportResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, CoachReportResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluator.kt
@@ -29,7 +29,8 @@ class JdAnalysisEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JdAnalysisResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, JdAnalysisResult::class.java)
                 ?.let { it.copy(passed = PassCriteriaPolicy.evaluate(it.overallMatchScore)) }
         }
     }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/JourneyReportGenerator.kt
@@ -46,7 +46,8 @@ class JourneyReportGenerator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(JourneyReportResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, JourneyReportResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluator.kt
@@ -26,7 +26,8 @@ class PersonalityInterviewEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, AiEvaluationResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluator.kt
@@ -28,7 +28,8 @@ class SkillAssessmentEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(SkillAssessmentResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, SkillAssessmentResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluator.kt
@@ -27,7 +27,8 @@ class SystemDesignEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, AiEvaluationResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluator.kt
@@ -27,7 +27,8 @@ class TechBlogEvaluator(
         ))
 
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt().system(systemPrompt).user(userPrompt).call().entity(AiEvaluationResult::class.java)
+            val content = chatClient.prompt().system(systemPrompt).user(userPrompt).call().content()
+            parseContent(content, AiEvaluationResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluator.kt
@@ -24,11 +24,12 @@ class TechInterviewEvaluator(
         val systemPrompt = questionsSystemTemplate.render()
         val userPrompt = questionsUserTemplate.render(mapOf("techStack" to techStack))
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt()
+            val content = chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
                 .call()
-                .entity(TechInterviewResult::class.java)
+                .content()
+            parseContent(content, TechInterviewResult::class.java)
         }
     }
 
@@ -61,11 +62,12 @@ class TechInterviewEvaluator(
             "questionsAndAnswers" to questionsAndAnswers,
         ))
         return aiCallExecutor.execute(this.javaClass.simpleName, modelName) {
-            chatClient.prompt()
+            val content = chatClient.prompt()
                 .system(systemPrompt)
                 .user(userPrompt)
                 .call()
-                .entity(TechInterviewResult::class.java)
+                .content()
+            parseContent(content, TechInterviewResult::class.java)
         }
     }
 }

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/ActClearReportEvaluatorTest.kt
@@ -1,0 +1,78 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class ActClearReportEvaluatorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
+    private val evaluator = ActClearReportEvaluator(chatClient, aiCallExecutor)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            evaluator.generate(
+                actId = 1,
+                actTitle = "이력서 작성",
+                questScores = mapOf("1-1" to 80, "1-2" to 70)
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("최종 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val json = """{"actId":1,"actTitle":"이력서 작성","overallScore":75,"grade":"B","developerClass":"주니어 백엔드","achievements":["이력서 구조화 완료"],"nextActHint":"기술 스택 정리 필요","encouragement":"잘 하셨어요!"}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
+
+        val result = evaluator.generate(
+            actId = 1,
+            actTitle = "이력서 작성",
+            questScores = mapOf("1-1" to 80, "1-2" to 70)
+        )
+
+        assertThat(result.actId).isEqualTo(1)
+        assertThat(result.overallScore).isEqualTo(75)
+        assertThat(result.grade).isEqualTo("B")
+        assertThat(result.achievements).hasSize(1)
+    }
+
+    @Test
+    fun `사용자 프롬프트에 actId와 점수 목록이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content())
+            .thenReturn("""{"actId":2,"actTitle":"기술 면접"}""")
+
+        evaluator.generate(
+            actId = 2,
+            actTitle = "기술 면접",
+            questScores = mapOf("2-1" to 90, "2-2" to 85)
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("2-1")
+        assertThat(prompt).contains("90")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/BossPackageEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.BossPackageResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -28,7 +27,7 @@ class BossPackageEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(BossPackageResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -45,21 +44,10 @@ class BossPackageEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = BossPackageResult(
-            overallScore = 85,
-            passed = true,
-            resumeImpactScore = 80,
-            githubConsistencyScore = 90,
-            technicalDepthScore = 85,
-            positionFitScore = 88,
-            differentiationScore = 82,
-            strengths = listOf("GitHub 활동 이력 풍부", "기술 깊이 우수"),
-            improvements = listOf("블로그 콘텐츠 보강 필요"),
-            overallFeedback = "전반적으로 경쟁력 있는 포트폴리오입니다"
-        )
+        val json = """{"overallScore":85,"passed":true,"resumeImpactScore":80,"githubConsistencyScore":90,"technicalDepthScore":85,"positionFitScore":88,"differentiationScore":82,"strengths":["GitHub 활동 이력 풍부","기술 깊이 우수"],"improvements":["블로그 콘텐츠 보강 필요"],"overallFeedback":"전반적으로 경쟁력 있는 포트폴리오입니다"}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(BossPackageResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.evaluate(
             resumeContent = "백엔드 개발 5년 경력",
@@ -78,10 +66,8 @@ class BossPackageEvaluatorTest {
     fun `사용자 프롬프트에 목표 포지션, GitHub URL, 이력서 내용이 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(BossPackageResult::class.java)
-        ).thenReturn(
-            BossPackageResult(overallScore = 75, passed = true)
-        )
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"overallScore":75,"passed":true}""")
 
         evaluator.evaluate(
             resumeContent = "Java Spring Boot 개발 경력",
@@ -100,10 +86,8 @@ class BossPackageEvaluatorTest {
     fun `블로그 URL이 빈 문자열이면 미제공으로 대체하여 호출된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(BossPackageResult::class.java)
-        ).thenReturn(
-            BossPackageResult(overallScore = 70, passed = true)
-        )
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"overallScore":70,"passed":true}""")
 
         evaluator.evaluate(
             resumeContent = "백엔드 개발 경력",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CareerEssayEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.EssayCheckResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -19,7 +18,6 @@ import org.springframework.ai.chat.client.ChatClient
 @ExtendWith(MockitoExtension::class)
 class CareerEssayEvaluatorTest {
 
-    // ChatClient의 fluent API 체인 전체를 deep stub으로 목킹
     private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
     private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
     private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
@@ -28,7 +26,7 @@ class CareerEssayEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(EssayCheckResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -44,21 +42,10 @@ class CareerEssayEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = EssayCheckResult(
-            score = 82,
-            passed = true,
-            grade = "A",
-            clarityScore = 25,
-            logicScore = 25,
-            motivationScore = 17,
-            growthScore = 15,
-            feedback = "우수합니다",
-            developerType = "아키텍트 지향형",
-            suggestedFocus = listOf("기술 스타트업")
-        )
+        val json = """{"score":82,"passed":true,"grade":"A","clarityScore":25,"logicScore":25,"motivationScore":17,"growthScore":15,"feedback":"우수합니다","developerType":"아키텍트 지향형","suggestedFocus":["기술 스타트업"]}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(EssayCheckResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.evaluate(
             dissatisfactions = listOf("불만1", "불만2", "불만3"),

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingHintEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.coding.CodingHint
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -27,8 +26,7 @@ class CodingHintEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call()
-                .entity(CodingHint::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy { evaluator.getHint(1L, "두 수의 합", "두 정수를 더하세요", 1) }
@@ -38,11 +36,10 @@ class CodingHintEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 힌트를 그대로 반환`() {
-        val expected = CodingHint(hint = "두 값을 더하는 방향으로 생각해보세요.")
+        val json = """{"hint":"두 값을 더하는 방향으로 생각해보세요."}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call()
-                .entity(CodingHint::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.getHint(1L, "두 수의 합", "두 정수를 더하세요", 1)
 
@@ -51,11 +48,10 @@ class CodingHintEvaluatorTest {
 
     @Test
     fun `hintLevel 3으로 호출해도 정상 동작`() {
-        val expected = CodingHint(hint = "반복문을 사용하여 누적합을 구하는 의사코드를 떠올려보세요.")
+        val json = """{"hint":"반복문을 사용하여 누적합을 구하는 의사코드를 떠올려보세요."}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call()
-                .entity(CodingHint::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.getHint(1L, "배열 합계", "배열의 합을 구하세요", 3)
 

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/CodingProblemGeneratorEvaluatorTest.kt
@@ -3,8 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.coding.CodingProblemGenerationResult
-import com.devquest.core.domain.model.coding.TestCase
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -28,8 +26,7 @@ class CodingProblemGeneratorEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call()
-                .entity(CodingProblemGenerationResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy { evaluator.generate("EASY", "JAVA", "ARRAY") }
@@ -39,16 +36,10 @@ class CodingProblemGeneratorEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = CodingProblemGenerationResult(
-            title = "제곱 계산",
-            description = "정수를 입력받아 제곱을 출력하세요.",
-            solutionCode = "class Main {}",
-            testCases = listOf(TestCase("5", "25"), TestCase("3", "9"))
-        )
+        val json = """{"title":"제곱 계산","description":"정수를 입력받아 제곱을 출력하세요.","solutionCode":"class Main {}","testCases":[{"input":"5","expectedOutput":"25"},{"input":"3","expectedOutput":"9"}]}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call()
-                .entity(CodingProblemGenerationResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.generate("EASY", "JAVA", "ARRAY")
 

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/DeveloperClassEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.DeveloperClassResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -28,7 +27,7 @@ class DeveloperClassEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(DeveloperClassResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -43,18 +42,10 @@ class DeveloperClassEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = DeveloperClassResult(
-            overallScore = 80,
-            passed = true,
-            developerClass = "시니어 백엔드 엔지니어",
-            classDescription = "높은 기술 역량과 커리어 방향성이 명확한 개발자",
-            strengths = listOf("Java 장기 실무 경험", "아키텍처 설계 능력"),
-            strategies = listOf("클라우드 역량 강화", "리더십 경험 추가"),
-            overallFeedback = "전반적으로 우수한 역량을 보유하고 있습니다"
-        )
+        val json = """{"overallScore":80,"passed":true,"developerClass":"시니어 백엔드 엔지니어","classDescription":"높은 기술 역량과 커리어 방향성이 명확한 개발자","strengths":["Java 장기 실무 경험","아키텍처 설계 능력"],"strategies":["클라우드 역량 강화","리더십 경험 추가"],"overallFeedback":"전반적으로 우수한 역량을 보유하고 있습니다"}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(DeveloperClassResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.evaluate(
             skillAssessmentJson = """{"score": 78}""",
@@ -71,10 +62,8 @@ class DeveloperClassEvaluatorTest {
     fun `사용자 프롬프트에 기술 평가 JSON과 커리어 에세이 JSON이 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(DeveloperClassResult::class.java)
-        ).thenReturn(
-            DeveloperClassResult(overallScore = 75, passed = true, developerClass = "미드레벨")
-        )
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"overallScore":75,"passed":true,"developerClass":"미드레벨"}""")
 
         evaluator.evaluate(
             skillAssessmentJson = """{"score": 78, "grade": "B"}""",
@@ -90,10 +79,8 @@ class DeveloperClassEvaluatorTest {
     fun `빈 문자열 입력 시 기본값으로 대체하여 호출된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(DeveloperClassResult::class.java)
-        ).thenReturn(
-            DeveloperClassResult(overallScore = 50, passed = false, developerClass = "주니어")
-        )
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"overallScore":50,"passed":false,"developerClass":"주니어"}""")
 
         evaluator.evaluate(
             skillAssessmentJson = "",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/InterviewCoachEvaluatorTest.kt
@@ -4,10 +4,6 @@ import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import com.devquest.core.domain.model.evaluation.CoachAnswerHistory
-import com.devquest.core.domain.model.evaluation.CoachAnswerResult
-import com.devquest.core.domain.model.evaluation.CoachReportResult
-import com.devquest.core.domain.model.evaluation.CoachSessionResult
-import com.devquest.core.domain.model.evaluation.CoachQuestion
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -34,7 +30,7 @@ class InterviewCoachEvaluatorTest {
     @Test
     fun `startSession - AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachSessionResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -46,17 +42,10 @@ class InterviewCoachEvaluatorTest {
 
     @Test
     fun `startSession - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = CoachSessionResult(
-            jdSummary = "Spring Boot 기반 백엔드 개발자 모집",
-            keyCompetencies = listOf("Spring Boot", "JPA", "MSA"),
-            questions = listOf(
-                CoachQuestion(0, "JPA N+1 문제를 어떻게 해결하셨나요?", "JPA"),
-                CoachQuestion(1, "MSA 환경에서 트랜잭션 처리 경험을 공유해주세요.", "MSA"),
-            )
-        )
+        val json = """{"jdSummary":"Spring Boot 기반 백엔드 개발자 모집","keyCompetencies":["Spring Boot","JPA","MSA"],"questions":[{"index":0,"question":"JPA N+1 문제를 어떻게 해결하셨나요?","competency":"JPA"},{"index":1,"question":"MSA 환경에서 트랜잭션 처리 경험을 공유해주세요.","competency":"MSA"}]}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachSessionResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.startSession(
             jdText = "Spring Boot 기반 백엔드 개발자를 모집합니다. JPA, MSA 경험 우대.",
@@ -72,8 +61,8 @@ class InterviewCoachEvaluatorTest {
     fun `startSession - 사용자 프롬프트에 JD 내용과 목표 포지션이 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(CoachSessionResult::class.java)
-        ).thenReturn(CoachSessionResult())
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"jdSummary":"","keyCompetencies":[],"questions":[]}""")
 
         evaluator.startSession(
             jdText = "Kotlin과 Spring Boot를 사용하는 팀입니다.",
@@ -90,7 +79,7 @@ class InterviewCoachEvaluatorTest {
     @Test
     fun `evaluateAnswer - AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachAnswerResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -107,15 +96,10 @@ class InterviewCoachEvaluatorTest {
 
     @Test
     fun `evaluateAnswer - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = CoachAnswerResult(
-            feedback = "STAR 기법을 잘 활용한 답변입니다.",
-            score = 82,
-            improvements = listOf("결과 수치를 더 구체적으로 제시하면 좋겠습니다."),
-            encouragement = "좋은 경험을 잘 전달하셨어요. 계속 화이팅!"
-        )
+        val json = """{"feedback":"STAR 기법을 잘 활용한 답변입니다.","score":82,"improvements":["결과 수치를 더 구체적으로 제시하면 좋겠습니다."],"encouragement":"좋은 경험을 잘 전달하셨어요. 계속 화이팅!"}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachAnswerResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.evaluateAnswer(
             question = "JPA N+1 문제를 어떻게 해결하셨나요?",
@@ -133,8 +117,8 @@ class InterviewCoachEvaluatorTest {
     fun `evaluateAnswer - 사용자 프롬프트에 질문 번호와 전체 문제 수가 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(CoachAnswerResult::class.java)
-        ).thenReturn(CoachAnswerResult())
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"feedback":"","score":0,"improvements":[],"encouragement":""}""")
 
         evaluator.evaluateAnswer(
             question = "테스트 질문",
@@ -153,7 +137,7 @@ class InterviewCoachEvaluatorTest {
     @Test
     fun `generateReport - AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachReportResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -169,16 +153,10 @@ class InterviewCoachEvaluatorTest {
 
     @Test
     fun `generateReport - AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = CoachReportResult(
-            overallScore = 78,
-            passLikelihood = 65,
-            strengths = listOf("기술적 깊이", "문제 해결 능력"),
-            weaknesses = listOf("결과 수치화 부족"),
-            finalAdvice = "STAR 기법 연습을 꾸준히 하면 합격 가능성이 높아집니다."
-        )
+        val json = """{"overallScore":78,"passLikelihood":65,"strengths":["기술적 깊이","문제 해결 능력"],"weaknesses":["결과 수치화 부족"],"finalAdvice":"STAR 기법 연습을 꾸준히 하면 합격 가능성이 높아집니다."}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(CoachReportResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.generateReport(
             targetRole = "시니어 백엔드 개발자",
@@ -198,8 +176,8 @@ class InterviewCoachEvaluatorTest {
     fun `generateReport - 사용자 프롬프트에 목표 포지션과 JD 요약이 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(CoachReportResult::class.java)
-        ).thenReturn(CoachReportResult())
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"overallScore":0,"passLikelihood":0,"strengths":[],"weaknesses":[],"finalAdvice":""}""")
 
         evaluator.generateReport(
             targetRole = "시니어 백엔드 개발자",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JdAnalysisEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.JdAnalysisResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -26,7 +25,7 @@ class JdAnalysisEvaluatorTest {
 
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
             .thenReturn(null)
 
         assertThatThrownBy {
@@ -43,13 +42,9 @@ class JdAnalysisEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
-        val expected = JdAnalysisResult(
-            companyName = "토스",
-            overallMatchScore = 85,
-            applicationStrategy = "포트폴리오 강조"
-        )
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
-            .thenReturn(expected)
+        val json = """{"companyName":"토스","overallMatchScore":85,"applicationStrategy":"포트폴리오 강조","passed":false}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.analyze(
             companyName = "토스",
@@ -60,14 +55,14 @@ class JdAnalysisEvaluatorTest {
 
         assertThat(result.companyName).isEqualTo("토스")
         assertThat(result.overallMatchScore).isEqualTo(85)
-        assertThat(result.passed).isTrue()
+        assertThat(result.passed).isTrue() // PassCriteriaPolicy: 85 >= 70 → true
     }
 
     @Test
     fun `overallMatchScore가 70 이상이면 passed가 true이다`() {
-        val expected = JdAnalysisResult(overallMatchScore = 70)
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
-            .thenReturn(expected)
+        val json = """{"overallMatchScore":70}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.analyze(
             companyName = "토스",
@@ -81,9 +76,9 @@ class JdAnalysisEvaluatorTest {
 
     @Test
     fun `overallMatchScore가 70 미만이면 passed가 false이다`() {
-        val expected = JdAnalysisResult(overallMatchScore = 69)
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(JdAnalysisResult::class.java))
-            .thenReturn(expected)
+        val json = """{"overallMatchScore":69}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.analyze(
             companyName = "토스",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JourneyReportGeneratorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/JourneyReportGeneratorTest.kt
@@ -1,0 +1,83 @@
+package com.devquest.client.ai.evaluator
+
+import com.devquest.client.ai.support.AiCallExecutor
+import com.devquest.client.ai.support.AiMetricsRecorder
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import com.devquest.core.domain.support.AiEvaluationException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.client.ChatClient
+
+@ExtendWith(MockitoExtension::class)
+class JourneyReportGeneratorTest {
+
+    private val chatClient: ChatClient = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val metricsRecorder = AiMetricsRecorder(SimpleMeterRegistry())
+    private val aiCallExecutor = AiCallExecutor(maxRetry = 1, metricsRecorder = metricsRecorder)
+    private val generator = JourneyReportGenerator(chatClient, aiCallExecutor)
+
+    @Test
+    fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(null)
+
+        assertThatThrownBy {
+            generator.generate(
+                companyName = "토스",
+                targetPosition = "시니어 백엔드 개발자",
+                questScores = mapOf("1-1" to 80),
+                totalXp = 1200,
+                completedQuestCount = 5
+            )
+        }
+            .isInstanceOf(AiEvaluationException::class.java)
+            .hasMessageContaining("최종 실패")
+    }
+
+    @Test
+    fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
+        val json = """{"companyName":"토스","targetPosition":"시니어 백엔드 개발자","totalXp":1200,"completedQuestCount":5,"narrative":"훌륭한 여정이었습니다.","lowestQuestId":"1-2","highestQuestId":"2-1","finalMessage":"합격을 응원합니다!"}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
+
+        val result = generator.generate(
+            companyName = "토스",
+            targetPosition = "시니어 백엔드 개발자",
+            questScores = mapOf("1-1" to 80, "1-2" to 60, "2-1" to 95),
+            totalXp = 1200,
+            completedQuestCount = 5
+        )
+
+        assertThat(result.companyName).isEqualTo("토스")
+        assertThat(result.totalXp).isEqualTo(1200)
+        assertThat(result.finalMessage).isEqualTo("합격을 응원합니다!")
+    }
+
+    @Test
+    fun `사용자 프롬프트에 회사명과 목표 포지션이 포함된다`() {
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        whenever(chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content())
+            .thenReturn("""{"companyName":"카카오"}""")
+
+        generator.generate(
+            companyName = "카카오",
+            targetPosition = "백엔드 개발자",
+            questScores = mapOf("1-1" to 80),
+            totalXp = 800,
+            completedQuestCount = 3
+        )
+
+        val prompt = promptCaptor.value
+        assertThat(prompt).contains("카카오")
+        assertThat(prompt).contains("백엔드 개발자")
+    }
+}

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/PersonalityInterviewEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -26,7 +25,7 @@ class PersonalityInterviewEvaluatorTest {
 
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
             .thenReturn(null)
 
         assertThatThrownBy {
@@ -41,13 +40,9 @@ class PersonalityInterviewEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
-        val expected = AiEvaluationResult(
-            score = 75,
-            passed = true,
-            grade = "B"
-        )
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
-            .thenReturn(expected)
+        val json = """{"score":75,"passed":true,"grade":"B"}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.evaluate(
             question = "갈등 상황을 어떻게 해결했나요?",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SkillAssessmentEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.SkillAssessmentResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -28,7 +27,7 @@ class SkillAssessmentEvaluatorTest {
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(SkillAssessmentResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy {
@@ -43,18 +42,10 @@ class SkillAssessmentEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = SkillAssessmentResult(
-            score = 78,
-            passed = true,
-            grade = "B",
-            developerType = "안정형 백엔드 스페셜리스트",
-            strengths = listOf("Java 장기 실무 경험", "Spring Boot 숙련도"),
-            improvements = listOf("Kubernetes 경험 부족", "클라우드 네이티브 전환 필요", "컨테이너 오케스트레이션 학습 우선"),
-            feedback = "백엔드 핵심 기술은 탄탄하나 클라우드 역량 보완 필요"
-        )
+        val json = """{"score":78,"passed":true,"grade":"B","developerType":"안정형 백엔드 스페셜리스트","strengths":["Java 장기 실무 경험","Spring Boot 숙련도"],"improvements":["Kubernetes 경험 부족","클라우드 네이티브 전환 필요","컨테이너 오케스트레이션 학습 우선"],"feedback":"백엔드 핵심 기술은 탄탄하나 클라우드 역량 보완 필요"}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(SkillAssessmentResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.evaluate(
             skills = listOf("Java:5년", "Spring Boot:3년", "Kubernetes:6개월"),
@@ -71,10 +62,8 @@ class SkillAssessmentEvaluatorTest {
     fun `사용자 프롬프트에 기술 목록과 목표 포지션이 포함된다`() {
         val promptCaptor = ArgumentCaptor.forClass(String::class.java)
         whenever(
-            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().entity(SkillAssessmentResult::class.java)
-        ).thenReturn(
-            SkillAssessmentResult(score = 70, passed = true, grade = "B")
-        )
+            chatClient.prompt().system(any<String>()).user(capture(promptCaptor)).call().content()
+        ).thenReturn("""{"score":70,"passed":true,"grade":"B"}""")
 
         evaluator.evaluate(
             skills = listOf("Java:5년", "Spring Boot:3년"),

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/SystemDesignEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -26,7 +25,7 @@ class SystemDesignEvaluatorTest {
 
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
             .thenReturn(null)
 
         assertThatThrownBy {
@@ -42,13 +41,9 @@ class SystemDesignEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
-        val expected = AiEvaluationResult(
-            score = 80,
-            passed = true,
-            grade = "A"
-        )
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
-            .thenReturn(expected)
+        val json = """{"score":80,"passed":true,"grade":"A"}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.evaluate(
             problemStatement = "URL 단축 서비스를 설계하세요",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechBlogEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.AiEvaluationResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -26,7 +25,7 @@ class TechBlogEvaluatorTest {
 
     @Test
     fun `AI가 null을 반환하면 AiEvaluationException이 발생한다`() {
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
             .thenReturn(null)
 
         assertThatThrownBy {
@@ -42,13 +41,9 @@ class TechBlogEvaluatorTest {
 
     @Test
     fun `AI가 정상 응답을 반환하면 결과를 그대로 반환한다`() {
-        val expected = AiEvaluationResult(
-            score = 82,
-            passed = true,
-            grade = "A"
-        )
-        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(AiEvaluationResult::class.java))
-            .thenReturn(expected)
+        val json = """{"score":82,"passed":true,"grade":"A"}"""
+        whenever(chatClient.prompt().system(any<String>()).user(any<String>()).call().content())
+            .thenReturn(json)
 
         val result = evaluator.evaluate(
             techTopic = "JVM",

--- a/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluatorTest.kt
+++ b/be/clients/client-ai/src/test/kotlin/com/devquest/client/ai/evaluator/TechInterviewEvaluatorTest.kt
@@ -3,7 +3,6 @@ package com.devquest.client.ai.evaluator
 import com.devquest.client.ai.support.AiCallExecutor
 import com.devquest.client.ai.support.AiMetricsRecorder
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import com.devquest.core.domain.model.evaluation.TechInterviewResult
 import com.devquest.core.domain.support.AiEvaluationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -50,7 +49,7 @@ class TechInterviewEvaluatorTest {
     @Test
     fun `generateQuestions — AI가 null을 반환하면 AiEvaluationException 발생`() {
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(TechInterviewResult::class.java)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
         ).thenReturn(null)
 
         assertThatThrownBy { evaluator.generateQuestions("Java,Spring Boot") }
@@ -60,10 +59,10 @@ class TechInterviewEvaluatorTest {
 
     @Test
     fun `generateQuestions — AI가 정상 응답을 반환하면 결과를 그대로 반환`() {
-        val expected = TechInterviewResult(questions = listOf("Q1", "Q2"))
+        val json = """{"questions":["Q1","Q2"],"overallScore":0,"feedback":"","passed":false,"modelAnswer":""}"""
         whenever(
-            chatClient.prompt().system(any<String>()).user(any<String>()).call().entity(TechInterviewResult::class.java)
-        ).thenReturn(expected)
+            chatClient.prompt().system(any<String>()).user(any<String>()).call().content()
+        ).thenReturn(json)
 
         val result = evaluator.generateQuestions("Java,Spring Boot")
 


### PR DESCRIPTION
## 문제

Spring AI 2.0.0-RC2 업그레이드(PR #198) 이후 `.entity()` 패턴을 사용하는 모든 Evaluator에서 AI 평가 시 500 에러 발생.

- **즉각 영향**: 데일리 질문 답변 제출 (`POST /api/v1/daily-question/evaluate`)
- **잠재 영향**: BossPackage, DeveloperClass, InterviewCoach 등 나머지 퀘스트 기능 전체

**근본 원인**: RC2에서 `.entity()` 메서드가 null 반환 또는 파싱 실패 → `AiCallExecutor` 3회 재시도 후 `AiEvaluationException` → 500

## 해결

기존 마이그레이션된 패턴 기준으로 14개 Evaluator 전체 통일:

```kotlin
// 변경 전
.call().entity(XxxResult::class.java)

// 변경 후
val content = .call().content()
parseContent(content, XxxResult::class.java)
```

## 테스트 개선

기존 테스트들이 `.entity()` stub을 사용해 구현의 거울이 됐던 문제 수정. `.content()` JSON stub으로 전환하여 구현이 `.entity()`로 되돌아가면 즉시 CI 실패. 누락된 `ActClearReportEvaluatorTest`, `JourneyReportGeneratorTest` 신규 추가.

## 부수 수정

`assert-pr-reviewed.sh`: 대용량 diff에서 `jq --arg` 인자 길이 초과 → `--rawfile`로 수정.

## 변경 범위

- 구현 14개, 테스트 13개 (기존 11개 전환 + 신규 2개)