### PR TITLE
fix(be): OTLP auto-config 중복 bean 수정 — spring.autoconfigure.exclude 적용

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `main` |
-| 열린 PR | 없음 |
+| 브랜치 | `fix/otlp-auto-config` |
+| 열린 PR | #209 — OTLP auto-config 중복 bean 수정 (머지 대기) |
 
 
 
@@ -72,6 +72,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #209 | OTLP auto-config 중복 bean 수정 — spring.autoconfigure.exclude로 OtlpMetricsExportAutoConfiguration 직접 제외 | 2026-06-17 |
 | #208 | 기술면접 평가 면접관 페르소나 수정 — "10년 이상 경력" → "경험 많은 기술 면접관", 5년차 기준 피드백 명시 | 2026-06-16 |
 | #207 | Grafana Loki 로그 전송 수정 (loki4j 1.x batch API), 레이턴시 메트릭 단위 수정 (baseTimeUnit seconds), orchestrator Self-Critique Gate 추가 | 2026-06-15 |
 | #206 | 평가 결과 마크다운 렌더링 + 모바일 가시성 개선 — MarkdownRenderer 컴포넌트, maxWidth 640 | 2026-06-15 |

--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -4,6 +4,9 @@ logging:
     org.flywaydb: INFO
 
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
   h2:
     console:
       enabled: false
@@ -25,12 +28,9 @@ grafana:
 
 # micrometer-registry-otlp가 classpath에 있으면 Spring Boot autoconfiguration이
 # OtlpMeterRegistry를 자동 생성 → OtlpMetricsConfig 수동 bean과 중복 생성됨.
-# 수동 bean(OtlpMetricsConfig)만 사용하도록 autoconfiguration 비활성화.
-management:
-  otlp:
-    metrics:
-      export:
-        enabled: false
+# Spring Boot 4.x에서 클래스가 spring-boot-micrometer-metrics 모듈로 이동됨.
+# management.otlp.metrics.export.enabled=false는 이 클래스에 적용 안 됨 → exclude로 직접 제거.
+# (spring.autoconfigure.exclude는 spring: 블록에 병합됨)
 
 storage:
   datasource:


### PR DESCRIPTION
## 문제

Spring Boot 4.x에서 OTLP auto-configuration 클래스가 `spring-boot-actuator-autoconfigure`에서 `spring-boot-micrometer-metrics` 모듈로 이동됨.

기존 비활성화 설정:
```yaml
management:
  otlp:
    metrics:
      export:
        enabled: false
```

이 프로퍼티가 새 모듈의 `OtlpMetricsExportAutoConfiguration`에 매핑되지 않아 비활성화 실패.

결과:
- `OtlpMeterRegistry` 두 개 생성 (수동 bean + auto-configured bean)
- auto-configured bean은 인증 정보 없이 Grafana Cloud에 전송 시도 → 401 → `Unexpected end of file from server` 반복
- Grafana 대시보드에 메트릭 데이터 미수신

## 원인 분석

- PR #172 (OTLP 도입) ~ #194: `start()` 누락으로 전송 자체 안 됨
- PR #195 (start() 추가): 처음으로 전송 시도, 동시에 auto-config 비활성화 시도했으나 실패
- PR #195 이후 현재까지: 두 개 registry 중 auto-configured bean이 항상 401 실패

## 수정

`management.otlp.metrics.export.enabled: false` → `spring.autoconfigure.exclude`로 클래스 직접 제외.

올바른 클래스명 (`spring-boot-micrometer-metrics-4.0.3.jar`에서 직접 확인):
```
org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
```

## 기대 효과

배포 후 `Publishing metrics for OtlpMeterRegistry` 로그가 1번만 찍히고, Grafana 대시보드에 메트릭 수신 시작.