### PR TITLE
fix(be): OTLP auto-config를 @SpringBootApplication excludeName으로 제외

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/DevQuestApplication.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/DevQuestApplication.kt
@@ -5,7 +5,13 @@ import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableScheduling
-@SpringBootApplication(scanBasePackages = ["com.devquest"])
+@SpringBootApplication(
+    scanBasePackages = ["com.devquest"],
+    // micrometer-registry-otlp가 classpath에 있으면 auto-configured OtlpMeterRegistry 생성됨.
+    // 수동 bean(OtlpMetricsConfig)만 사용하도록 직접 제외.
+    // excludeName: core-api 모듈에 해당 클래스 의존성 없어 String으로 지정.
+    excludeName = ["org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration"],
+)
 class DevQuestApplication
 
 fun main(args: Array<String>) {

--- a/be/core/core-api/src/main/resources/application.yml
+++ b/be/core/core-api/src/main/resources/application.yml
@@ -5,13 +5,6 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
-  autoconfigure:
-    exclude:
-      # micrometer-registry-otlp가 classpath에 있으면 auto-configured OtlpMeterRegistry가 생성됨.
-      # 수동 bean(OtlpMetricsConfig)만 사용하도록 제외.
-      # application-prod.yml의 exclude는 auto-config 처리 타이밍 이후 로드되어 효과 없음 → 여기서 제외.
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
-
   config:
     import:
       - classpath:db-core.yml


### PR DESCRIPTION
## 문제

PR #209, #211에서 `spring.autoconfigure.exclude`를 yml에 추가했으나 `Publishing metrics` 로그가 여전히 2번 출력.

**원인**: yml 기반 exclude는 Spring Boot auto-configuration 처리 이후 로드되어 타이밍상 무효.

## 수정

`@SpringBootApplication(excludeName = [...])` 으로 어노테이션 레벨에서 직접 제외.

`exclude = [OtlpMetricsExportAutoConfiguration::class]` 대신 `excludeName`(String) 사용 — `core-api` 모듈에 해당 클래스 의존성 없어 직접 참조 불가.

## 기대 효과

배포 후 `Publishing metrics` 로그 **1번**만 찍히고 Grafana 메트릭 수신 정상화.