### PR TITLE
fix(be): OTLP auto-config 비활성화 — Registry 중복 429 rate limit 수정

### DIFF
--- a/be/core/core-api/src/main/resources/application-prod.yml
+++ b/be/core/core-api/src/main/resources/application-prod.yml
@@ -23,6 +23,14 @@ grafana:
     enabled: true
     instance-id: "1680166"
 
+management:
+  otlp:
+    metrics:
+      export:
+        # Spring Boot auto-config OtlpMeterRegistry 비활성화.
+        # 수동 Bean(OtlpMetricsConfig)만 사용. 두 개 동시 기동 시 429 rate limit 발생.
+        enabled: false
+
 
 storage:
   datasource:


### PR DESCRIPTION
## 문제

Fly.io 로그에서 OTLP push 429 rate limit 에러 발견 (06-19 05:28~):
\`\`\`
HTTP 429 — the request has been rejected because the tenant exceeded the request rate limit (err-mimir-tenant-max-request-rate)
\`\`\`

시작 로그에서 \`Publishing metrics for OtlpMeterRegistry\`가 동일 시각에 **2줄** 찍힘 → \`OtlpMeterRegistry\` 인스턴스 2개가 동시에 기동됨.

## 원인

Spring Boot 4.x의 \`spring-boot-micrometer-metrics\` jar에 \`OtlpMetricsExportAutoConfiguration\`이 \`AutoConfiguration.imports\`에 등록되어 있음.

\`@SpringBootApplication(excludeName = [...])\`으로 제외 시도했으나 imports 기반 auto-config에 불안정 → auto-config OtlpMeterRegistry + 수동 Bean 두 개 동시 기동.

→ 60초 push 2배 → Grafana Cloud rate limit 초과 → 그라파나 공백

## 해결

\`application-prod.yml\`에 명시적 비활성화:
\`\`\`yaml
management:
  otlp:
    metrics:
      export:
        enabled: false
\`\`\`

QA에서 \`spring-configuration-metadata.json\` 직접 확인 — 이 키가 \`OtlpMetricsExportAutoConfiguration\`의 비활성화 조건과 정확히 일치함.