### PR TITLE
chore(k8s): BE Deployment, Service 초기 매니페스트 추가

### DIFF
--- a/k8s/be/deployment.yaml
+++ b/k8s/be/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1        # Deployment가 속한 API 그룹
+kind: Deployment           # 오브젝트 타입
+metadata:
+  name: devquest-be        # 이 Deployment의 이름
+  namespace: default       # 네임스페이스 (지금은 default 사용)
+spec:
+  replicas: 1              # Pod 몇 개 유지할지
+  selector:
+    matchLabels:
+      app: devquest-be     # 이 Deployment가 관리할 Pod를 라벨로 선택
+  template:                # Pod 템플릿 — 아래부터 실제 Pod 스펙
+    metadata:
+      labels:
+        app: devquest-be   # Pod에 붙는 라벨 (selector와 반드시 일치)
+    spec:
+      containers:
+        - name: devquest-be
+          image: devquest-be:local      # 방금 로드한 이미지
+          imagePullPolicy: Never        # 레지스트리에서 pull하지 말고 로컬 이미지 사용
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"

--- a/k8s/be/deployment.yaml
+++ b/k8s/be/deployment.yaml
@@ -21,4 +21,7 @@ spec:
             - containerPort: 8080
           env:
             - name: SPRING_PROFILES_ACTIVE
-              value: "prod"
+              value: "local"          # local: H2 in-memory, OTLP/Loki 비활성 → 외부 서비스 불필요
+          envFrom:
+            - secretRef:
+                name: devquest-secrets  # GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, JWT_SECRET 주입

--- a/k8s/be/services.yaml
+++ b/k8s/be/services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: devquest-be-service
+  namespace: default
+spec:
+  selector:
+    app: devquest-be       # 이 라벨을 가진 Pod로 트래픽 전달
+  ports:
+    - protocol: TCP
+      port: 8080           # Service가 외부에 노출하는 포트
+      targetPort: 8080     # Pod의 실제 포트
+  type: ClusterIP          # 클러스터 내부에서만 접근 가능 (외부 노출 X)

--- a/k8s/docs/env-requirements.md
+++ b/k8s/docs/env-requirements.md
@@ -1,0 +1,80 @@
+# 프로파일별 환경변수 요구사항
+
+## local 프로파일 (`SPRING_PROFILES_ACTIVE=local`)
+
+로컬 개발 / kind 클러스터 학습용. DB는 H2 in-memory, Loki·OTLP 비활성.
+
+| 환경변수 | 기본값 | 필수 여부 | 비고 |
+|---------|--------|---------|------|
+| `GITHUB_CLIENT_ID` | 없음 | ✅ 필수 | `application.yml` — 기본값 없음 |
+| `GITHUB_CLIENT_SECRET` | 없음 | ✅ 필수 | `application.yml` — 기본값 없음 |
+| `JWT_SECRET` | 없음 | ✅ 필수 | `application.yml` — 기본값 없음, 256bit 이상 |
+| `ANTHROPIC_API_KEY` | `""` (빈 문자열) | 선택 | AI 기능 호출 시에만 필요. 미설정 시 앱 기동은 가능 |
+| `JUDGE0_API_KEY` | `""` | 선택 | 코드 실행 기능 |
+| `RESEND_API_KEY` | `""` | 선택 | 메일 발송 기능 |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | 선택 | |
+| `JWT_EXPIRATION_MS` | `2592000000` (30일) | 선택 | |
+| `MAIL_ENABLED` | `false` | 선택 | |
+
+### kind 클러스터 Secret 최소 구성 (3개만 필수)
+
+```bash
+kubectl create secret generic devquest-secrets \
+  --from-literal=GITHUB_CLIENT_ID=dummy-client-id \
+  --from-literal=GITHUB_CLIENT_SECRET=dummy-client-secret \
+  --from-literal=JWT_SECRET=local-k8s-jwt-secret-must-be-at-least-256-bits-long-xxxxx
+```
+
+### deployment.yaml envFrom 설정
+
+```yaml
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "local"
+envFrom:
+  - secretRef:
+      name: devquest-secrets
+```
+
+---
+
+## prod 프로파일 (`SPRING_PROFILES_ACTIVE=prod`)
+
+Fly.io 배포용. 외부 DB(Neon PostgreSQL) + Grafana Cloud(OTLP, Loki) 연동.
+
+| 환경변수 | 필수 여부 | 비고 |
+|---------|---------|------|
+| `GITHUB_CLIENT_ID` | ✅ | |
+| `GITHUB_CLIENT_SECRET` | ✅ | |
+| `JWT_SECRET` | ✅ | |
+| `DB_HOST` | ✅ | Neon PostgreSQL 호스트 |
+| `DB_NAME` | ✅ | |
+| `DB_USERNAME` | ✅ | |
+| `DB_PASSWORD` | ✅ | |
+| `ANTHROPIC_API_KEY` | ✅ | AI 기능 |
+| `GRAFANA_API_KEY` | ✅ | `OtlpMetricsConfig` — prod에서 `grafana.otlp.enabled=true` 고정 |
+| `GRAFANA_LOKI_URL` | ✅ | `logback-spring.xml` prod 프로파일 Loki Appender URI |
+| `RESEND_API_KEY` | 선택 | 메일 발송 |
+| `JUDGE0_API_KEY` | 선택 | 코드 실행 |
+
+### prod 주의사항
+
+- `grafana.otlp.enabled`는 `application-prod.yml`에 `true`로 **하드코딩**됨
+  → `GRAFANA_API_KEY` 미설정 시 `PlaceholderResolutionException`으로 앱 기동 실패
+- `GRAFANA_LOKI_URL`이 빈값이면 Logback 초기화 단계(Spring context 이전)에서 URI 파싱 오류 발생
+  → 반드시 유효한 URL 형식 필요
+
+---
+
+## 의존 구조 요약
+
+```
+application.yml (항상 로드)
+  ├── db-core.yml          → H2 기본값 내장 (local에선 외부 DB 불필요)
+  ├── client-ai-anthropic.yml → ANTHROPIC_API_KEY 기본값 "" (선택)
+  ├── logging.yml          → logback-spring.xml 참조
+  └── monitoring.yml       → OtlpMetricsConfig (grafana.otlp.enabled 조건부 활성)
+
+application-local.yml (local 프로파일 시 로드) — .gitignore 대상
+application-prod.yml  (prod  프로파일 시 로드) — grafana.otlp.enabled=true 하드코딩
+```


### PR DESCRIPTION
## 변경 내용

K8s 학습용 초기 매니페스트 추가.

- `k8s/be/deployment.yaml`: devquest-be Deployment (replicas=1, imagePullPolicy=Never, local 프로파일)
- `k8s/be/services.yaml`: ClusterIP Service (port 8080)
- `k8s/docs/env-requirements.md`: local / prod 프로파일별 필수·선택 환경변수 정리

## 비고

- local 프로파일: H2 in-memory, OTLP/Loki 비활성 → 필수 env 3개만 필요
- K8s Secret(`devquest-secrets`)은 클러스터에서 직접 생성 (git 비포함)
- 프로덕션 배포용 아님, K8s 학습 목적