### PR TITLE
feat: 지원 상태 전환 이력 — 파이프라인 여정 타임라인 (Phase 4-1)

### DIFF
--- a/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CompanyService.kt
+++ b/be/core/core-api/src/main/kotlin/com/devquest/core/domain/CompanyService.kt
@@ -64,11 +64,26 @@ class CompanyService(
         val existing = companyPort.findByIdAndUserId(companyId, userId)
             ?: throw CoreException(ErrorType.COMPANY_NOT_FOUND)
 
+        val fromStatus = existing.status
         val updated = existing.copy(
             status = status,
             appliedAt = appliedAt ?: existing.appliedAt,
         )
         val saved = companyPort.save(updated)
+
+        if (fromStatus != status) {
+            val json = objectMapper.writeValueAsString(mapOf("from" to fromStatus.name, "to" to status.name))
+            companyActivityPort.save(
+                CompanyActivity(
+                    companyId = companyId,
+                    userId = userId,
+                    activityType = ActivityType.STATUS_CHANGE,
+                    aiScore = 0,
+                    aiResultJson = json,
+                )
+            )
+        }
+
         log.info("회사 상태 변경: userId=${userId}, companyId=${companyId}, status=${status}")
         return saved
     }

--- a/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CompanyServiceTest.kt
+++ b/be/core/core-api/src/test/kotlin/com/devquest/core/domain/CompanyServiceTest.kt
@@ -84,10 +84,48 @@ class CompanyServiceTest {
         val updated = existing.copy(status = ApplicationStatus.APPLIED, appliedAt = LocalDateTime.now())
         whenever(companyPort.findByIdAndUserId(1L, "user-1")).thenReturn(existing)
         whenever(companyPort.save(any())).thenReturn(updated)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("""{"from":"INTERESTED","to":"APPLIED"}""")
+        whenever(companyActivityPort.save(any())).thenReturn(
+            CompanyActivity(id = 1L, companyId = 1L, userId = "user-1", activityType = ActivityType.STATUS_CHANGE)
+        )
 
         val result = service.updateStatus("user-1", 1L, ApplicationStatus.APPLIED, null)
 
         assertThat(result.status).isEqualTo(ApplicationStatus.APPLIED)
+    }
+
+    @Test
+    fun `상태 변경 시 STATUS_CHANGE 활동이 기록된다`() {
+        val existing = company(id = 1L, status = ApplicationStatus.INTERESTED)
+        val updated = existing.copy(status = ApplicationStatus.APPLIED, appliedAt = LocalDateTime.now())
+        whenever(companyPort.findByIdAndUserId(1L, "user-1")).thenReturn(existing)
+        whenever(companyPort.save(any())).thenReturn(updated)
+        whenever(objectMapper.writeValueAsString(any())).thenReturn("""{"from":"INTERESTED","to":"APPLIED"}""")
+        whenever(companyActivityPort.save(any())).thenReturn(
+            CompanyActivity(id = 1L, companyId = 1L, userId = "user-1", activityType = ActivityType.STATUS_CHANGE)
+        )
+
+        service.updateStatus("user-1", 1L, ApplicationStatus.APPLIED, null)
+
+        val captor = org.mockito.kotlin.argumentCaptor<CompanyActivity>()
+        verify(companyActivityPort).save(captor.capture())
+        val saved = captor.firstValue
+        assertThat(saved.activityType).isEqualTo(ActivityType.STATUS_CHANGE)
+        assertThat(saved.aiScore).isEqualTo(0)
+        assertThat(saved.aiResultJson).isEqualTo("""{"from":"INTERESTED","to":"APPLIED"}""")
+    }
+
+    @Test
+    fun `상태 변경 시 from과 to가 같으면 활동을 기록하지 않는다`() {
+        val existing = company(id = 1L, status = ApplicationStatus.INTERESTED)
+        val updated = existing.copy()
+        whenever(companyPort.findByIdAndUserId(1L, "user-1")).thenReturn(existing)
+        whenever(companyPort.save(any())).thenReturn(updated)
+
+        val result = service.updateStatus("user-1", 1L, ApplicationStatus.INTERESTED, null)
+
+        assertThat(result.status).isEqualTo(ApplicationStatus.INTERESTED)
+        verify(companyActivityPort, never()).save(any())
     }
 
     @Test

--- a/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/CompanyActivity.kt
+++ b/be/core/core-domain/src/main/kotlin/com/devquest/core/domain/model/CompanyActivity.kt
@@ -18,4 +18,5 @@ enum class ActivityType {
     TECH_INTERVIEW,
     HR_INTERVIEW,
     BOSS_PACKAGE,
+    STATUS_CHANGE,
 }

--- a/fe/src/features/company-pipeline/components/CompanyCard.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyCard.tsx
@@ -7,7 +7,7 @@ import type {
   CompanyActivity,
 } from '@/types/api.types'
 
-const STATUS_LABELS: Record<ApplicationStatus, string> = {
+export const STATUS_LABELS: Record<ApplicationStatus, string> = {
   INTERESTED: '관심',
   APPLIED: '지원',
   SCREENING_PASS: '서류 통과',
@@ -397,6 +397,19 @@ function ResumeCheckPanel({ result }: ResumeCheckPanelProps) {
 const ACTIVITY_TYPE_STYLE: Record<CompanyActivity['activityType'], { label: string; color: string; background: string; border: string }> = {
   JD_ANALYSIS: { label: 'JD', color: '#A78BFA', background: 'rgba(167,139,250,0.12)', border: '1px solid rgba(167,139,250,0.3)' },
   RESUME_CHECK: { label: '이력서', color: '#F59E0B', background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)' },
+  STATUS_CHANGE: { label: '상태', color: '#94A3B8', background: 'rgba(148,163,184,0.12)', border: '1px solid rgba(148,163,184,0.3)' },
+}
+
+function parseStatusChange(aiResultJson: string): { from: ApplicationStatus; to: ApplicationStatus } | null {
+  try {
+    const parsed = JSON.parse(aiResultJson) as { from?: string; to?: string }
+    if (parsed.from && parsed.to && parsed.from in STATUS_LABELS && parsed.to in STATUS_LABELS) {
+      return { from: parsed.from as ApplicationStatus, to: parsed.to as ApplicationStatus }
+    }
+    return null
+  } catch {
+    return null
+  }
 }
 
 interface ActivityHistoryListProps {
@@ -406,13 +419,15 @@ interface ActivityHistoryListProps {
 function ActivityHistoryList({ activities }: ActivityHistoryListProps) {
   const recent = [...activities]
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .slice(0, 3)
+    .slice(0, 5)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', marginTop: 4 }}>
       {recent.map((activity) => {
         const typeStyle = ACTIVITY_TYPE_STYLE[activity.activityType]
+        const isStatusChange = activity.activityType === 'STATUS_CHANGE'
         const scoreStyle = getScoreStyle(activity.aiScore)
+        const statusChange = isStatusChange ? parseStatusChange(activity.aiResultJson) : null
         return (
           <div
             key={activity.id}
@@ -422,25 +437,36 @@ function ActivityHistoryList({ activities }: ActivityHistoryListProps) {
               justifyContent: 'space-between',
               padding: '6px 0',
               borderBottom: '1px solid rgba(255,255,255,0.04)',
+              gap: 8,
             }}
           >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
               <span
                 style={{
                   fontSize: 10,
                   fontWeight: 600,
                   padding: '2px 6px',
                   borderRadius: 3,
+                  flexShrink: 0,
                   ...typeStyle,
                 }}
               >
                 {typeStyle.label}
               </span>
-              <span style={{ fontSize: 11, color: '#475569' }}>
+              {isStatusChange && (
+                <span style={{ fontSize: 11, color: '#F1F5F9', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {statusChange
+                    ? `${STATUS_LABELS[statusChange.from]} → ${STATUS_LABELS[statusChange.to]}`
+                    : '상태 변경'}
+                </span>
+              )}
+              <span style={{ fontSize: 11, color: '#475569', flexShrink: 0 }}>
                 {new Date(activity.createdAt).toLocaleDateString('ko-KR')}
               </span>
             </div>
-            <span style={{ fontSize: 12, fontWeight: 700, color: scoreStyle.color }}>{activity.aiScore}</span>
+            <span style={{ fontSize: 12, fontWeight: 700, color: isStatusChange ? '#475569' : scoreStyle.color, flexShrink: 0 }}>
+              {isStatusChange ? '-' : activity.aiScore}
+            </span>
           </div>
         )
       })}
@@ -450,7 +476,7 @@ function ActivityHistoryList({ activities }: ActivityHistoryListProps) {
 
 interface CompanyCardProps {
   company: AppliedCompany
-  onStatusChange: (id: number, status: ApplicationStatus) => void
+  onStatusChange: (id: number, status: ApplicationStatus) => Promise<void>
   onDelete: (id: number) => void
   analysisResult?: JdAnalysisResult
   onAnalyze: (id: number, skills: string[], experiences: string[]) => Promise<JdAnalysisResult>
@@ -569,6 +595,15 @@ export function CompanyCard({
       setApiError(e instanceof Error ? e.message : 'RESUME_CHECK_FAILED')
     } finally {
       setCheckingResume(false)
+    }
+  }
+
+  const handleStatusChange = async (status: ApplicationStatus) => {
+    try {
+      await onStatusChange(company.id, status)
+      invalidateActivities()
+    } catch {
+      // 상태 변경 실패는 상위(select 값 롤백 등)에서 별도 처리
     }
   }
 
@@ -717,7 +752,7 @@ export function CompanyCard({
       {/* 1행: 상태 select */}
       <select
         value={company.status}
-        onChange={(e) => onStatusChange(company.id, e.target.value as ApplicationStatus)}
+        onChange={(e) => { handleStatusChange(e.target.value as ApplicationStatus) }}
         disabled={busy}
         style={{
           background: '#0A0E1A',

--- a/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
@@ -111,7 +111,7 @@ export function CompanyPipelinePanel({
             <CompanyCard
               key={company.id}
               company={company}
-              onStatusChange={(id, status) => { onStatusChange(id, status).catch(() => {}) }}
+              onStatusChange={onStatusChange}
               onDelete={(id) => { onDelete(id).catch(() => {}) }}
               analysisResult={analysisResults[company.id]}
               onAnalyze={handleAnalyze}

--- a/fe/src/types/api.types.ts
+++ b/fe/src/types/api.types.ts
@@ -264,7 +264,7 @@ export interface CompanyResumeCheckResult {
   checkedAt: string
 }
 
-export type CompanyActivityType = 'RESUME_CHECK' | 'JD_ANALYSIS'
+export type CompanyActivityType = 'RESUME_CHECK' | 'JD_ANALYSIS' | 'STATUS_CHANGE'
 
 export interface CompanyActivity {
   id: number


### PR DESCRIPTION
## Summary
- 지원 상태 전환 이력 (파이프라인 Phase 4-1) — 상태 변경 시 `company_activity`에 `STATUS_CHANGE` 기록 (`{"from","to"}`), 카드 "점검 이력"에 `관심 → 지원 완료` 타임라인 표시
- 기존 테이블 재사용 (마이그레이션 불필요), from==to 재선택은 기록 안 함
- FE: 상태 변경 성공 시 이력 캐시 무효화, STATUS_LABELS 공용화, 이력 표시 3→5건

## Why
status가 덮어써져 "언제 서류 합격했는지" 같은 지원 여정 기록이 안 남았음 — 스냅샷을 타임라인으로 전환.

## Test plan
- [x] BE: CompanyServiceTest 3건 (기록·JSON 검증·from==to 미기록, TDD RED→GREEN), `./gradlew build` 성공
- [x] FE: `npx tsc --noEmit` 0 errors, `npm run build` 성공
- [x] QA: HIGH/MEDIUM 0. 트랜잭션 롤백·Promise 시그니처 전파(App→QuestMap→Panel→Card)·JSON 계약 일치 확인. LOW 2건(주석 문구, onDelete 패턴 통일)은 tech-debt
- [ ] 머지 후: 상태 변경 → 이력 토글에서 전환 기록 확인
