### PR TITLE
fix(fe): CompanyCard 에러 처리 통일 및 formatSavedAt invalid date 방어

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,17 +7,17 @@
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | (없음 — main 최신) |
-| 열린 PR | 없음 |
+| 브랜치 | fix/fe-tech-debt-low |
+| 열린 PR | #259 — FE tech-debt LOW 3건 정리 (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
 | PR/커밋 | 내용 | 날짜 |
 |---------|------|------|
+| #259 | FE tech-debt LOW 3건 — onDelete/onStatusChange 에러 패턴 통일(Promise<void> 전환, swallow 제거), formatSavedAt invalid date 방어, 주석 보완. QA HIGH/MEDIUM 0 | 2026-07-10 |
 | #257 | 데일리 질문 휘발형 학습(후속 질문) Phase A — POST /daily-question/explain(원본 Q/답변/피드백 컨텍스트, 단발·순수텍스트), explain 전용 레이트리밋(IP당 5회/일, 기존 2회/일 버킷과 분리 신설), DailyQuestionPage 후속질문 섹션. 게스트 허용. QA HIGH 0, MEDIUM 2 수정. CD 배포 트리거됨 | 2026-07-09 |
 | #255 | 프롬프트 체계에 Finding Your Unknowns 기법 적용 — Deviations 로그(builder→QA 주입), Blindspot Pass(3.5단계), Design 다방향 모드, Gate 결정 테이블, Merge Quiz 스킬 | 2026-07-08 |
 | #253 | 지원 상태 전환 이력 Phase 4-1 — STATUS_CHANGE activity 기록 + 이력 타임라인(관심→지원). 배포 완료 | 2026-07-07 |
-| #252 | 점검 결과 표시 fix — 세부 점수 32/40 배점 표기·비율 색상 + 저장 시각 포맷 (prod 실사용 테스트 발견분) | 2026-07-07 |
 
 ## 다음 작업
 
@@ -26,8 +26,8 @@
       prod 테스트 완료) ② 테스트 데이터 정리 — 회사 "테스트-토스" 삭제, 임시 이력서를 실제로 교체
 - [ ] **Phase 4 후보 (실사용 후 판단)**: 면접 회고 메모(activity NOTE 타입), 같은 회사 카드
       그룹핑 뷰, JD 등록/수정 모달(현재 AddCompanyModal에서만 입력 가능), Phase 3c(JD URL 파싱)
-- [ ] tech-debt(LOW): CompanyCard handleStatusChange 주석 보완, onDelete/onStatusChange 에러
-      패턴 통일, formatSavedAt invalid date 방어
+- [ ] tech-debt(LOW): CompanyCard 삭제/상태변경 진행 중 busy 플래그(연타 중복 요청 가드, #259 QA LOW),
+      FE 테스트 러너 미도입(vitest 등 — 인프라 도입 여부 별도 결정 필요, #259에서 확인)
 - [ ] Phase 3a MEDIUM 보류: UserResumeAdapter upsert read-then-write 경합 — 다중 기기 동시
       사용 필요해지면 DB ON CONFLICT 전환
 - [ ] **OOM 후속 관찰** (#245 swap 배포 후): ① 업타임 4~5일째 `fly_instance_memory_swap_free`
@@ -36,8 +36,8 @@
       + `MALLOC_ARENA_MAX=2` + `G1PeriodicGCInterval=300000` → RSS 천장 ~409→~300MB (512MB 내 근본 해결)
       리스크: 힙 피크 90MB 관측이 대표적이지 않으면(대형 AI 응답) JVM OOME — 단 컨테이너 kill보다 양성
 - [ ] 에이전트 Disambiguation Gate / Closing Summary 미비점 보완 (Gate 횟수 상한, 트리거 기준 명시 — 실사용 경험 더 쌓은 뒤 결정)
-- [ ] **#255 후속**: ① 다음 기능 작업에서 Deviations·Blindspot Pass 실효성 확인 ② `E:/development/.claude/template/`에
-      orchestrator·clarify·quiz 동기화 (별도 저장소, 이 레포 밖)
+- [ ] **#255 후속**: 다음 기능 작업에서 Blindspot Pass 실효성 확인 (Deviations→QA 집중검토 흐름은
+      #259에서 1차 동작 확인. template 동기화는 07-10 완료 — orchestrator·clarify·quiz + 훅 스크립트 3종)
 - [ ] 질문 뱅크 category 파라미터 — 현재 DailyMailScheduler가 항상 null로 호출해 카테고리 분기가
       죽은 경로 (QA MEDIUM, 의도적 보류). 향후 카테고리별 배분 쓸 계획 생기면 활성화
 - [ ] 질문 뱅크 규모 확대 시(수백 건↑) `findAllBy...` 전체 로드 방식 재검토 — `ORDER BY RANDOM() LIMIT 1`

--- a/fe/src/features/company-pipeline/components/CompanyCard.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyCard.tsx
@@ -477,7 +477,7 @@ function ActivityHistoryList({ activities }: ActivityHistoryListProps) {
 interface CompanyCardProps {
   company: AppliedCompany
   onStatusChange: (id: number, status: ApplicationStatus) => Promise<void>
-  onDelete: (id: number) => void
+  onDelete: (id: number) => Promise<void>
   analysisResult?: JdAnalysisResult
   onAnalyze: (id: number, skills: string[], experiences: string[]) => Promise<JdAnalysisResult>
   hasResume: boolean
@@ -509,6 +509,7 @@ export function CompanyCard({
   const [analysisError, setAnalysisError] = useState<string | null>(null)
   const [checkingResume, setCheckingResume] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
 
   const [activitiesExpanded, setActivitiesExpanded] = useState(false)
   const [activities, setActivities] = useState<CompanyActivity[] | null>(null)
@@ -599,11 +600,23 @@ export function CompanyCard({
   }
 
   const handleStatusChange = async (status: ApplicationStatus) => {
+    setActionError(null)
     try {
       await onStatusChange(company.id, status)
       invalidateActivities()
     } catch {
-      // 상태 변경 실패는 상위(select 값 롤백 등)에서 별도 처리
+      // select는 company.status(상위 상태)로 다시 렌더링되어 실패 시 자동으로 이전 값으로 되돌아간다.
+      // 사용자에게는 아래 actionError 배너로 실패 사실만 안내한다.
+      setActionError('상태 변경에 실패했습니다. 다시 시도해주세요.')
+    }
+  }
+
+  const handleDelete = async () => {
+    setActionError(null)
+    try {
+      await onDelete(company.id)
+    } catch {
+      setActionError('삭제에 실패했습니다. 다시 시도해주세요.')
     }
   }
 
@@ -821,7 +834,7 @@ export function CompanyCard({
         )}
 
         <button
-          onClick={() => onDelete(company.id)}
+          onClick={handleDelete}
           disabled={busy}
           style={{
             flex: '1 1 80px',
@@ -839,6 +852,10 @@ export function CompanyCard({
           삭제
         </button>
       </div>
+
+      {actionError && (
+        <p style={{ fontSize: 11, color: '#EF4444', margin: 0 }}>{actionError}</p>
+      )}
 
       {checkingResume && (
         <p style={{ fontSize: 11, color: '#475569', margin: '6px 0 0' }}>

--- a/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
+++ b/fe/src/features/company-pipeline/components/CompanyPipelinePanel.tsx
@@ -112,7 +112,7 @@ export function CompanyPipelinePanel({
               key={company.id}
               company={company}
               onStatusChange={onStatusChange}
-              onDelete={(id) => { onDelete(id).catch(() => {}) }}
+              onDelete={onDelete}
               analysisResult={analysisResults[company.id]}
               onAnalyze={handleAnalyze}
               hasResume={hasResume}

--- a/fe/src/features/resume/components/ResumeProfilePage.tsx
+++ b/fe/src/features/resume/components/ResumeProfilePage.tsx
@@ -7,6 +7,7 @@ const PLACEHOLDER = '## 경력 요약\n- ...\n\n## 기술 스택\n- ...\n\n## �
 
 function formatSavedAt(iso: string): string {
   const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '알 수 없음'
   const datePart = d.toLocaleDateString('ko-KR')
   const timePart = d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
   return `${datePart} ${timePart}`


### PR DESCRIPTION
## Summary
- CompanyCard `onDelete`/`onStatusChange` 에러 처리를 코드베이스 표준 패턴(로컬 에러 상태 + 인라인 안내 메시지)으로 통일
- `onDelete` 시그니처 `void` → `Promise<void>` 전환, CompanyPipelinePanel의 에러 swallow 래퍼(`.catch(() => {})`) 제거
- `formatSavedAt` invalid date 방어 — 유효하지 않은 날짜 시 `'알 수 없음'` 표기
- `handleStatusChange` 주석 실제 동작 기준으로 보완

## Why
CONTEXT.md tech-debt(LOW) 3건 정리. 삭제/상태변경 실패가 조용히 무시되던 문제와 invalid date 크래시 가능성 제거.

## Test plan
- [x] `npx tsc --noEmit` 통과 (에러 0건)
- [x] `npm run build` 성공
- [x] eslint 수정 파일 3개 0건
- [x] QA 리뷰: HIGH 0 / MEDIUM 0 / LOW 2 (tech-debt 재기록으로 처리)
