### PR TITLE
fix(be): OTLP 메트릭 push keep-alive stale connection 오류 수정

### DIFF
--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -41,7 +41,12 @@ class OtlpMetricsConfig(
                 else -> null
             }
             override fun headers(): Map<String, String> =
-                mapOf("Authorization" to "Basic $encoded")
+                mapOf(
+                    "Authorization" to "Basic $encoded",
+                    // keep-alive stale connection 방지: Java HttpURLConnection이 idle connection을
+                    // 재사용하다 "Unexpected end of file from server" 오류 발생 → Connection: close로 강제 종료
+                    "Connection" to "close",
+                )
         }
         val threadFactory = ThreadFactory { runnable ->
             Executors.defaultThreadFactory().newThread(runnable).apply {

--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -54,6 +54,11 @@ class OtlpMetricsConfig(
                 isDaemon = true
             }
         }
+        // HttpURLConnection keep-alive 비활성화: 60초 이상 유휴 상태인 connection을
+        // Grafana Cloud 서버가 닫은 후 재사용 시 "Unexpected end of file from server" 오류 발생.
+        // OTLP push는 60초 간격이므로 keep-alive 이점보다 stale connection 위험이 큼.
+        System.setProperty("http.keepAlive", "false")
+
         return OtlpMeterRegistry(config, clock).also { created ->
             created.start(threadFactory)
             registry = created


### PR DESCRIPTION
## 문제

Grafana Cloud OTLP 엔드포인트로 메트릭 push 시 `Unexpected end of file from server` 오류 반복 발생.

**원인**: Java `HttpURLConnection` keep-alive connection pool에서 60초 유휴 후 Grafana Cloud 서버가 닫은 connection을 재사용하다 실패.

## 수정

`OtlpMetricsConfig.otlpMeterRegistry()` 초기화 시 두 가지 방어:

1. `OtlpConfig.headers()`에 `Connection: close` 추가 → 서버에 connection 닫도록 요청
2. `System.setProperty("http.keepAlive", "false")` → JVM `HttpURLConnection` keep-alive pool 자체 비활성화 (1번이 restricted header로 무시될 경우 대비)

**전역 영향 범위**: `http.keepAlive=false`는 `HttpURLConnection` 기반 연결에만 적용. Loki(loki4j 자체 클라이언트), Anthropic SDK(별도 HTTP 클라이언트)에는 영향 없음.

## 변경 파일

- `be/support/monitoring/.../OtlpMetricsConfig.kt` — headers()에 Connection: close 추가, http.keepAlive 시스템 프로퍼티 설정