### PR TITLE
fix(be): parseContent lazy regex 버그 수정 — 중첩 코드블록 포함 AI 응답 파싱 실패 수정

### DIFF
--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
@@ -18,13 +18,17 @@ abstract class BaseAiEvaluator(
     private val objectMapper = jacksonObjectMapper()
 
     /**
-     * AI 응답에서 마크다운 코드 블록(```json ... ```)을 제거하고 Jackson으로 파싱.
-     * .entity() 대신 사용 — 중첩 객체가 많은 응답에서 AI가 마크다운으로 감싸는 경우 대응.
+     * AI 응답에서 JSON 객체를 추출하고 Jackson으로 파싱.
+     * 첫 번째 '{' ~ 마지막 '}' 범위를 추출하므로 코드블록 유무·중첩 여부와 무관하게 동작.
+     *
+     * 기존 lazy regex(```json ... ```)는 modelAnswer 내부에 중첩 코드블록(```java...```)이 포함되면
+     * 첫 ``` 에서 멈춰 JSON이 잘리는 버그가 있었음.
      */
     protected fun <T> parseContent(content: String?, targetClass: Class<T>): T? {
         val raw = content?.trim() ?: return null
-        val codeBlockRegex = Regex("```(?:json)?\\s*([\\s\\S]*?)```")
-        val json = codeBlockRegex.find(raw)?.groupValues?.get(1)?.trim() ?: raw
+        val start = raw.indexOf('{')
+        val end = raw.lastIndexOf('}')
+        val json = if (start != -1 && end != -1 && start < end) raw.substring(start, end + 1) else raw
         return objectMapper.readValue(json, targetClass)
     }
 }


### PR DESCRIPTION
## 문제

`POST /api/v1/daily-question/evaluate` → 500 `AI_EVALUATION_FAILED`

복잡한 한국어 질문(오늘의 면접 질문) + 한국어 답변 제출 시 AI 평가 실패.

## 원인

`BaseAiEvaluator.parseContent()`의 lazy regex 버그.

Claude Haiku가 `modelAnswer` 필드에 Java 코드 예시를 포함할 때, 응답 구조는 다음과 같음:

````
```json
{
  "modelAnswer": "...```java\n@Transactional\n...\n```..."
}
```
````

기존 lazy regex `([\s\S]*?)` 가 외부 코드블록 종료 ` ``` ` 대신 내부 ` ```java ` 에서 멈춰 JSON이 잘림 → Jackson 파싱 실패 → 3회 재시도 → `AiEvaluationException` → 500.

단순한 질문(영어, 짧은 한국어)은 `modelAnswer`에 코드 예시 없음 → regex 정상 → 성공. 실제 오늘의 면접 질문(복잡한 JPA multi-paragraph)은 코드 예시 포함 → 실패.

Anthropic API 직접 테스트로 확인.

## 수정

lazy regex 제거 → `firstIndexOf('{')` ~ `lastIndexOf('}')` 범위 추출 방식으로 교체.

코드블록 유무, 중첩 코드블록 여부와 무관하게 JSON 객체만 추출.

```kotlin
// 변경 전
val codeBlockRegex = Regex("```(?:json)?\s*([\s\S]*?)```")
val json = codeBlockRegex.find(raw)?.groupValues?.get(1)?.trim() ?: raw

// 변경 후
val start = raw.indexOf('{')
val end = raw.lastIndexOf('}')
val json = if (start != -1 && end != -1 && start < end) raw.substring(start, end + 1) else raw
```

중첩 JSON 객체(`{"a": {"b": 1}}`)도 `firstIndexOf`/`lastIndexOf` 조합으로 정확히 추출됨 (QA 검증 완료).

## 영향

`BaseAiEvaluator`를 상속하는 전체 Evaluator(약 14개)에 적용. 모두 이 방식이 더 안전.