### PR TITLE
feat: 이력서 프로필 — 1회 등록·재사용 기반 (지원 파이프라인 Phase 3a)

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,8 +7,8 @@
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | (없음 — main 최신) |
-| 열린 PR | 없음 |
+| 브랜치 | feat/resume-profile |
+| 열린 PR | #248 — 이력서 프로필 Phase 3a (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
@@ -21,6 +21,12 @@
 ## 다음 작업
 
 ### 코드 작업
+- [ ] **지원 파이프라인 Phase 3b — 회사 카드 원클릭 이력서 점검** (#248 머지 후):
+      `POST /api/v1/companies/{id}/resume-check` — 저장된 JD + 저장된 이력서 → ResumeCheckEvaluator
+      재사용, 결과 company_activity 저장. FE 회사 카드 버튼 + 이력 표시.
+      + analyzeCompany의 userSkills/userExperiences 수동 입력도 이력서 자동 추출로 대체
+- [ ] Phase 3a MEDIUM 보류: UserResumeAdapter upsert read-then-write 경합 — 다중 기기 동시
+      사용 필요해지면 DB ON CONFLICT 전환
 - [ ] **OOM 후속 관찰** (#245 swap 배포 후): ① 업타임 4~5일째 `fly_instance_memory_swap_free`
       감소 추이 ② exit 137 재발 여부 ③ 스왑 사용 중 응답 지연 체감
 - [ ] **JVM 메모리 다이어트 PR** (스왑 관찰 후 진행): 힙 상한 50%→35% + `ReservedCodeCacheSize=96m`

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ResumeController.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/ResumeController.kt
@@ -1,0 +1,37 @@
+package com.devquest.core.api.controller.v1
+
+import com.devquest.core.api.controller.v1.request.ResumeRequestDto
+import com.devquest.core.domain.ResumeService
+import com.devquest.core.support.response.ApiResponse
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/resume")
+class ResumeController(
+    private val resumeService: ResumeService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping
+    fun getResume(
+        @AuthenticationPrincipal userId: String,
+    ): ApiResponse<*> {
+        return ApiResponse.success(resumeService.getResume(userId))
+    }
+
+    @PutMapping
+    fun saveResume(
+        @AuthenticationPrincipal userId: String,
+        @Valid @RequestBody request: ResumeRequestDto,
+    ): ApiResponse<*> {
+        val result = resumeService.saveResume(userId, request.content)
+        return ApiResponse.success(result)
+    }
+}

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ResumeRequestDto.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/api/controller/v1/request/ResumeRequestDto.kt
@@ -1,0 +1,10 @@
+package com.devquest.core.api.controller.v1.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class ResumeRequestDto(
+    @field:NotBlank
+    @field:Size(max = 50_000)
+    val content: String = "",
+)

--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ResumeService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/ResumeService.kt
@@ -1,0 +1,26 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.model.UserResume
+import com.devquest.core.domain.port.UserResumePort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ResumeService(
+    private val userResumePort: UserResumePort
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun getResume(userId: String): UserResume? {
+        return userResumePort.findByUserId(userId)
+    }
+
+    @Transactional
+    fun saveResume(userId: String, content: String): UserResume {
+        val resume = UserResume(userId = userId, content = content)
+        val saved = userResumePort.save(resume)
+        log.info("이력서 저장: userId=${userId}")
+        return saved
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ResumeControllerTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/api/controller/v1/ResumeControllerTest.kt
@@ -1,0 +1,102 @@
+package com.devquest.core.api.controller.v1
+
+import com.devquest.core.api.controller.ApiControllerAdvice
+import com.devquest.core.domain.ResumeService
+import com.devquest.core.domain.model.UserResume
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.put
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ExtendWith(MockitoExtension::class)
+class ResumeControllerTest {
+
+    @Mock
+    private lateinit var resumeService: ResumeService
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("user-1", null, emptyList())
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(ResumeController(resumeService))
+            .setControllerAdvice(ApiControllerAdvice())
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
+            .build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `GET resume - 등록된 이력서가 있으면 200과 데이터 반환`() {
+        whenever(resumeService.getResume("user-1")).thenReturn(
+            UserResume(id = 1L, userId = "user-1", content = "5년차 백엔드 개발자")
+        )
+
+        mockMvc.get("/api/v1/resume")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.result") { value("SUCCESS") }
+                jsonPath("$.data.content") { value("5년차 백엔드 개발자") }
+            }
+    }
+
+    @Test
+    fun `GET resume - 등록된 이력서가 없으면 200과 null 데이터 반환`() {
+        whenever(resumeService.getResume("user-1")).thenReturn(null)
+
+        mockMvc.get("/api/v1/resume")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.result") { value("SUCCESS") }
+                jsonPath("$.data") { value(org.hamcrest.Matchers.nullValue()) }
+            }
+    }
+
+    @Test
+    fun `PUT resume - 정상 요청이면 200과 저장된 이력서 반환`() {
+        whenever(resumeService.saveResume("user-1", "새 이력서 내용")).thenReturn(
+            UserResume(id = 1L, userId = "user-1", content = "새 이력서 내용")
+        )
+
+        mockMvc.put("/api/v1/resume") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"content":"새 이력서 내용"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.result") { value("SUCCESS") }
+            jsonPath("$.data.content") { value("새 이력서 내용") }
+        }
+
+        verify(resumeService).saveResume("user-1", "새 이력서 내용")
+    }
+
+    @Test
+    fun `PUT resume - content가 비어있으면 400 반환`() {
+        mockMvc.put("/api/v1/resume") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"content":""}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.result") { value("ERROR") }
+        }
+    }
+}

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ResumeServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/ResumeServiceTest.kt
@@ -1,0 +1,56 @@
+package com.devquest.core.domain
+
+import com.devquest.core.domain.model.UserResume
+import com.devquest.core.domain.port.UserResumePort
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class ResumeServiceTest {
+
+    @Mock
+    private lateinit var userResumePort: UserResumePort
+
+    @InjectMocks
+    private lateinit var service: ResumeService
+
+    @Test
+    fun `이력서 조회 시 등록된 이력서가 있으면 반환한다`() {
+        whenever(userResumePort.findByUserId("user-1")).thenReturn(
+            UserResume(id = 1L, userId = "user-1", content = "5년차 백엔드 개발자")
+        )
+
+        val result = service.getResume("user-1")
+
+        assertThat(result).isNotNull
+        assertThat(result?.content).isEqualTo("5년차 백엔드 개발자")
+    }
+
+    @Test
+    fun `이력서 조회 시 등록된 이력서가 없으면 null을 반환한다`() {
+        whenever(userResumePort.findByUserId("user-1")).thenReturn(null)
+
+        val result = service.getResume("user-1")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `이력서 저장 시 저장된 결과를 반환한다`() {
+        val saved = UserResume(id = 1L, userId = "user-1", content = "새 이력서 내용")
+        whenever(userResumePort.save(any())).thenReturn(saved)
+
+        val result = service.saveResume("user-1", "새 이력서 내용")
+
+        assertThat(result.content).isEqualTo("새 이력서 내용")
+        assertThat(result.userId).isEqualTo("user-1")
+        verify(userResumePort).save(any())
+    }
+}

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/UserResume.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/UserResume.kt
@@ -1,0 +1,11 @@
+package com.devquest.core.domain.model
+
+import java.time.LocalDateTime
+
+data class UserResume(
+    val id: Long = 0L,
+    val userId: String = "",
+    val content: String = "",
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/UserResumePort.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/port/UserResumePort.kt
@@ -1,0 +1,8 @@
+package com.devquest.core.domain.port
+
+import com.devquest.core.domain.model.UserResume
+
+interface UserResumePort {
+    fun findByUserId(userId: String): UserResume?
+    fun save(resume: UserResume): UserResume
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/UserResumeEntity.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/UserResumeEntity.kt
@@ -1,0 +1,15 @@
+package com.devquest.storage.db.core
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "user_resume")
+class UserResumeEntity(
+    @Column(nullable = false, unique = true)
+    val userId: String = "",
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String = "",
+) : BaseEntity()

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/UserResumeRepository.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/UserResumeRepository.kt
@@ -1,0 +1,7 @@
+package com.devquest.storage.db.core
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserResumeRepository : JpaRepository<UserResumeEntity, Long> {
+    fun findByUserId(userId: String): UserResumeEntity?
+}

--- a/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/UserResumeAdapter.kt
+++ b/be/storage/db-core/src/main/kotlin/com/devquest/storage/db/core/adapter/UserResumeAdapter.kt
@@ -1,0 +1,37 @@
+package com.devquest.storage.db.core.adapter
+
+import com.devquest.core.domain.model.UserResume
+import com.devquest.core.domain.port.UserResumePort
+import com.devquest.storage.db.core.UserResumeEntity
+import com.devquest.storage.db.core.UserResumeRepository
+import org.springframework.stereotype.Component
+
+@Component
+class UserResumeAdapter(
+    private val repository: UserResumeRepository
+) : UserResumePort {
+
+    override fun findByUserId(userId: String): UserResume? {
+        return repository.findByUserId(userId)?.toDomain()
+    }
+
+    override fun save(resume: UserResume): UserResume {
+        val existing = repository.findByUserId(resume.userId)
+        val entity = if (existing != null) {
+            existing.apply { content = resume.content }
+        } else {
+            UserResumeEntity(userId = resume.userId, content = resume.content)
+        }
+        return repository.save(entity).toDomain()
+    }
+
+    private fun UserResumeEntity.toDomain(): UserResume {
+        return UserResume(
+            id = this.id,
+            userId = this.userId,
+            content = this.content,
+            createdAt = this.createdAt,
+            updatedAt = this.updatedAt,
+        )
+    }
+}

--- a/be/storage/db-core/src/main/resources/db/migration/V12__create_user_resume.sql
+++ b/be/storage/db-core/src/main/resources/db/migration/V12__create_user_resume.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_resume (
+    id BIGSERIAL PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_user_resume_user_id ON user_resume(user_id);

--- a/be/storage/db-core/src/test/kotlin/com/devquest/storage/db/core/adapter/UserResumeAdapterTest.kt
+++ b/be/storage/db-core/src/test/kotlin/com/devquest/storage/db/core/adapter/UserResumeAdapterTest.kt
@@ -1,0 +1,67 @@
+package com.devquest.storage.db.core.adapter
+
+import com.devquest.core.domain.model.UserResume
+import com.devquest.storage.db.core.UserResumeEntity
+import com.devquest.storage.db.core.UserResumeRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class UserResumeAdapterTest {
+
+    @Mock
+    private lateinit var repository: UserResumeRepository
+
+    @InjectMocks
+    private lateinit var adapter: UserResumeAdapter
+
+    @Test
+    fun `findByUserId - 존재하면 도메인으로 반환한다`() {
+        val entity = UserResumeEntity(userId = "user-1", content = "5년차 백엔드 개발자")
+        whenever(repository.findByUserId("user-1")).thenReturn(entity)
+
+        val result = adapter.findByUserId("user-1")
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.userId).isEqualTo("user-1")
+        assertThat(result.content).isEqualTo("5년차 백엔드 개발자")
+    }
+
+    @Test
+    fun `findByUserId - 존재하지 않으면 null을 반환한다`() {
+        whenever(repository.findByUserId("user-1")).thenReturn(null)
+
+        val result = adapter.findByUserId("user-1")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `save - 신규 이력서면 새로 저장한다`() {
+        whenever(repository.findByUserId("user-1")).thenReturn(null)
+        val savedEntity = UserResumeEntity(userId = "user-1", content = "새 이력서")
+        whenever(repository.save(any())).thenReturn(savedEntity)
+
+        val result = adapter.save(UserResume(userId = "user-1", content = "새 이력서"))
+
+        assertThat(result.userId).isEqualTo("user-1")
+        assertThat(result.content).isEqualTo("새 이력서")
+    }
+
+    @Test
+    fun `save - 기존 이력서가 있으면 내용을 갱신한다`() {
+        val existing = UserResumeEntity(userId = "user-1", content = "기존 이력서")
+        whenever(repository.findByUserId("user-1")).thenReturn(existing)
+        whenever(repository.save(any())).thenReturn(existing)
+
+        val result = adapter.save(UserResume(userId = "user-1", content = "수정된 이력서"))
+
+        assertThat(result.content).isEqualTo("수정된 이력서")
+    }
+}

--- a/fe/src/app/App.tsx
+++ b/fe/src/app/App.tsx
@@ -9,6 +9,7 @@ import { CharacterCreate, OnboardingIntro } from '@/features/character'
 import { InterviewCoach } from '@/features/interview-coach'
 import { GrowthDashboard } from '@/features/growth'
 import { SettingsPage } from '@/features/settings'
+import { ResumeProfilePage } from '@/features/resume'
 import { TechInterviewPage, TechInterviewDemoPage, DailyQuestionPage } from '@/features/tech-interview'
 import { CodingQuestPage, CodingRoadmapPage } from '@/features/coding-quest'
 import { useAuth } from '@/hooks/useAuth'
@@ -57,6 +58,7 @@ type View =
   | { kind: 'interview-coach' }
   | { kind: 'growth' }
   | { kind: 'settings' }
+  | { kind: 'resume' }
   | { kind: 'tech-interview' }
   | { kind: 'tech-interview-demo' }
   | { kind: 'coding-roadmap' }
@@ -413,7 +415,7 @@ export function App() {
         color: '#F8FAFC',
       }}
     >
-      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth' || view.kind === 'briefing' || view.kind === 'settings' || view.kind === 'tech-interview') && (
+      {(view.kind === 'detail' || view.kind === 'act-clear' || view.kind === 'interview-coach' || view.kind === 'growth' || view.kind === 'briefing' || view.kind === 'settings' || view.kind === 'tech-interview' || view.kind === 'resume') && (
         <button
           onClick={() => setView({ kind: 'map' })}
           style={{
@@ -511,6 +513,22 @@ export function App() {
             >
               ⚙️ 설정
             </button>
+            <button
+              onClick={() => setView({ kind: 'resume' })}
+              style={{
+                background: 'rgba(245,158,11,0.1)',
+                border: '1px solid rgba(245,158,11,0.3)',
+                color: '#F59E0B',
+                cursor: 'pointer',
+                fontSize: 13,
+                padding: '10px 20px',
+                borderRadius: 8,
+                fontFamily: "'Courier New', monospace",
+                width: '100%',
+              }}
+            >
+              📄 이력서 관리
+            </button>
           </div>
         </>
       )}
@@ -563,6 +581,10 @@ export function App() {
 
       {view.kind === 'tech-interview' && (
         <TechInterviewPage />
+      )}
+
+      {view.kind === 'resume' && (
+        <ResumeProfilePage />
       )}
 
     </div>

--- a/fe/src/features/resume/api/resumeApi.ts
+++ b/fe/src/features/resume/api/resumeApi.ts
@@ -1,0 +1,10 @@
+import { fetchResume, saveResume } from '@/lib/apiClient'
+import type { Resume } from '@/types/api.types'
+
+export async function loadResume(): Promise<Resume | null> {
+  return fetchResume()
+}
+
+export async function updateResume(content: string): Promise<Resume> {
+  return saveResume(content)
+}

--- a/fe/src/features/resume/components/ResumeProfilePage.tsx
+++ b/fe/src/features/resume/components/ResumeProfilePage.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react'
+import { MarkdownRenderer } from '@/components/MarkdownRenderer'
+import { loadResume, updateResume } from '../api/resumeApi'
+
+const MAX_LENGTH = 50000
+const PLACEHOLDER = '## 경력 요약\n- ...\n\n## 기술 스택\n- ...\n\n## 프로젝트 경험\n### 프로젝트명\n- 역할:\n- 성과:'
+
+export function ResumeProfilePage() {
+  const [content, setContent] = useState('')
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null)
+  const [registered, setRegistered] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [previewing, setPreviewing] = useState(false)
+  const [message, setMessage] = useState<{ text: string; success: boolean } | null>(null)
+
+  useEffect(() => {
+    loadResume()
+      .then((resume) => {
+        if (resume) {
+          setContent(resume.content)
+          setUpdatedAt(resume.updatedAt)
+          setRegistered(true)
+        }
+      })
+      .catch(() => {/* 조회 실패 시 빈 상태 유지 */})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleSave = async () => {
+    if (!content.trim() || saving) return
+    setSaving(true)
+    setMessage(null)
+    try {
+      const resume = await updateResume(content.trim())
+      setContent(resume.content)
+      setUpdatedAt(resume.updatedAt)
+      setRegistered(true)
+      setMessage({ text: '저장되었습니다.', success: true })
+    } catch {
+      setMessage({ text: '저장에 실패했습니다. 내용을 확인 후 다시 시도해주세요.', success: false })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const length = content.length
+  const countColor = length >= MAX_LENGTH ? '#EF4444' : length >= 45000 ? '#F59E0B' : '#475569'
+  const saveDisabled = saving || !content.trim()
+
+  return (
+    <div style={{ maxWidth: 480, margin: '0 auto', paddingTop: 24 }}>
+      <h2 style={{ color: '#F8FAFC', fontSize: 20, marginBottom: 8, fontFamily: "'Courier New', monospace" }}>
+        이력서 프로필
+      </h2>
+      <p style={{ color: '#475569', fontSize: 13, marginBottom: 24, fontFamily: "'Courier New', monospace" }}>
+        한 번 등록해두면 회사별 AI 이력서 점검에 자동으로 사용됩니다.
+      </p>
+
+      <div
+        style={{
+          background: '#0F172A',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 12,
+          padding: 20,
+        }}
+      >
+        {loading ? (
+          <p style={{ color: '#475569', fontSize: 13, fontFamily: "'Courier New', monospace" }}>불러오는 중...</p>
+        ) : (
+          <>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+              <span style={{ color: '#475569', fontSize: 12, fontFamily: "'Courier New', monospace" }}>
+                {registered && updatedAt ? `마지막 저장: ${updatedAt}` : '아직 등록된 이력서가 없습니다'}
+              </span>
+              <span style={{ color: countColor, fontSize: 12, fontFamily: "'Courier New', monospace" }}>
+                {length} / {MAX_LENGTH}
+              </span>
+            </div>
+
+            {previewing ? (
+              <div
+                style={{
+                  minHeight: 320,
+                  background: '#0A0E1A',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 8,
+                  padding: 12,
+                  boxSizing: 'border-box',
+                }}
+              >
+                <MarkdownRenderer content={content} fontSize={13} />
+              </div>
+            ) : (
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder={registered ? undefined : PLACEHOLDER}
+                maxLength={MAX_LENGTH}
+                style={{
+                  width: '100%',
+                  minHeight: 320,
+                  background: '#0A0E1A',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 8,
+                  padding: 12,
+                  color: '#F1F5F9',
+                  fontSize: 14,
+                  fontFamily: "'Courier New', monospace",
+                  resize: 'vertical',
+                  boxSizing: 'border-box',
+                  outline: 'none',
+                }}
+                onFocus={(e) => { e.currentTarget.style.borderColor = 'rgba(245,158,11,0.4)' }}
+                onBlur={(e) => { e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)' }}
+              />
+            )}
+
+            {registered && (
+              <button
+                onClick={() => setPreviewing((prev) => !prev)}
+                style={{
+                  marginTop: 8,
+                  background: 'none',
+                  border: 'none',
+                  color: '#F59E0B',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  padding: 0,
+                  fontFamily: "'Courier New', monospace",
+                }}
+              >
+                {previewing ? '편집으로 돌아가기' : '미리보기'}
+              </button>
+            )}
+
+            <button
+              onClick={handleSave}
+              disabled={saveDisabled}
+              style={{
+                marginTop: 12,
+                width: '100%',
+                background: saveDisabled ? 'rgba(245,158,11,0.05)' : 'rgba(245,158,11,0.1)',
+                border: '1px solid rgba(245,158,11,0.3)',
+                color: '#F59E0B',
+                cursor: saveDisabled ? 'not-allowed' : 'pointer',
+                fontSize: 14,
+                padding: '12px 0',
+                borderRadius: 8,
+                fontFamily: "'Courier New', monospace",
+              }}
+            >
+              {saving ? '저장 중...' : registered ? '수정 사항 저장' : '이력서 등록하기'}
+            </button>
+
+            {message && (
+              <p
+                style={{
+                  marginTop: 10,
+                  fontSize: 13,
+                  color: message.success ? '#10B981' : '#EF4444',
+                  fontFamily: "'Courier New', monospace",
+                }}
+              >
+                {message.text}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/fe/src/features/resume/index.ts
+++ b/fe/src/features/resume/index.ts
@@ -1,0 +1,1 @@
+export { ResumeProfilePage } from './components/ResumeProfilePage'

--- a/fe/src/lib/apiClient.ts
+++ b/fe/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult, CategoryProgress, CodingRankResult } from '@/types/api.types'
+import type { ApiResponse, ProgressResult, ActClearReportResult, QuestHistoryItem, JourneyReportResult, UserEmailResult, TechInterviewResult, CodingProblem, CodingSubmissionResult, CodingLevelResult, CategoryProgress, CodingRankResult, Resume } from '@/types/api.types'
 import { getToken, clearToken } from '@/hooks/useAuth'
 import { STORAGE_KEYS } from '@/lib/storageKeys'
 
@@ -186,6 +186,26 @@ export async function fetchHint(
   assertOk(res)
   const json: ApiResponse<HintResult> = await res.json()
   if (json.result !== 'SUCCESS' || json.data == null) throw new Error('힌트 조회 실패')
+  return json.data
+}
+
+export async function fetchResume(): Promise<Resume | null> {
+  const res = await fetch(`${API_BASE}/resume`, { headers: authHeaders() })
+  assertOk(res)
+  const json: ApiResponse<Resume> = await res.json()
+  if (json.result !== 'SUCCESS') throw new Error('이력서 조회 실패')
+  return json.data
+}
+
+export async function saveResume(content: string): Promise<Resume> {
+  const res = await fetch(`${API_BASE}/resume`, {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify({ content }),
+  })
+  assertOk(res)
+  const json: ApiResponse<Resume> = await res.json()
+  if (json.result !== 'SUCCESS' || json.data == null) throw new Error('이력서 저장 실패')
   return json.data
 }
 

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -232,6 +232,14 @@ export type ApplicationStatus =
   | 'REJECTED'
   | 'WITHDRAWN'
 
+export interface Resume {
+  id: number
+  userId: string
+  content: string
+  createdAt: string
+  updatedAt: string
+}
+
 export interface AppliedCompany {
   id: number
   userId: string


### PR DESCRIPTION
## Summary
- 이력서 프로필 기능 (지원 파이프라인 Phase 3a) — 이력서를 마크다운 텍스트로 1회 등록하면 이후 AI 점검 기능이 재사용하는 기반
- BE: `user_resume` 테이블(V12) + `GET/PUT /api/v1/resume` (upsert, 미등록 시 `data: null`)
- FE: `ResumeProfilePage` — 등록/수정, 글자 수 카운터, MarkdownRenderer 미리보기, QuestMap 하단 "📄 이력서 관리" 진입 (Amber 액센트)

## Why
기존 ResumeCheck·JD 분석이 매번 이력서 plain text 복붙을 요구해 입력 마찰로 사용되지 않음.
이력서 1회 등록 → Phase 3b(회사 카드 원클릭 이력서 점검)의 선행 작업.
파일 업로드(PDF 파싱)는 512MB 메모리 환경 리스크로 의도적 제외 — 텍스트만.

## Test plan
- [x] BE: ResumeServiceTest·ResumeControllerTest·UserResumeAdapterTest — TDD RED→GREEN, `./gradlew build` BUILD SUCCESSFUL
- [x] FE: `npx tsc --noEmit` 0 errors, `npm run build` 성공
- [x] QA 리뷰: HIGH 0건. MEDIUM 1건(upsert read-then-write 경합 — 단일 유저 + FE saving-lock으로 보류, 다중 기기 시나리오 필요 시 DB ON CONFLICT 전환)
- [x] Flyway V12 — 두 마이그레이션 디렉토리 합산 버전 중복 없음 확인 (QA 재검증)
- [ ] 머지 후: prod 배포 확인 + 모바일에서 등록 플로우 실사용
