### PR TITLE
fix(fe): 점검 세부 점수 배점 표기·색상 + 이력서 저장 시각 포맷

### DIFF
--- a/fe/src/features/company-pipeline/components/CompanyCard.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyCard.tsx
@@ -262,14 +262,14 @@ function ResumeCheckPanel({ result }: ResumeCheckPanelProps) {
         </span>
       </div>
 
-      {/* 세부 점수 3종 */}
+      {/* 세부 점수 3종 (배점제: STAR /40, 정량화 /30, 키워드매칭 /30) */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 6 }}>
         {([
-          { label: 'STAR', value: result.starMethodScore },
-          { label: '정량화', value: result.quantificationScore },
-          { label: '키워드매칭', value: result.keywordMatchScore },
+          { label: 'STAR', value: result.starMethodScore, max: 40 },
+          { label: '정량화', value: result.quantificationScore, max: 30 },
+          { label: '키워드매칭', value: result.keywordMatchScore, max: 30 },
         ] as const).map((item) => {
-          const style = getScoreStyle(item.value)
+          const style = getScoreStyle((item.value / item.max) * 100)
           return (
             <div
               key={item.label}
@@ -282,7 +282,9 @@ function ResumeCheckPanel({ result }: ResumeCheckPanelProps) {
               }}
             >
               <p style={{ fontSize: 10, color: '#475569', margin: '0 0 4px' }}>{item.label}</p>
-              <p style={{ fontSize: 14, fontWeight: 700, color: style.color, margin: 0 }}>{item.value}</p>
+              <p style={{ fontSize: 14, fontWeight: 700, color: style.color, margin: 0 }}>
+                {item.value}/{item.max}
+              </p>
             </div>
           )
         })}

--- a/fe/src/features/resume/components/ResumeProfilePage.tsx
+++ b/fe/src/features/resume/components/ResumeProfilePage.tsx
@@ -5,6 +5,13 @@ import { loadResume, updateResume } from '../api/resumeApi'
 const MAX_LENGTH = 50000
 const PLACEHOLDER = '## 경력 요약\n- ...\n\n## 기술 스택\n- ...\n\n## 프로젝트 경험\n### 프로젝트명\n- 역할:\n- 성과:'
 
+function formatSavedAt(iso: string): string {
+  const d = new Date(iso)
+  const datePart = d.toLocaleDateString('ko-KR')
+  const timePart = d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+  return `${datePart} ${timePart}`
+}
+
 export function ResumeProfilePage() {
   const [content, setContent] = useState('')
   const [updatedAt, setUpdatedAt] = useState<string | null>(null)
@@ -71,7 +78,7 @@ export function ResumeProfilePage() {
           <>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
               <span style={{ color: '#475569', fontSize: 12, fontFamily: "'Courier New', monospace" }}>
-                {registered && updatedAt ? `마지막 저장: ${updatedAt}` : '아직 등록된 이력서가 없습니다'}
+                {registered && updatedAt ? `마지막 저장: ${formatSavedAt(updatedAt)}` : '아직 등록된 이력서가 없습니다'}
               </span>
               <span style={{ color: countColor, fontSize: 12, fontFamily: "'Courier New', monospace" }}>
                 {length} / {MAX_LENGTH}


### PR DESCRIPTION
## Summary
- 이력서 점검 세부 점수 `{value}/{max}` 표기 + 배점 비율 기준 색상 (STAR /40, 정량화 /30, 키워드 /30)
- 이력서 "마지막 저장" 시각 `2026. 7. 7. 14:32` 포맷 적용 (raw ISO 제거)

## Why
prod 실사용 테스트에서 발견 — 세부 점수가 배점제인데 0~100 기준 색상이 적용돼 정상 점수(32/40 등)가 전부 빨강으로 렌더, 낙제처럼 오해됨.

## Test plan
- [x] `npx tsc --noEmit` 0 errors, `npm run build` 성공
- [x] QA: HIGH/MEDIUM 0 (LOW 1 — invalid date 방어, 선택사항으로 스킵). getScoreStyle 기존 호출부 3곳 영향 없음 확인
- [ ] 머지 후: 점검 결과 패널에서 32/40 표기·색상 확인
