### PR TITLE
chore(be): JVM 메모리 다이어트 - RSS creep OOM 근본 완화

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -7,8 +7,8 @@
 
 | 항목 | 내용 |
 |------|------|
-| 브랜치 | main |
-| 열린 PR | 없음 |
+| 브랜치 | chore/jvm-memory-diet |
+| 열린 PR | #263 — JVM 메모리 다이어트 (OOM 근본 완화, 무비용) (머지 대기) |
 
 ## 최근 완료 (최근 3건)
 
@@ -38,9 +38,13 @@
       = 스왑 배포 직전, anon-rss 409MB), 스왑 소비 22~32MB/일 선형(배포 재시작 시 리셋),
       mem_available 12~47MB 바닥권 지속 → 무배포 8~10일 시 스왑 소진·재발 가능성 🟡.
       남은 확인: 4~5일차(07-11~12) creep 둔화 여부 → JVM 다이어트 조정폭 확정 후 PR 착수
-- [ ] **JVM 메모리 다이어트 PR** (스왑 관찰 후 진행): 힙 상한 50%→35% + `ReservedCodeCacheSize=96m`
-      + `MALLOC_ARENA_MAX=2` + `G1PeriodicGCInterval=300000` → RSS 천장 ~409→~300MB (512MB 내 근본 해결)
-      리스크: 힙 피크 90MB 관측이 대표적이지 않으면(대형 AI 응답) JVM OOME — 단 컨테이너 kill보다 양성
+- [ ] **JVM 메모리 다이어트 (#263 — 머지·배포·관측 대기)**: 힙 50%→35%(~179MB) + Metaspace 160→128m
+      + `ReservedCodeCacheSize=96m` + `-Xlog:gc`(GC 확정용). Dockerfile ENTRYPOINT 수정. RSS 천장 ~409→~300MB 목표.
+      **Blindspot Pass로 계획 2건 제외**: `MALLOC_ARENA_MAX`(musl/alpine라 glibc 튜너블 무효),
+      `G1PeriodicGCInterval`(1cpu/512MB라 기본 SerialGC 추정 → G1 미사용). 배포 후 `-Xlog:gc`로 GC 확정.
+      **post-deploy 필수 관측**: `fly_instance_memory_mem_available` 며칠 → RSS 천장 ~300 안착 여부 +
+      AI 평가 시 힙 피크 179MB 초과(OOME) 여부. 리스크: 힙 피크 초과 시 OOME — 단 컨테이너 kill보다 양성.
+      GC 확정 후 page 반납 레버(SerialGC엔 없음 → 필요 시 G1 명시 전환) 별도 판단.
 - [ ] 에이전트 Disambiguation Gate / Closing Summary 미비점 보완 (Gate 횟수 상한, 트리거 기준 명시 — 실사용 경험 더 쌓은 뒤 결정)
 - [ ] **#255 후속**: 다음 기능 작업에서 Blindspot Pass 실효성 확인 (Deviations→QA 집중검토 흐름은
       #259에서 1차 동작 확인. template 동기화는 07-10 완료 — orchestrator·clarify·quiz + 훅 스크립트 3종)

--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -22,14 +22,18 @@ COPY --from=builder /app/core/core-api/build/libs/*.jar app.jar
 EXPOSE 8080
 
 # 컨테이너 메모리 예산: 512MB (Fly.io shared-cpu-1x) — 근사치, 배포 후 실측 검증 필요
-# - 힙: MaxRAMPercentage=50.0 → 최대 256MB (기존 75%=384MB는 비힙 공간 부족으로 구조적 OOM 유발)
-# - Metaspace: 160MB 상한 (클래스 메타데이터, 무제한 성장 방지)
+# - 힙: MaxRAMPercentage=35.0 → 최대 약 179MB (RSS creep로 인한 OOM 재발 방지 위해 50%=256MB에서 축소)
+# - Metaspace: 128MB 상한 (클래스 메타데이터, 무제한 성장 방지, 기존 160m 과다 상한 축소)
+# - Reserved Code Cache: 96MB 상한 (JIT 컴파일 코드 캐시 — native 메모리 상한 고정으로 억제)
 # - 스레드 스택: 512k — 플랫폼(carrier) 스레드·GC 스레드 등 JVM 내부 스레드 스택 절감용.
 #   spring.threads.virtual.enabled=true로 요청 처리는 가상 스레드(힙 스택)를 사용하므로 영향 없음
-# - 나머지(~96MB)는 코드캐시, 네이티브 메모리, 스레드 오버헤드용으로 여유 확보
+# - GC 로그(-Xlog:gc)는 배포 후 실제 사용 중인 GC 종류 확정용. 저트래픽 환경이라 로그량 미미
+# - 나머지는 스레드 오버헤드, 기타 네이티브 메모리용으로 여유 확보
 ENTRYPOINT ["java", \
   "-XX:+UseContainerSupport", \
-  "-XX:MaxRAMPercentage=50.0", \
-  "-XX:MaxMetaspaceSize=160m", \
+  "-XX:MaxRAMPercentage=35.0", \
+  "-XX:MaxMetaspaceSize=128m", \
+  "-XX:ReservedCodeCacheSize=96m", \
   "-Xss512k", \
+  "-Xlog:gc::time,level,tags", \
   "-jar", "app.jar"]


### PR DESCRIPTION
## 배경

prod 단일 머신(Fly.io shared-cpu-1x / 512MB + swap 256MB)에서 RSS가 시간당 ~3MB creep → ~409MB 도달 시 커널 OOM kill이 3~5일 주기로 발생(스왑으로 8~10일 연장). JVM 힙은 90MB 피크뿐인데 커널이 죽이는 구조 → 원인은 힙 예약 총량 + native 메모리 실체화. 스케일업($5.7/월)·스왑은 각각 비용·미봉책이라, 무비용으로 512MB 안에 근본 안착시키는 JVM 다이어트를 선택.

## 변경 (be/Dockerfile ENTRYPOINT)

| 항목 | 이전 | 이후 | 목적 |
|------|------|------|------|
| MaxRAMPercentage | 50.0 (힙 256MB) | **35.0 (~179MB)** | 힙 예약 총량 축소 (핵심 레버, 피크 90MB 대비 2배 여유) |
| MaxMetaspaceSize | 160m | **128m** | 과다 상한 축소 |
| ReservedCodeCacheSize | (무제한) | **96m 신규** | JIT 코드캐시 상한 고정 → native 억제 |
| -Xlog:gc | 없음 | **신규** | 배포 후 실제 GC 종류 확정용 (저트래픽이라 로그량 미미) |

→ 예상 RSS 천장 ~409 → ~300MB 초반.

## Blindspot Pass 결과 (계획에서 제외한 항목)

- `MALLOC_ARENA_MAX=2` — 베이스 이미지가 **musl libc(alpine)**라 glibc 전용 튜너블 무효 → 제외
- `G1PeriodicGCInterval` — 1cpu/512MB라 기본 GC가 SerialGC일 가능성 높음(G1 미사용) → 이번 -Xlog:gc로 확정 후 별도 PR 판단

## 검증

- `./gradlew build` → BUILD SUCCESSFUL (exit 0)
- ENTRYPOINT JSON 배열 문법 정상
- **post-deploy 관측 필요**: 배포 후 며칠간 `fly_instance_memory_mem_available`로 RSS 천장이 실제 ~300 초반 안착하는지 + AI 평가 시 힙 피크가 179MB 넘지 않는지 확인. `-Xlog:gc`로 실제 GC 종류 확정.

## 리스크

힙 35%=~179MB. 대형 AI 응답이 몰려 힙 피크가 179MB 초과 시 JVM OutOfMemoryError 가능 — 단 컨테이너 OOM kill보다 양성(해당 요청만 graceful 실패, 머신 생존, 로그 잔존).