### PR TITLE
fix(grafana): 토큰 패널 increase 범위 $__rate_interval로 교체

### DIFF
--- a/grafana/ai-metrics-dashboard.json
+++ b/grafana/ai-metrics-dashboard.json
@@ -457,7 +457,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (evaluatorType) (increase(ai_tokens_input_total[90s]))",
+          "expr": "sum by (evaluatorType) (increase(ai_tokens_input_total[$__rate_interval]))",
           "legendFormat": "input - {{evaluatorType}}",
           "refId": "A"
         },
@@ -466,7 +466,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (evaluatorType) (increase(ai_tokens_output_total[90s]))",
+          "expr": "sum by (evaluatorType) (increase(ai_tokens_output_total[$__rate_interval]))",
           "legendFormat": "output - {{evaluatorType}}",
           "refId": "B"
         }
@@ -548,7 +548,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(increase(ai_tokens_cache_read_total[90s]))",
+          "expr": "sum(increase(ai_tokens_cache_read_total[$__rate_interval]))",
           "legendFormat": "cache_read",
           "refId": "A"
         },
@@ -557,7 +557,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(increase(ai_tokens_cache_creation_total[90s]))",
+          "expr": "sum(increase(ai_tokens_cache_creation_total[$__rate_interval]))",
           "legendFormat": "cache_creation",
           "refId": "B"
         }
@@ -674,7 +674,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (evaluatorType) (increase(ai_tokens_cache_read_total[90s]))",
+          "expr": "sum by (evaluatorType) (increase(ai_tokens_cache_read_total[$__rate_interval]))",
           "legendFormat": "saved - {{evaluatorType}}",
           "refId": "A"
         }


### PR DESCRIPTION
## 문제

토큰 time-series 패널이 no data 반환.

원인: `increase(ai_tokens_input_total[90s])` — 90초 윈도우 안에 OTLP 데이터 포인트가 2개 이상 필요.
Grafana 패널 step이 90s보다 크면(예: 5분 단위) 각 포인트의 90s 윈도우에 포인트 1개뿐 → increase() 계산 불가.

메트릭 자체는 Mimir에 정상 적재 확인 (`ai_tokens_input_total`, `ai_tokens_output_total` Explore에서 확인).

## 수정

`[90s]` → `[$__rate_interval]` — Grafana가 패널 step 기반으로 자동 계산, 항상 충분한 포인트 보장.

대상 패널:
- Input / Output Tokens by Evaluator
- Cache Tokens (cache_read vs cache_creation)
- Cache Saved Tokens by Evaluator