### PR TITLE
refactor(be): client-ai Jackson 2/3 혼재 정리 — tools.jackson 통일

### DIFF
--- a/be/clients/client-ai/build.gradle.kts
+++ b/be/clients/client-ai/build.gradle.kts
@@ -7,6 +7,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-jackson")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // tools.jackson 코어(jackson-databind 등)는 Spring Boot 4 관리 의존성(jackson-bom 3.x)으로 클래스패스에 이미 존재
+    // (core-api가 tools.jackson.databind.ObjectMapper 사용 중). 여기서는 Kotlin 모듈만 추가하면 됨.
+    // 버전은 BOM이 관리하므로 명시하지 않음.
     implementation("tools.jackson.module:jackson-module-kotlin")
 
     // RC2에서 anthropic-java-client-okhttp가 transitive에서 제거됨 — 통합 테스트에서 직접 사용

--- a/be/clients/client-ai/build.gradle.kts
+++ b/be/clients/client-ai/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-jackson")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("tools.jackson.module:jackson-module-kotlin")
 
     // RC2에서 anthropic-java-client-okhttp가 transitive에서 제거됨 — 통합 테스트에서 직접 사용
     testImplementation("com.anthropic:anthropic-java-client-okhttp:2.35.0")

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/CompanyFitEvaluator.kt
@@ -7,8 +7,8 @@ import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.CompanyFitResult
 import com.devquest.core.domain.port.CompanyFitEvaluatorPort
 import com.devquest.core.domain.port.CompanyInfo
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.prompt.PromptTemplate

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/evaluator/MockInterviewEvaluator.kt
@@ -6,8 +6,8 @@ import com.devquest.client.ai.support.BaseAiEvaluator.Companion.AiModel
 import com.devquest.core.domain.support.AiEvaluationException
 import com.devquest.core.domain.model.evaluation.InterviewEvaluationResult
 import com.devquest.core.domain.port.InterviewEvaluatorPort
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.prompt.PromptTemplate

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/BaseAiEvaluator.kt
@@ -1,6 +1,6 @@
 package com.devquest.client.ai.support
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.ai.chat.client.ChatClient
 
 abstract class BaseAiEvaluator(

--- a/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/ConferenceReferenceLoader.kt
+++ b/be/clients/client-ai/src/main/kotlin/com/devquest/client/ai/support/ConferenceReferenceLoader.kt
@@ -1,8 +1,8 @@
 package com.devquest.client.ai.support
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.ClassPathResource
 import org.springframework.stereotype.Component


### PR DESCRIPTION
## 요약

client-ai 모듈의 Jackson 2(com.fasterxml) / Jackson 3(tools.jackson) 혼재를 tools.jackson으로 통일. 동작 변경 없음.

## 변경

- `tools.jackson.module:jackson-module-kotlin` 의존성 추가 — 코어(jackson-databind 등)는 Spring Boot 4 관리 의존성(jackson-bom 3.x)으로 이미 클래스패스에 존재 (core-api가 tools.jackson.databind.ObjectMapper 사용 중), 버전은 BOM 관리
- 4개 파일 import 교체: BaseAiEvaluator, ConferenceReferenceLoader, CompanyFitEvaluator, MockInterviewEvaluator
- `@JsonIgnoreProperties`는 미변경 — Jackson 3 databind도 com.fasterxml annotations(공용 모듈)에 의존
- root 전역 Jackson 2 kotlin 모듈 의존성은 유지 (다른 모듈 + victools transitive 필요, Spring Boot 4 공식 병행 패턴)

## QA 결과

- HIGH/MEDIUM 없음
- 핵심 검증: Jackson 3 `FAIL_ON_UNKNOWN_PROPERTIES` 기본값 false(2는 true) — AI JSON 파싱이 관대해지는 방향, 회귀 없음 (바이트코드 확인)
- 17개 Evaluator 전수 커버 확인 (직접 mapper 보유 2곳 마이그레이션 + 15곳 BaseAiEvaluator 경유)
- ConferenceReferenceLoaderTest가 실제 JSON을 mocking 없이 로드 통과 — 런타임 클래스패스에 Jackson 3 코어 존재 실증

## 검증

- `./gradlew :clients:client-ai:build` BUILD SUCCESSFUL
- `./gradlew test` 전체 모듈 0 failures