### PR TITLE
fix(be): OtlpMeterRegistry 중복 start() 제거 + push 성공 로그 추가

### DIFF
--- a/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
+++ b/be/support/monitoring/src/main/kotlin/com/devquest/monitoring/OtlpMetricsConfig.kt
@@ -59,11 +59,19 @@ class OtlpMetricsConfig(
         // OTLP push는 60초 간격이므로 keep-alive 이점보다 stale connection 위험이 큼.
         System.setProperty("http.keepAlive", "false")
 
-        return OtlpMeterRegistry(config, clock).also { created ->
-            created.start(threadFactory)
-            registry = created
-            log.info("OtlpMeterRegistry started — pushing to Grafana Cloud every 60s")
+        // 3-arg 생성자 사용: 내부 private 4-arg 생성자가 threadFactory로 start() 를 1회 호출.
+        // 기존: OtlpMeterRegistry(config, clock) → DEFAULT_THREAD_FACTORY로 start() 자동 호출
+        //       + created.start(threadFactory) 명시 호출 → 총 2회 → "Publishing metrics" 2줄 로그.
+        // publish() 오버라이드: 60초 push 성공 시 INFO 로그. 실패 시 Micrometer 내부 WARN 로그 유지.
+        val created = object : OtlpMeterRegistry(config, clock, threadFactory) {
+            override fun publish() {
+                super.publish()
+                log.info("OTLP metrics pushed to Grafana Cloud successfully")
+            }
         }
+        registry = created
+        log.info("OtlpMeterRegistry started — pushing to Grafana Cloud every 60s")
+        return created
     }
 
     @PreDestroy


### PR DESCRIPTION
## 문제

\`OtlpMeterRegistry\` 기동 시 \`Publishing metrics for OtlpMeterRegistry\` 로그가 2줄 출력됨.

**원인** (v1.16.3 소스 확인):
\`OtlpMeterRegistry\`의 private 4-arg 생성자 내부 마지막에 \`start(threadFactory)\`를 자동 호출.
기존 코드에서 2-arg 생성자 사용 후 \`created.start(threadFactory)\` 명시 호출 → 총 2회.

\`\`\`
OtlpMeterRegistry(config, clock)          // 2-arg
  → this(config, clock, DEFAULT_THREAD_FACTORY)
    → private 4-arg 생성자
      → start(DEFAULT_THREAD_FACTORY)     ← 1번째 (자동)

created.start(threadFactory)              ← 2번째 (명시) → 제거 대상
\`\`\`

## 수정

**중복 start() 제거**: 3-arg 생성자 사용 → 커스텀 \`threadFactory\`로 start() 1회만 호출.

**push 성공 로그 추가**: \`publish()\` 오버라이드 → 60초 push 성공 시 INFO 로그.
실패 시 Micrometer 내부 WARN 로그 유지 (이중 로그 없음).

**배포 후 기대 로그:**
\`\`\`
# 기동 시
INFO OtlpMeterRegistry started — pushing to Grafana Cloud every 60s
INFO Publishing metrics for OtlpMeterRegistry every 1m ...   ← 이제 1줄만

# 매 60초 성공 시
INFO OTLP metrics pushed to Grafana Cloud successfully

# 실패 시 (기존과 동일)
WARN Failed to publish metrics to OTLP receiver ... HTTP 429 ...
\`\`\`

## 영향 범위
- \`be/support/monitoring\` 모듈만 변경. 전체 BE 테스트 통과.