### PR TITLE
feat(be,fe): 지원 파이프라인 Phase 2 — JD 분석 코칭 연동

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -57,7 +57,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 | 항목 | 내용 |
 |------|------|
 | 브랜치 | `feat/company-pipeline-phase2` |
-| 열린 PR | #228 — K8s Stage 3 학습 인덱스 (머지 대기) / 진행 중 — JD 분석 코칭 Phase 2 |
+| 열린 PR | #228 — K8s Stage 3 학습 인덱스 (머지 대기), #229 — JD 분석 코칭 Phase 2 (머지 대기) |
 
 ### K8s 학습 진행 상태
 
@@ -86,6 +86,7 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #229 | 지원 파이프라인 Phase 2 — JD 분석 코칭 연동 (company_activity 연결, AI 분석 endpoint, CoachPanel UI) | 2026-06-30 |
 | #228 | K8s Stage 3 학습 인덱스 — PostgreSQL StatefulSet + PV/PVC 예습 | 2026-06-29 |
 | #227 | 회사별 지원 파이프라인 Phase 1 — AppliedCompany CRUD + 지원 현황 UI | 2026-06-28 |
 | #226 | 데일리 기술면접 참고자료 — 국내 컨퍼런스 발표 카테고리 주입 | 2026-06-27 |

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -56,8 +56,8 @@ Spring Boot 4.x에서 Flyway auto-configuration 제거됨 (spring-boot-autoconfi
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | `docs/k8s-stage3-index` |
-| 열린 PR | #228 — K8s Stage 3 학습 인덱스 (머지 대기) |
+| 브랜치 | `feat/company-pipeline-phase2` |
+| 열린 PR | #228 — K8s Stage 3 학습 인덱스 (머지 대기) / 진행 중 — JD 분석 코칭 Phase 2 |
 
 ### K8s 학습 진행 상태
 

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/CompanyController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/CompanyController.kt
@@ -1,5 +1,6 @@
 package com.devquest.core.api.controller.v1
 
+import com.devquest.core.api.controller.v1.request.AnalyzeCompanyRequestDto
 import com.devquest.core.api.controller.v1.request.CreateCompanyRequestDto
 import com.devquest.core.api.controller.v1.request.UpdateCompanyStatusRequestDto
 import com.devquest.core.domain.CompanyService
@@ -23,7 +24,7 @@ class CompanyController(
         @AuthenticationPrincipal userId: String,
         @Valid @RequestBody request: CreateCompanyRequestDto,
     ): ApiResponse<*> {
-        val result = companyService.createCompany(userId, request.companyName, request.position, request.jdUrl)
+        val result = companyService.createCompany(userId, request.companyName, request.position, request.jdUrl, request.jobDescription)
         return ApiResponse.success(result)
     }
 
@@ -51,5 +52,15 @@ class CompanyController(
         @PathVariable id: Long,
     ) {
         companyService.deleteCompany(userId, id)
+    }
+
+    @PostMapping("/{id}/analyze")
+    fun analyzeCompany(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: AnalyzeCompanyRequestDto,
+    ): ApiResponse<*> {
+        val result = companyService.analyzeCompany(userId, id, request.userSkills, request.userExperiences)
+        return ApiResponse.success(result)
     }
 }

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/AnalyzeCompanyRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/AnalyzeCompanyRequestDto.kt
@@ -1,0 +1,8 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotEmpty
+
+data class AnalyzeCompanyRequestDto(
+    @field:NotEmpty val userSkills: List<String> = emptyList(),
+    @field:NotEmpty val userExperiences: List<String> = emptyList(),
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CompanyRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/CompanyRequestDto.kt
@@ -9,6 +9,7 @@ data class CreateCompanyRequestDto(
     @field:NotBlank val companyName: String = "",
     val position: String = "",
     val jdUrl: String? = null,
+    val jobDescription: String? = null,
 )
 
 data class UpdateCompanyStatusRequestDto(

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CompanyService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CompanyService.kt
@@ -1,18 +1,27 @@
 package com.devquest.core.domain
 
+import com.devquest.core.domain.model.ActivityType
 import com.devquest.core.domain.model.AppliedCompany
 import com.devquest.core.domain.model.ApplicationStatus
+import com.devquest.core.domain.model.CompanyActivity
+import com.devquest.core.domain.model.evaluation.JdAnalysisResult
+import com.devquest.core.domain.port.CompanyActivityPort
 import com.devquest.core.domain.port.CompanyPort
+import com.devquest.core.domain.port.JdAnalysisEvaluatorPort
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
 import java.time.LocalDateTime
 
 @Service
 class CompanyService(
     private val companyPort: CompanyPort,
+    private val jdAnalysisEvaluatorPort: JdAnalysisEvaluatorPort,
+    private val companyActivityPort: CompanyActivityPort,
+    private val objectMapper: ObjectMapper,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -22,12 +31,14 @@ class CompanyService(
         companyName: String,
         position: String,
         jdUrl: String?,
+        jobDescription: String? = null,
     ): AppliedCompany {
         val company = AppliedCompany(
             userId = userId,
             companyName = companyName,
             position = position,
             jdUrl = jdUrl,
+            jobDescription = jobDescription,
         )
         val saved = companyPort.save(company)
         log.info("회사 생성: userId=${userId}, companyName=${companyName}")
@@ -64,5 +75,30 @@ class CompanyService(
 
         companyPort.delete(companyId, userId)
         log.info("회사 삭제: userId=${userId}, companyId=${companyId}")
+    }
+
+    @Transactional
+    fun analyzeCompany(
+        userId: String,
+        companyId: Long,
+        userSkills: List<String>,
+        userExperiences: List<String>,
+    ): JdAnalysisResult {
+        val company = companyPort.findByIdAndUserId(companyId, userId)
+            ?: throw CoreException(ErrorType.COMPANY_NOT_FOUND)
+        val jd = company.jobDescription ?: throw CoreException(ErrorType.INVALID_REQUEST)
+        val result = jdAnalysisEvaluatorPort.analyze(company.companyName, jd, userSkills, userExperiences)
+        val json = objectMapper.writeValueAsString(result)
+        companyActivityPort.save(
+            CompanyActivity(
+                companyId = companyId,
+                userId = userId,
+                activityType = ActivityType.JD_ANALYSIS,
+                aiScore = result.overallMatchScore,
+                aiResultJson = json,
+            )
+        )
+        log.info("JD 분석 완료: userId=${userId}, companyId=${companyId}, score=${result.overallMatchScore}")
+        return result
     }
 }

--- a/be/core/core-api/src/main/resources/db/migration/V9__company_jd_analysis.sql
+++ b/be/core/core-api/src/main/resources/db/migration/V9__company_jd_analysis.sql
@@ -1,0 +1,2 @@
+ALTER TABLE applied_company
+    ADD COLUMN job_description TEXT;

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/CompanyControllerTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/CompanyControllerTest.kt
@@ -4,6 +4,7 @@ import com.devquest.core.api.controller.ApiControllerAdvice
 import com.devquest.core.domain.CompanyService
 import com.devquest.core.domain.model.AppliedCompany
 import com.devquest.core.domain.model.ApplicationStatus
+import com.devquest.core.domain.model.evaluation.JdAnalysisResult
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
 import org.junit.jupiter.api.AfterEach
@@ -53,7 +54,7 @@ class CompanyControllerTest {
 
     @Test
     fun `POST companies - 정상 요청이면 201과 SUCCESS 반환`() {
-        whenever(companyService.createCompany(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(companyService.createCompany(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
             AppliedCompany(id = 1L, userId = "user-1", companyName = "카카오", position = "백엔드")
         )
 
@@ -66,7 +67,7 @@ class CompanyControllerTest {
             jsonPath("$.data.companyName") { value("카카오") }
         }
 
-        verify(companyService).createCompany("user-1", "카카오", "백엔드", null)
+        verify(companyService).createCompany("user-1", "카카오", "백엔드", null, null)
     }
 
     @Test
@@ -160,5 +161,62 @@ class CompanyControllerTest {
                 status { isNotFound() }
                 jsonPath("$.result") { value("ERROR") }
             }
+    }
+
+    // ===== analyzeCompany 테스트 =====
+
+    @Test
+    fun `POST companies id analyze - 정상 요청이면 200과 분석 결과 반환`() {
+        whenever(companyService.analyzeCompany(any(), any(), any(), any()))
+            .thenReturn(JdAnalysisResult(companyName = "카카오", overallMatchScore = 85, passed = true))
+
+        mockMvc.post("/api/v1/companies/1/analyze") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userSkills":["Java","Spring"],"userExperiences":["3년 백엔드"]}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.result") { value("SUCCESS") }
+            jsonPath("$.data.companyName") { value("카카오") }
+            jsonPath("$.data.overallMatchScore") { value(85) }
+        }
+    }
+
+    @Test
+    fun `POST companies id analyze - JD 없는 회사면 400 반환`() {
+        whenever(companyService.analyzeCompany(any(), any(), any(), any()))
+            .thenThrow(CoreException(ErrorType.INVALID_REQUEST))
+
+        mockMvc.post("/api/v1/companies/1/analyze") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userSkills":["Java"],"userExperiences":["3년 백엔드"]}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.result") { value("ERROR") }
+        }
+    }
+
+    @Test
+    fun `POST companies id analyze - 없는 회사면 404 반환`() {
+        whenever(companyService.analyzeCompany(any(), any(), any(), any()))
+            .thenThrow(CoreException(ErrorType.COMPANY_NOT_FOUND))
+
+        mockMvc.post("/api/v1/companies/999/analyze") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userSkills":["Java"],"userExperiences":["3년 백엔드"]}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.result") { value("ERROR") }
+        }
+    }
+
+    @Test
+    fun `POST companies id analyze - userSkills 빈 배열이면 400 반환`() {
+        mockMvc.post("/api/v1/companies/1/analyze") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userSkills":[],"userExperiences":["3년 백엔드"]}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.result") { value("ERROR") }
+        }
     }
 }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CompanyServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CompanyServiceTest.kt
@@ -1,8 +1,13 @@
 package com.devquest.core.domain
 
+import com.devquest.core.domain.model.ActivityType
 import com.devquest.core.domain.model.AppliedCompany
 import com.devquest.core.domain.model.ApplicationStatus
+import com.devquest.core.domain.model.CompanyActivity
+import com.devquest.core.domain.model.evaluation.JdAnalysisResult
+import com.devquest.core.domain.port.CompanyActivityPort
 import com.devquest.core.domain.port.CompanyPort
+import com.devquest.core.domain.port.JdAnalysisEvaluatorPort
 import com.devquest.core.support.error.CoreException
 import com.devquest.core.support.error.ErrorType
 import org.assertj.core.api.Assertions.assertThat
@@ -16,6 +21,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import tools.jackson.databind.ObjectMapper
 import java.time.LocalDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -23,6 +29,15 @@ class CompanyServiceTest {
 
     @Mock
     private lateinit var companyPort: CompanyPort
+
+    @Mock
+    private lateinit var jdAnalysisEvaluatorPort: JdAnalysisEvaluatorPort
+
+    @Mock
+    private lateinit var companyActivityPort: CompanyActivityPort
+
+    @Mock
+    private lateinit var objectMapper: ObjectMapper
 
     @InjectMocks
     private lateinit var service: CompanyService
@@ -32,7 +47,7 @@ class CompanyServiceTest {
         val saved = company(id = 1L, companyName = "카카오", position = "백엔드")
         whenever(companyPort.save(any())).thenReturn(saved)
 
-        val result = service.createCompany("user-1", "카카오", "백엔드", null)
+        val result = service.createCompany("user-1", "카카오", "백엔드", null, null)
 
         assertThat(result.companyName).isEqualTo("카카오")
         assertThat(result.userId).isEqualTo("user-1")
@@ -106,9 +121,60 @@ class CompanyServiceTest {
         val saved = company(id = 1L, userId = "user-42")
         whenever(companyPort.save(any())).thenReturn(saved)
 
-        val result = service.createCompany("user-42", "삼성", "iOS", "https://job.samsung.com")
+        val result = service.createCompany("user-42", "삼성", "iOS", "https://job.samsung.com", null)
 
         assertThat(result.userId).isEqualTo("user-42")
+    }
+
+    // ===== analyzeCompany 테스트 =====
+
+    @Test
+    fun `analyzeCompany - 성공 시 JdAnalysisResult 반환하고 activityPort save가 호출된다`() {
+        val companyWithJd = company(id = 1L, companyName = "카카오", jobDescription = "Java 백엔드 개발자 모집")
+        val expected = JdAnalysisResult(companyName = "카카오", overallMatchScore = 80, passed = true)
+        val savedActivity = CompanyActivity(id = 1L, companyId = 1L, userId = "user-1")
+        whenever(companyPort.findByIdAndUserId(1L, "user-1")).thenReturn(companyWithJd)
+        whenever(jdAnalysisEvaluatorPort.analyze(any(), any(), any(), any())).thenReturn(expected)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("{}")
+        whenever(companyActivityPort.save(any())).thenReturn(savedActivity)
+
+        val result = service.analyzeCompany("user-1", 1L, listOf("Java"), listOf("3년 백엔드"))
+
+        assertThat(result.companyName).isEqualTo("카카오")
+        assertThat(result.overallMatchScore).isEqualTo(80)
+        verify(companyActivityPort).save(any())
+    }
+
+    @Test
+    fun `analyzeCompany - jobDescription이 null이면 INVALID_REQUEST 예외가 발생한다`() {
+        val companyWithoutJd = company(id = 1L, jobDescription = null)
+        whenever(companyPort.findByIdAndUserId(1L, "user-1")).thenReturn(companyWithoutJd)
+
+        assertThatThrownBy {
+            service.analyzeCompany("user-1", 1L, listOf("Java"), listOf("3년 백엔드"))
+        }
+            .isInstanceOf(CoreException::class.java)
+            .satisfies({ ex ->
+                assertThat((ex as CoreException).errorType).isEqualTo(ErrorType.INVALID_REQUEST)
+            })
+
+        verify(companyActivityPort, never()).save(any())
+    }
+
+    @Test
+    fun `analyzeCompany - 회사가 없으면 COMPANY_NOT_FOUND 예외가 발생한다`() {
+        whenever(companyPort.findByIdAndUserId(999L, "user-1")).thenReturn(null)
+
+        assertThatThrownBy {
+            service.analyzeCompany("user-1", 999L, listOf("Java"), listOf("3년 백엔드"))
+        }
+            .isInstanceOf(CoreException::class.java)
+            .satisfies({ ex ->
+                assertThat((ex as CoreException).errorType).isEqualTo(ErrorType.COMPANY_NOT_FOUND)
+            })
+
+        verify(jdAnalysisEvaluatorPort, never()).analyze(any(), any(), any(), any())
+        verify(companyActivityPort, never()).save(any())
     }
 
     private fun company(
@@ -117,11 +183,13 @@ class CompanyServiceTest {
         companyName: String = "카카오",
         position: String = "백엔드",
         status: ApplicationStatus = ApplicationStatus.INTERESTED,
+        jobDescription: String? = null,
     ) = AppliedCompany(
         id = id,
         userId = userId,
         companyName = companyName,
         position = position,
         status = status,
+        jobDescription = jobDescription,
     )
 }

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/AppliedCompany.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/AppliedCompany.kt
@@ -8,6 +8,7 @@ data class AppliedCompany(
     val companyName: String = "",
     val position: String = "",
     val jdUrl: String? = null,
+    val jobDescription: String? = null,
     val status: ApplicationStatus = ApplicationStatus.INTERESTED,
     val notes: String? = null,
     val appliedAt: LocalDateTime? = null,

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CompanyActivityPort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/CompanyActivityPort.kt
@@ -1,0 +1,9 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.ActivityType
+import com.devquest.core.domain.model.CompanyActivity
+
+interface CompanyActivityPort {
+    fun save(activity: CompanyActivity): CompanyActivity
+    fun findLatestByCompanyIdAndType(companyId: Long, type: ActivityType): CompanyActivity?
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/AppliedCompanyEntity.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/AppliedCompanyEntity.kt
@@ -19,6 +19,9 @@ class AppliedCompanyEntity(
     @Column(length = 2048)
     var jdUrl: String? = null,
 
+    @Column(columnDefinition = "TEXT")
+    var jobDescription: String? = null,
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     var status: ApplicationStatus = ApplicationStatus.INTERESTED,

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CompanyActivityRepository.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/CompanyActivityRepository.kt
@@ -1,0 +1,11 @@
+package com.devquest.storage.db.core
+
+import com.devquest.core.domain.model.ActivityType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CompanyActivityRepository : JpaRepository<CompanyActivityEntity, Long> {
+    fun findTopByCompanyIdAndActivityTypeOrderByCreatedAtDesc(
+        companyId: Long,
+        activityType: ActivityType,
+    ): CompanyActivityEntity?
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CompanyActivityAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CompanyActivityAdapter.kt
@@ -1,0 +1,44 @@
+package com.devquest.storage.db.core.adapter
+
+import com.devquest.core.domain.model.ActivityType
+import com.devquest.core.domain.model.CompanyActivity
+import com.devquest.core.domain.port.CompanyActivityPort
+import com.devquest.storage.db.core.CompanyActivityEntity
+import com.devquest.storage.db.core.CompanyActivityRepository
+import org.springframework.stereotype.Component
+
+@Component
+class CompanyActivityAdapter(
+    private val repository: CompanyActivityRepository
+) : CompanyActivityPort {
+
+    override fun save(activity: CompanyActivity): CompanyActivity {
+        return repository.save(activity.toEntity()).toDomain()
+    }
+
+    override fun findLatestByCompanyIdAndType(companyId: Long, type: ActivityType): CompanyActivity? {
+        return repository.findTopByCompanyIdAndActivityTypeOrderByCreatedAtDesc(companyId, type)?.toDomain()
+    }
+
+    private fun CompanyActivityEntity.toDomain(): CompanyActivity {
+        return CompanyActivity(
+            id = this.id,
+            companyId = this.companyId,
+            userId = this.userId,
+            activityType = this.activityType,
+            aiScore = this.aiScore,
+            aiResultJson = this.aiResultJson,
+            createdAt = this.createdAt,
+        )
+    }
+
+    private fun CompanyActivity.toEntity(): CompanyActivityEntity {
+        return CompanyActivityEntity(
+            companyId = this.companyId,
+            userId = this.userId,
+            activityType = this.activityType,
+            aiScore = this.aiScore,
+            aiResultJson = this.aiResultJson,
+        )
+    }
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CompanyAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/CompanyAdapter.kt
@@ -16,6 +16,7 @@ class CompanyAdapter(
             repository.findById(company.id).orElse(null)?.apply {
                 position = company.position
                 jdUrl = company.jdUrl
+                jobDescription = company.jobDescription
                 status = company.status
                 notes = company.notes
                 appliedAt = company.appliedAt
@@ -45,6 +46,7 @@ class CompanyAdapter(
             companyName = this.companyName,
             position = this.position,
             jdUrl = this.jdUrl,
+            jobDescription = this.jobDescription,
             status = this.status,
             notes = this.notes,
             appliedAt = this.appliedAt,
@@ -58,6 +60,7 @@ class CompanyAdapter(
             companyName = company.companyName,
             position = company.position,
             jdUrl = company.jdUrl,
+            jobDescription = company.jobDescription,
             status = company.status,
             notes = company.notes,
             appliedAt = company.appliedAt,

--- a/be/storage/db-core/src/test/kotlin/com/devquest/storage/db/core/adapter/CompanyActivityAdapterTest.kt
+++ b/be/storage/db-core/src/test/kotlin/com/devquest/storage/db/core/adapter/CompanyActivityAdapterTest.kt
@@ -1,0 +1,81 @@
+package com.devquest.storage.db.core.adapter
+
+import com.devquest.core.domain.model.ActivityType
+import com.devquest.core.domain.model.CompanyActivity
+import com.devquest.storage.db.core.CompanyActivityEntity
+import com.devquest.storage.db.core.CompanyActivityRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class CompanyActivityAdapterTest {
+
+    @Mock
+    private lateinit var repository: CompanyActivityRepository
+
+    @InjectMocks
+    private lateinit var adapter: CompanyActivityAdapter
+
+    @Test
+    fun `save - 활동을 저장하고 도메인으로 반환한다`() {
+        val activity = CompanyActivity(
+            companyId = 1L,
+            userId = "user-1",
+            activityType = ActivityType.JD_ANALYSIS,
+            aiScore = 80,
+            aiResultJson = "{}",
+        )
+        val savedEntity = CompanyActivityEntity(
+            companyId = 1L,
+            userId = "user-1",
+            activityType = ActivityType.JD_ANALYSIS,
+            aiScore = 80,
+            aiResultJson = "{}",
+        )
+        whenever(repository.save(any())).thenReturn(savedEntity)
+
+        val result = adapter.save(activity)
+
+        assertThat(result.companyId).isEqualTo(1L)
+        assertThat(result.userId).isEqualTo("user-1")
+        assertThat(result.activityType).isEqualTo(ActivityType.JD_ANALYSIS)
+        assertThat(result.aiScore).isEqualTo(80)
+    }
+
+    @Test
+    fun `findLatestByCompanyIdAndType - 존재하면 도메인으로 반환한다`() {
+        val entity = CompanyActivityEntity(
+            companyId = 1L,
+            userId = "user-1",
+            activityType = ActivityType.JD_ANALYSIS,
+            aiScore = 75,
+            aiResultJson = """{"companyName":"카카오"}""",
+        )
+        whenever(
+            repository.findTopByCompanyIdAndActivityTypeOrderByCreatedAtDesc(1L, ActivityType.JD_ANALYSIS)
+        ).thenReturn(entity)
+
+        val result = adapter.findLatestByCompanyIdAndType(1L, ActivityType.JD_ANALYSIS)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.companyId).isEqualTo(1L)
+        assertThat(result.aiScore).isEqualTo(75)
+    }
+
+    @Test
+    fun `findLatestByCompanyIdAndType - 존재하지 않으면 null을 반환한다`() {
+        whenever(
+            repository.findTopByCompanyIdAndActivityTypeOrderByCreatedAtDesc(999L, ActivityType.JD_ANALYSIS)
+        ).thenReturn(null)
+
+        val result = adapter.findLatestByCompanyIdAndType(999L, ActivityType.JD_ANALYSIS)
+
+        assertThat(result).isNull()
+    }
+}

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -16,7 +16,7 @@ import { LoginPage } from '@/features/auth/components/LoginPage'
 import { AuthCallback } from '@/features/auth/components/AuthCallback'
 import { useCharacter } from '@/hooks/useCharacter'
 import { fetchProgress, completeQuest, fetchActClearReport } from '@/lib/apiClient'
-import { getCompanies, createCompany, updateCompanyStatus, deleteCompany } from '@/features/company-pipeline'
+import { getCompanies, createCompany, updateCompanyStatus, deleteCompany, analyzeCompany } from '@/features/company-pipeline'
 import { STORAGE_KEYS } from '@/lib/storageKeys'
 import { ACTS } from '@/features/quest-map/constants/questData'
 
@@ -229,9 +229,13 @@ export function App() {
     setView({ kind: 'map' })
   }
 
-  const handleAddCompany = async (data: { companyName: string; position: string; jdUrl?: string }) => {
+  const handleAddCompany = async (data: { companyName: string; position: string; jdUrl?: string; jobDescription?: string }) => {
     const added = await createCompany(data)
     setCompanies((prev) => [added, ...prev])
+  }
+
+  const handleAnalyzeCompany = async (id: number, skills: string[], experiences: string[]) => {
+    return analyzeCompany(id, { userSkills: skills, userExperiences: experiences })
   }
 
   const handleCompanyStatusChange = async (id: number, status: ApplicationStatus) => {
@@ -440,6 +444,7 @@ export function App() {
             onAddCompany={handleAddCompany}
             onCompanyStatusChange={handleCompanyStatusChange}
             onDeleteCompany={handleDeleteCompany}
+            onAnalyzeCompany={handleAnalyzeCompany}
           />
           <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
             <button

--- a/fe/src/features/company-pipeline/api/companyApi.ts
+++ b/fe/src/features/company-pipeline/api/companyApi.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, AppliedCompany, ApplicationStatus } from '@/types/api.types'
+import type { ApiResponse, AppliedCompany, ApplicationStatus, JdAnalysisResult } from '@/types/api.types'
 import { getToken } from '@/hooks/useAuth'
 
 const API_BASE = '/api/v1'
@@ -19,6 +19,7 @@ export async function createCompany(body: {
   companyName: string
   position: string
   jdUrl?: string
+  jobDescription?: string
 }): Promise<AppliedCompany> {
   const res = await fetch(`${API_BASE}/companies`, {
     method: 'POST',
@@ -61,4 +62,19 @@ export async function deleteCompany(id: number): Promise<void> {
     headers: authHeaders(),
   })
   assertOk(res)
+}
+
+export async function analyzeCompany(
+  id: number,
+  body: { userSkills: string[]; userExperiences: string[] },
+): Promise<JdAnalysisResult> {
+  const res = await fetch(`${API_BASE}/companies/${id}/analyze`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  })
+  assertOk(res)
+  const json: ApiResponse<JdAnalysisResult> = await res.json()
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('JD 분석 실패')
+  return json.data
 }

--- a/fe/src/features/company-pipeline/components/AddCompanyModal.tsx
+++ b/fe/src/features/company-pipeline/components/AddCompanyModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 interface AddCompanyModalProps {
-  onAdd: (data: { companyName: string; position: string; jdUrl?: string }) => Promise<void>
+  onAdd: (data: { companyName: string; position: string; jdUrl?: string; jobDescription?: string }) => Promise<void>
   onClose: () => void
 }
 
@@ -9,6 +9,7 @@ export function AddCompanyModal({ onAdd, onClose }: AddCompanyModalProps) {
   const [companyName, setCompanyName] = useState('')
   const [position, setPosition] = useState('')
   const [jdUrl, setJdUrl] = useState('')
+  const [jobDescription, setJobDescription] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -25,6 +26,7 @@ export function AddCompanyModal({ onAdd, onClose }: AddCompanyModalProps) {
         companyName: companyName.trim(),
         position: position.trim(),
         ...(jdUrl.trim() ? { jdUrl: jdUrl.trim() } : {}),
+        ...(jobDescription.trim() ? { jobDescription: jobDescription.trim() } : {}),
       })
       onClose()
     } catch {
@@ -115,6 +117,20 @@ export function AddCompanyModal({ onAdd, onClose }: AddCompanyModalProps) {
               onChange={(e) => setJdUrl(e.target.value)}
               placeholder="https://..."
               style={inputStyle}
+            />
+          </div>
+
+          <div>
+            <label style={labelStyle}>JD 내용 (선택 — AI 분석용)</label>
+            <textarea
+              value={jobDescription}
+              onChange={(e) => setJobDescription(e.target.value)}
+              placeholder="채용공고 본문을 붙여넣으세요"
+              style={{
+                ...inputStyle,
+                height: 120,
+                resize: 'vertical',
+              }}
             />
           </div>
 

--- a/fe/src/features/company-pipeline/components/CompanyCard.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyCard.tsx
@@ -1,4 +1,5 @@
-import type { AppliedCompany, ApplicationStatus } from '@/types/api.types'
+import { useState } from 'react'
+import type { AppliedCompany, ApplicationStatus, JdAnalysisResult } from '@/types/api.types'
 
 const STATUS_LABELS: Record<ApplicationStatus, string> = {
   INTERESTED: '관심',
@@ -44,14 +45,224 @@ function getStatusStyle(status: ApplicationStatus): { color: string; background:
   }
 }
 
+function getScoreStyle(score: number): { color: string; background: string; border: string } {
+  if (score >= 70) return { color: '#10B981', background: 'rgba(16,185,129,0.12)', border: '1px solid rgba(16,185,129,0.3)' }
+  if (score >= 50) return { color: '#F59E0B', background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)' }
+  return { color: '#EF4444', background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)' }
+}
+
+interface JdAnalysisCoachPanelProps {
+  result: JdAnalysisResult
+}
+
+function JdAnalysisCoachPanel({ result }: JdAnalysisCoachPanelProps) {
+  const [showHidden, setShowHidden] = useState(false)
+  const scoreStyle = getScoreStyle(result.overallMatchScore)
+
+  return (
+    <div
+      style={{
+        marginTop: 10,
+        background: 'rgba(167,139,250,0.04)',
+        border: '1px solid rgba(167,139,250,0.2)',
+        borderRadius: 8,
+        padding: '12px 14px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        fontFamily: "'Courier New', monospace",
+      }}
+    >
+      {/* 점수 + 합격 뱃지 */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            padding: '3px 10px',
+            borderRadius: 4,
+            ...scoreStyle,
+          }}
+        >
+          매칭 {result.overallMatchScore}점
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            padding: '3px 10px',
+            borderRadius: 4,
+            ...(result.passed
+              ? { color: '#10B981', background: 'rgba(16,185,129,0.1)', border: '1px solid rgba(16,185,129,0.25)' }
+              : { color: '#F59E0B', background: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.25)' }),
+          }}
+        >
+          {result.passed ? '합격 가능성 ✓' : 'Gap 있음'}
+        </span>
+      </div>
+
+      {/* 전략 */}
+      {result.applicationStrategy && (
+        <div>
+          <p style={{ fontSize: 10, letterSpacing: 2, color: '#A78BFA', margin: '0 0 4px' }}>전략</p>
+          <p style={{ fontSize: 12, color: '#F1F5F9', margin: 0, lineHeight: 1.6 }}>
+            {result.applicationStrategy}
+          </p>
+        </div>
+      )}
+
+      {/* 핵심 차별화 포인트 */}
+      {result.keyDifferentiators.length > 0 && (
+        <div>
+          <p style={{ fontSize: 10, letterSpacing: 2, color: '#A78BFA', margin: '0 0 4px' }}>핵심 차별화</p>
+          <ul style={{ margin: 0, paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {result.keyDifferentiators.slice(0, 3).map((item, i) => (
+              <li key={i} style={{ fontSize: 12, color: '#F1F5F9' }}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* 스킬 요구사항 */}
+      {result.requiredSkills.length > 0 && (
+        <div>
+          <p style={{ fontSize: 10, letterSpacing: 2, color: '#A78BFA', margin: '0 0 6px' }}>스킬 분석</p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {result.requiredSkills.map((s, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  background: '#0F172A',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                  borderRadius: 6,
+                  padding: '6px 10px',
+                }}
+              >
+                <span style={{ fontSize: 12, color: '#F1F5F9', flex: 1, minWidth: 0, wordBreak: 'break-word' }}>
+                  {s.skill}
+                </span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+                  {s.required && s.userLevel === '' && (
+                    <span
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 700,
+                        padding: '2px 6px',
+                        borderRadius: 3,
+                        color: '#EF4444',
+                        background: 'rgba(239,68,68,0.12)',
+                        border: '1px solid rgba(239,68,68,0.3)',
+                      }}
+                    >
+                      Gap
+                    </span>
+                  )}
+                  {s.importance && (
+                    <span style={{ fontSize: 10, color: '#475569' }}>{s.importance}</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 숨겨진 요구사항 (접을 수 있음) */}
+      {result.hiddenRequirements.length > 0 && (
+        <div>
+          <button
+            onClick={() => setShowHidden((v) => !v)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+              fontFamily: "'Courier New', monospace",
+              fontSize: 10,
+              letterSpacing: 2,
+              color: '#A78BFA',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            숨겨진 요구사항 {showHidden ? '▲' : '▼'}
+          </button>
+          {showHidden && (
+            <ul style={{ margin: '6px 0 0', paddingLeft: 16, display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {result.hiddenRequirements.map((item, i) => (
+                <li key={i} style={{ fontSize: 12, color: '#475569' }}>{item}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface CompanyCardProps {
   company: AppliedCompany
   onStatusChange: (id: number, status: ApplicationStatus) => void
   onDelete: (id: number) => void
+  analysisResult?: JdAnalysisResult
+  onAnalyze: (id: number, skills: string[], experiences: string[]) => Promise<JdAnalysisResult>
 }
 
-export function CompanyCard({ company, onStatusChange, onDelete }: CompanyCardProps) {
+export function CompanyCard({ company, onStatusChange, onDelete, analysisResult, onAnalyze }: CompanyCardProps) {
   const statusStyle = getStatusStyle(company.status)
+  const [showAnalysisForm, setShowAnalysisForm] = useState(false)
+  const [showResultPanel, setShowResultPanel] = useState(false)
+  const [skillsInput, setSkillsInput] = useState('')
+  const [experiencesInput, setExperiencesInput] = useState('')
+  const [analyzing, setAnalyzing] = useState(false)
+  const [analysisError, setAnalysisError] = useState<string | null>(null)
+
+  const handleAnalysisButtonClick = () => {
+    if (analysisResult) {
+      setShowResultPanel((v) => !v)
+    } else {
+      setShowAnalysisForm((v) => !v)
+    }
+  }
+
+  const handleAnalysisSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const skills = skillsInput.split(',').map((s) => s.trim()).filter(Boolean)
+    const experiences = experiencesInput.split('\n').map((s) => s.trim()).filter(Boolean)
+    if (skills.length === 0 || experiences.length === 0) {
+      setAnalysisError('스킬과 경험을 모두 입력해주세요.')
+      return
+    }
+    setAnalyzing(true)
+    setAnalysisError(null)
+    try {
+      await onAnalyze(company.id, skills, experiences)
+      setShowAnalysisForm(false)
+      setShowResultPanel(true)
+    } catch {
+      setAnalysisError('분석에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setAnalyzing(false)
+    }
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    background: '#0A0E1A',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: 6,
+    color: '#F1F5F9',
+    fontSize: 12,
+    padding: '8px 10px',
+    fontFamily: "'Courier New', monospace",
+    boxSizing: 'border-box',
+    outline: 'none',
+  }
 
   return (
     <div
@@ -129,6 +340,29 @@ export function CompanyCard({ company, onStatusChange, onDelete }: CompanyCardPr
             <option key={s} value={s}>{STATUS_LABELS[s]}</option>
           ))}
         </select>
+
+        {company.jobDescription && (
+          <button
+            onClick={handleAnalysisButtonClick}
+            style={{
+              background: analysisResult
+                ? 'rgba(167,139,250,0.15)'
+                : 'rgba(167,139,250,0.1)',
+              border: '1px solid rgba(167,139,250,0.3)',
+              borderRadius: 6,
+              color: '#A78BFA',
+              fontSize: 12,
+              padding: '6px 10px',
+              cursor: 'pointer',
+              fontFamily: "'Courier New', monospace",
+              flexShrink: 0,
+              fontWeight: analysisResult ? 600 : 400,
+            }}
+          >
+            {analysisResult ? 'AI 결과' : 'AI 분석'}
+          </button>
+        )}
+
         <button
           onClick={() => onDelete(company.id)}
           style={{
@@ -146,6 +380,92 @@ export function CompanyCard({ company, onStatusChange, onDelete }: CompanyCardPr
           삭제
         </button>
       </div>
+
+      {/* 분석 입력 폼 */}
+      {showAnalysisForm && !analysisResult && (
+        <form
+          onSubmit={handleAnalysisSubmit}
+          style={{
+            background: 'rgba(167,139,250,0.04)',
+            border: '1px solid rgba(167,139,250,0.15)',
+            borderRadius: 8,
+            padding: '12px 14px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <p style={{ fontSize: 10, letterSpacing: 2, color: '#A78BFA', margin: 0 }}>JD AI 분석</p>
+          <div>
+            <label style={{ fontSize: 10, color: '#475569', display: 'block', marginBottom: 4 }}>
+              보유 스킬 (쉼표 구분)
+            </label>
+            <input
+              type="text"
+              value={skillsInput}
+              onChange={(e) => setSkillsInput(e.target.value)}
+              placeholder="Kotlin, Spring Boot, JPA"
+              style={inputStyle}
+            />
+          </div>
+          <div>
+            <label style={{ fontSize: 10, color: '#475569', display: 'block', marginBottom: 4 }}>
+              주요 경험 (줄바꿈 구분)
+            </label>
+            <textarea
+              value={experiencesInput}
+              onChange={(e) => setExperiencesInput(e.target.value)}
+              placeholder={'3년 백엔드 개발\nMSA 아키텍처 경험'}
+              style={{ ...inputStyle, height: 80, resize: 'vertical' }}
+            />
+          </div>
+          {analysisError && (
+            <p style={{ fontSize: 11, color: '#EF4444', margin: 0 }}>{analysisError}</p>
+          )}
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => setShowAnalysisForm(false)}
+              style={{
+                flex: 1,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 6,
+                color: '#475569',
+                fontSize: 12,
+                padding: '7px',
+                cursor: 'pointer',
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={analyzing}
+              style={{
+                flex: 2,
+                background: analyzing ? 'rgba(167,139,250,0.05)' : 'rgba(167,139,250,0.15)',
+                border: '1px solid rgba(167,139,250,0.3)',
+                borderRadius: 6,
+                color: '#A78BFA',
+                fontSize: 12,
+                padding: '7px',
+                cursor: analyzing ? 'not-allowed' : 'pointer',
+                fontFamily: "'Courier New', monospace",
+                fontWeight: 600,
+              }}
+            >
+              {analyzing ? '분석 중...' : '분석 시작'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* 분석 결과 패널 */}
+      {showResultPanel && analysisResult && (
+        <JdAnalysisCoachPanel result={analysisResult} />
+      )}
     </div>
   )
 }

--- a/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
-import type { AppliedCompany, ApplicationStatus } from '@/types/api.types'
+import type { AppliedCompany, ApplicationStatus, JdAnalysisResult } from '@/types/api.types'
 import { CompanyCard } from './CompanyCard'
 import { AddCompanyModal } from './AddCompanyModal'
 
 interface CompanyPipelinePanelProps {
   companies: AppliedCompany[]
-  onAdd: (data: { companyName: string; position: string; jdUrl?: string }) => Promise<void>
+  onAdd: (data: { companyName: string; position: string; jdUrl?: string; jobDescription?: string }) => Promise<void>
   onStatusChange: (id: number, status: ApplicationStatus) => Promise<void>
   onDelete: (id: number) => Promise<void>
+  onAnalyzeCompany: (id: number, skills: string[], experiences: string[]) => Promise<JdAnalysisResult>
 }
 
 export function CompanyPipelinePanel({
@@ -15,8 +16,16 @@ export function CompanyPipelinePanel({
   onAdd,
   onStatusChange,
   onDelete,
+  onAnalyzeCompany,
 }: CompanyPipelinePanelProps) {
   const [showModal, setShowModal] = useState(false)
+  const [analysisResults, setAnalysisResults] = useState<Record<number, JdAnalysisResult>>({})
+
+  const handleAnalyze = async (id: number, skills: string[], experiences: string[]): Promise<JdAnalysisResult> => {
+    const result = await onAnalyzeCompany(id, skills, experiences)
+    setAnalysisResults((prev) => ({ ...prev, [id]: result }))
+    return result
+  }
 
   return (
     <div
@@ -76,6 +85,8 @@ export function CompanyPipelinePanel({
               company={company}
               onStatusChange={(id, status) => { onStatusChange(id, status).catch(() => {}) }}
               onDelete={(id) => { onDelete(id).catch(() => {}) }}
+              analysisResult={analysisResults[company.id]}
+              onAnalyze={handleAnalyze}
             />
           ))}
         </div>

--- a/fe/src/features/company-pipeline/index.ts
+++ b/fe/src/features/company-pipeline/index.ts
@@ -1,4 +1,4 @@
 export { CompanyPipelinePanel } from './components/CompanyPipelinePanel'
 export { CompanyCard } from './components/CompanyCard'
 export { AddCompanyModal } from './components/AddCompanyModal'
-export { createCompany, getCompanies, updateCompanyStatus, deleteCompany } from './api/companyApi'
+export { createCompany, getCompanies, updateCompanyStatus, deleteCompany, analyzeCompany } from './api/companyApi'

--- a/fe/src/features/quest-map/components/QuestMap.tsx
+++ b/fe/src/features/quest-map/components/QuestMap.tsx
@@ -1,6 +1,6 @@
 import type { Act, Quest } from '@/types/quest.types'
 import type { Character } from '@/types/character.types'
-import type { AppliedCompany, ApplicationStatus } from '@/types/api.types'
+import type { AppliedCompany, ApplicationStatus, JdAnalysisResult } from '@/types/api.types'
 import { ACTS, ACT_UNLOCK_THRESHOLD } from '../constants/questData'
 import { ActCard } from './ActCard'
 import { StatsPanel } from './StatsPanel'
@@ -17,12 +17,13 @@ interface QuestMapProps {
   character: Character
   lastCompletedAt?: string | null
   companies: AppliedCompany[]
-  onAddCompany: (data: { companyName: string; position: string; jdUrl?: string }) => Promise<void>
+  onAddCompany: (data: { companyName: string; position: string; jdUrl?: string; jobDescription?: string }) => Promise<void>
   onCompanyStatusChange: (id: number, status: ApplicationStatus) => Promise<void>
   onDeleteCompany: (id: number) => Promise<void>
+  onAnalyzeCompany: (id: number, skills: string[], experiences: string[]) => Promise<JdAnalysisResult>
 }
 
-export function QuestMap({ onSelectAct, onSelectQuest, onOpenCoach, completed, getActProgress, character, lastCompletedAt, companies, onAddCompany, onCompanyStatusChange, onDeleteCompany }: QuestMapProps) {
+export function QuestMap({ onSelectAct, onSelectQuest, onOpenCoach, completed, getActProgress, character, lastCompletedAt, companies, onAddCompany, onCompanyStatusChange, onDeleteCompany, onAnalyzeCompany }: QuestMapProps) {
   const completedCount = Object.keys(completed).length
 
   return (
@@ -100,6 +101,7 @@ export function QuestMap({ onSelectAct, onSelectQuest, onOpenCoach, completed, g
         onAdd={onAddCompany}
         onStatusChange={onCompanyStatusChange}
         onDelete={onDeleteCompany}
+        onAnalyzeCompany={onAnalyzeCompany}
       />
     </div>
   )

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -238,6 +238,7 @@ export interface AppliedCompany {
   companyName: string
   position: string
   jdUrl?: string
+  jobDescription?: string
   status: ApplicationStatus
   notes?: string
   appliedAt?: string


### PR DESCRIPTION
## 개요

Phase 1(#227)에서 구현한 회사별 지원 현황 CRUD에 AI 코칭 기능을 연결한다.
채용공고(JD) 전문 텍스트를 입력하면 `JdAnalysisEvaluator`가 분석하고, 결과를 `company_activity` 테이블에 저장하며 카드 UI에 코칭 패널을 표시한다.

## 변경 사항

### DB
- `V9__company_jd_analysis.sql`: `applied_company.job_description TEXT` 컬럼 추가

### BE
- `CompanyActivityPort` / `CompanyActivityRepository` / `CompanyActivityAdapter` 신규 — V8에서 방치된 `company_activity` 테이블 연결
- `POST /api/v1/companies/{id}/analyze` 신규 엔드포인트
  - Request: `{userSkills, userExperiences}`
  - Response: `JdAnalysisResult` (점수·스킬갭·전략 포함)
  - 기존 `/ai-check/jd-analysis` 재사용 안 함 — `questProgressRecorder` 사이드이펙트 방지
- `POST /api/v1/companies` Request에 `jobDescription?` 추가

### FE
- `AddCompanyModal`: JD 내용 textarea 추가 (선택, AI 분석용)
- `CompanyCard`: "AI 분석" 버튼 + 인라인 스킬/경험 입력 폼 + `JdAnalysisCoachPanel`
  - `jobDescription` 있는 회사에만 버튼 노출
  - 결과 없음 → 폼 표시, 결과 있음 → 패널 토글
  - 점수 배지(녹/황/적), 전략, 스킬갭, 차별점 표시
- Props drilling: `App.tsx → QuestMap → CompanyPipelinePanel → CompanyCard`

## tech-debt (이번 PR에서 미수정)
- `CompanyService.analyzeCompany()` — `@Transactional` 범위에 AI 외부 호출 포함. 현재 트래픽 규모 무해하나 향후 커넥션 풀 소진 가능성
- `ErrorType.INVALID_REQUEST`가 "JD 없음"과 "요청 파라미터 오류" 두 케이스 공용 → 향후 `JD_NOT_FOUND` 분리 고려

## 테스트
- `CompanyServiceTest`: 3케이스 신규 (성공·JD null·회사 없음)
- `CompanyControllerTest`: 4케이스 신규 (200·400·404·validation)
- `CompanyActivityAdapterTest`: 3케이스 신규 (save·findLatest·null)
- FE: `tsc --noEmit` + `npm run build` 통과