### PR TITLE
fix(be): OTLP auto-config exclude를 application.yml로 이동

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -4,9 +4,6 @@ logging:
     org.flywaydb: INFO
 
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
   h2:
     console:
       enabled: false
@@ -26,11 +23,6 @@ grafana:
     enabled: true
     instance-id: "1680166"
 
-# micrometer-registry-otlp가 classpath에 있으면 Spring Boot autoconfiguration이
-# OtlpMeterRegistry를 자동 생성 → OtlpMetricsConfig 수동 bean과 중복 생성됨.
-# Spring Boot 4.x에서 클래스가 spring-boot-micrometer-metrics 모듈로 이동됨.
-# management.otlp.metrics.export.enabled=false는 이 클래스에 적용 안 됨 → exclude로 직접 제거.
-# (spring.autoconfigure.exclude는 spring: 블록에 병합됨)
 
 storage:
   datasource:

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -5,6 +5,13 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
+  autoconfigure:
+    exclude:
+      # micrometer-registry-otlp가 classpath에 있으면 auto-configured OtlpMeterRegistry가 생성됨.
+      # 수동 bean(OtlpMetricsConfig)만 사용하도록 제외.
+      # application-prod.yml의 exclude는 auto-config 처리 타이밍 이후 로드되어 효과 없음 → 여기서 제외.
+      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
+
   config:
     import:
       - classpath:db-core.yml


### PR DESCRIPTION
## 문제

PR #209에서 `spring.autoconfigure.exclude`를 `application-prod.yml`에 추가했으나 여전히 `Publishing metrics` 로그 2번 출력.

**원인**: Spring Boot auto-configuration 제외 처리가 프로파일 yml(`application-prod.yml`) 로드보다 먼저 일어남 → 프로파일 yml의 `exclude` 설정이 타이밍상 무효.

## 수정

`application-prod.yml`의 `spring.autoconfigure.exclude` → `application.yml`(기본 설정)으로 이동.

기본 yml은 auto-configuration 처리 전에 로드되어 exclude가 정상 적용됨.

## 기대 효과

배포 후 `Publishing metrics for OtlpMeterRegistry` 로그가 **1번만** 찍히고 Grafana 메트릭 수신 정상화.